### PR TITLE
fix: headers de segurança, year dinâmico e baseUrl segura nos forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ credentials.json
 key.json
 *.key
 
+# Lock files temporários do Excel/Office
+~$*
+
 # Dev Tools (Tests)
 src/dev/

--- a/api/cmd/api/middleware.go
+++ b/api/cmd/api/middleware.go
@@ -31,6 +31,9 @@ func (app *application) enableCORS(next http.Handler) http.Handler {
 					break
 				}
 			}
+			// Vary: Origin obrigatório quando a resposta varia por origem,
+			// evita que CDN/proxy cache a resposta de uma origem e sirva a outra
+			w.Header().Set("Vary", "Origin")
 			if allowed {
 				w.Header().Set("Access-Control-Allow-Origin", requestOrigin)
 				w.Header().Set("Access-Control-Allow-Credentials", "true")
@@ -42,6 +45,11 @@ func (app *application) enableCORS(next http.Handler) http.Handler {
 
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-API-Key, Cache-Control, Pragma")
+
+		// Previne MIME sniffing (browser interpretar JSON como script/HTML)
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		// Previne clickjacking via <iframe>
+		w.Header().Set("X-Frame-Options", "DENY")
 
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)

--- a/web/src/components/forms/alunos-form.tsx
+++ b/web/src/components/forms/alunos-form.tsx
@@ -108,7 +108,7 @@ export function AlunosForm({ schoolId, onSuccess, onBack }: AlunosFormProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             school_id: schoolId,
-            year: 2026,
+            year: new Date().getFullYear(),
             status: "draft", 
             data: data 
         }),

--- a/web/src/components/forms/avaliacao-form.tsx
+++ b/web/src/components/forms/avaliacao-form.tsx
@@ -48,13 +48,13 @@ export function AvaliacaoForm({ schoolId, onSuccess, onBack }: AvaliacaoFormProp
   async function onSubmit(data: AvaliacaoFormValues) {
     setIsSaving(true);
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
       const response = await fetch(`${baseUrl}/v1/census`, {
-        method: "POST", 
+        method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             school_id: schoolId,
-            year: 2026,
+            year: new Date().getFullYear(),
             status: "draft", 
             data: data 
         }),

--- a/web/src/components/forms/general-data-form.tsx
+++ b/web/src/components/forms/general-data-form.tsx
@@ -244,7 +244,7 @@ export function GeneralDataForm({ schoolId, onSuccess, onBack }: GeneralDataForm
       const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/v1/census`, {
         method: "POST", 
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ school_id: schoolId, year: 2026, status: "draft", data: payload }),
+        body: JSON.stringify({ school_id: schoolId, year: new Date().getFullYear(), status: "draft", data: payload }),
       });
 
       if (!response.ok) throw new Error("erro ao salvar");

--- a/web/src/components/forms/gestao-form.tsx
+++ b/web/src/components/forms/gestao-form.tsx
@@ -47,11 +47,11 @@ export function GestaoForm({ schoolId, onSuccess, onBack }: GestaoFormProps) {
   async function onSubmit(data: GestaoFormValues) {
     setIsSaving(true);
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_API_URL; 
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
       const response = await fetch(`${baseUrl}/v1/census`, {
-        method: "POST", 
+        method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ school_id: schoolId, year: 2026, status: "draft", data: data }),
+        body: JSON.stringify({ school_id: schoolId, year: new Date().getFullYear(), status: "draft", data: data }),
       });
 
       if (!response.ok) throw new Error("erro ao salvar");

--- a/web/src/components/forms/merenda-form.tsx
+++ b/web/src/components/forms/merenda-form.tsx
@@ -58,7 +58,7 @@ export function MerendaForm({ schoolId, onSuccess, onBack }: MerendaFormProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             school_id: schoolId,
-            year: 2026,
+            year: new Date().getFullYear(),
             status: "draft", 
             data: data 
         }),

--- a/web/src/components/forms/observacoes-form.tsx
+++ b/web/src/components/forms/observacoes-form.tsx
@@ -69,13 +69,13 @@ export function ObservacoesForm({ schoolId, onSuccess, onBack }: ObservacoesForm
   async function onSubmit(data: ObservacoesFormValues) {
     setIsSaving(true);
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
       const response = await fetch(`${baseUrl}/v1/census`, {
-        method: "POST", 
+        method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             school_id: schoolId,
-            year: 2026,
+            year: new Date().getFullYear(),
             status: "completed", 
             data: data 
         }),

--- a/web/src/components/forms/portaria-form.tsx
+++ b/web/src/components/forms/portaria-form.tsx
@@ -51,7 +51,7 @@ export function PortariaForm({ schoolId, onSuccess, onBack }: PortariaFormProps)
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             school_id: schoolId,
-            year: 2026,
+            year: new Date().getFullYear(),
             status: "draft", 
             data: data 
         }),

--- a/web/src/components/forms/servicos-gerais-form.tsx
+++ b/web/src/components/forms/servicos-gerais-form.tsx
@@ -52,7 +52,7 @@ export function ServicosGeraisForm({ schoolId, onSuccess, onBack }: ServicosGera
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             school_id: schoolId,
-            year: 2026,
+            year: new Date().getFullYear(),
             status: "draft", 
             data: data 
         }),

--- a/web/src/components/forms/servidores-form.tsx
+++ b/web/src/components/forms/servidores-form.tsx
@@ -56,7 +56,7 @@ export function ServidoresForm({ schoolId, onSuccess, onBack }: ServidoresFormPr
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             school_id: schoolId,
-            year: 2026,
+            year: new Date().getFullYear(),
             status: "draft", 
             data: data 
         }),

--- a/web/src/components/forms/tecnologia-form.tsx
+++ b/web/src/components/forms/tecnologia-form.tsx
@@ -57,7 +57,7 @@ export function TecnologiaForm({ schoolId, onSuccess, onBack }: TecnologiaFormPr
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             school_id: schoolId,
-            year: 2026,
+            year: new Date().getFullYear(),
             status: "draft", 
             data: data 
         }),


### PR DESCRIPTION
## Resumo

Terceira rodada da auditoria de segurança. Nenhuma mudança exige login ou afeta o fluxo dos diretores.

## Correções

### Backend — `middleware.go`
- **`X-Content-Type-Options: nosniff`** — impede que o browser interprete respostas JSON como HTML ou script (MIME sniffing)
- **`X-Frame-Options: DENY`** — impede que endpoints sejam embutidos em `<iframe>` malicioso (clickjacking)
- **`Vary: Origin`** — adicionado em modo whitelist para evitar que CDN/proxy cache a resposta CORS de uma origem e sirva para outra (cache poisoning CORS)

### Frontend — 10 formulários com `year: 2026` hardcoded
Substituído por `new Date().getFullYear()` em todos os forms (`alunos`, `avaliacao`, `general-data`, `gestao`, `merenda`, `observacoes`, `portaria`, `servicos-gerais`, `servidores`, `tecnologia`).
Sem essa correção, em 2027 todo dado seria gravado no registro de 2026 e o censo do novo ano ficaria invisível no banco.

### Frontend — 3 formulários sem fallback na `baseUrl`
`gestao-form`, `avaliacao-form` e `observacoes-form` usavam `process.env.NEXT_PUBLIC_API_URL` diretamente sem fallback. Se a variável não estivesse definida, a URL virava `undefined/v1/census` e o formulário falhava silenciosamente sem salvar nada.

### `.gitignore`
Adicionado padrão `~$*` para ignorar lock files temporários do Excel (`~$locations.xlsx` estava sendo rastreado sem necessidade).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKTi4SHRNopYvcSEodum56)_