### PR TITLE
chore: corrigir alertas de lint e otimizar imagem institucional

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "upload.wikimedia.org",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useState, useEffect } from "react";
 import { Stepper } from "@/components/ui/stepper";
 import { CENSUS_STEPS } from "@/config/steps";
@@ -337,11 +338,13 @@ export default function CensusPage() {
         <div className="container mx-auto px-4 h-24 flex items-center justify-between gap-2 sm:gap-6">
             <div className="flex items-center gap-3 sm:gap-6">
                 <div className="shrink-0">
-                    <img 
-                        src="https://upload.wikimedia.org/wikipedia/commons/b/bc/Bras%C3%A3o_do_Par%C3%A1.svg" 
-                        alt="Brasão do Pará" 
-                        // MUDANÇA: Removido 'hidden sm:block' e ajustado o tamanho para não estourar no celular
-                        className="h-10 sm:h-12 md:h-14 w-auto" 
+                    <Image
+                        src="https://upload.wikimedia.org/wikipedia/commons/b/bc/Bras%C3%A3o_do_Par%C3%A1.svg"
+                        alt="Brasão do Pará"
+                        width={56}
+                        height={56}
+                        className="h-10 sm:h-12 md:h-14 w-auto"
+                        priority
                     />
                 </div>
                 <div className="flex flex-col justify-center">

--- a/web/src/components/forms/alunos-form.tsx
+++ b/web/src/components/forms/alunos-form.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { alunosSchema, AlunosFormValues } from "@/schemas/steps/alunos"; 
 import { Button } from "@/components/ui/button";
 import { Form, FormField, FormItem, FormControl, FormLabel, FormMessage } from "@/components/ui/form";
-import { NumberInput, TextInput } from "@/components/ui/form-components";
+import { TextInput } from "@/components/ui/form-components";
 import { Separator } from "@/components/ui/separator";
 import { useCensusPersistence } from "@/hooks/use-census-persistence";
 

--- a/web/src/components/ui/form-components.tsx
+++ b/web/src/components/ui/form-components.tsx
@@ -104,7 +104,7 @@ export function NumberInput<T extends FieldValues>({
               onKeyDown={blockInvalidChar} 
               placeholder={placeholder}
               {...field}
-              onFocus={(e) => {
+              onFocus={() => {
                 if (field.value === 0) {
                     field.onChange("");
                 }

--- a/web/src/hooks/use-census-persistence.ts
+++ b/web/src/hooks/use-census-persistence.ts
@@ -91,7 +91,7 @@ export function useCensusPersistence<T extends FieldValues>(
     };
 
     loadData();
-  }, [schoolId, stepKey, endpoint, reset]); 
+  }, [schoolId, stepKey, endpoint, reset, defaultValues]); 
 
   const saveLocalDraft = (data: T) => {
     if (isClearedRef.current || !schoolId) return;

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const tailwindcssAnimate = require("tailwindcss-animate");
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: ["class"],
@@ -73,5 +76,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 }


### PR DESCRIPTION
### Motivation
- Corrigir avisos e erros de lint e melhorar a exibição da imagem institucional para evitar warnings e problemas de build no frontend.
- Melhorar a robustez da persistência local para garantir que `defaultValues` sejam considerados nas dependências do hook.

### Description
- Configurado `web/next.config.ts` para permitir imagens remotas de `upload.wikimedia.org` via `images.remotePatterns` para uso com `next/image`.
- Substituído o elemento `<img>` por `<Image />` em `web/src/app/page.tsx` e adicionado `width`, `height` e `priority` para otimizar carregamento e evitar o aviso do linter; também importado `Image` do `next/image`.
- Removido um `import` não utilizado (`NumberInput`) em `web/src/components/forms/alunos-form.tsx` para eliminar warning de variável não usada.
- Ajustado `web/src/components/ui/form-components.tsx` para remover o parâmetro não utilizado no `onFocus` do `NumberInput` e evitar o warning de variável `e` não usada.
- Atualizada a lista de dependências do `useEffect` em `web/src/hooks/use-census-persistence.ts` adicionando `defaultValues` para evitar comportamento inesperado de cache/merge.
- Alterado `web/tailwind.config.js` para declarar `tailwindcss-animate` em uma variável e desativar a regra eslint que bloqueava `require`, evitando erro de lint por `require()`.

### Testing
- Executado `cd api && go test -vet=off ./...` e não foram encontrados testes para executar, resultado sem falhas relevantes. ✅
- Executado `cd web && npm run lint` e os problemas de lint previamente reportados foram resolvidos, lint passou com sucesso. ✅
- Tentado `cd web && npm run build` que falhou devido à indisponibilidade de rede ao baixar a fonte `Inter` do Google Fonts via `next/font`, portanto build não completou por causa externa de rede; o erro não está relacionado às alterações de lint. ⚠️
- Rodado `npm run dev` e capturado screenshot da home via Playwright para validar visualmente a mudança do cabeçalho com `next/image`. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b14f9791b08333bfffa23ab7151e55)