### PR TITLE
fix: rastreia sync com planilha e adiciona retry automático para censos perdidos

### DIFF
--- a/api/cmd/api/handlers.go
+++ b/api/cmd/api/handlers.go
@@ -177,21 +177,28 @@ func (app *application) CreateOrUpdateCenso(w http.ResponseWriter, r *http.Reque
 
 	// LÓGICA DE FINALIZAÇÃO: Planilha e Google Drive
 	if req.Status == "completed" {
-		// 1. Enviar para Planilha (Goroutine)
-		go func(c models.CensusResponse) {
-			if app.sheets == nil {
-				return
-			}
-			school, err := app.models.Schools.Get(c.SchoolID)
-			if err != nil {
-				app.logger.Println("Erro ao buscar escola para planilha:", err)
-				return
-			}
-			err = app.sheets.AppendCenso(c, *school)
-			if err != nil {
-				app.logger.Println("Erro ao salvar na planilha:", err)
-			}
-		}(censo)
+		// 1. Enviar para Planilha — apenas se ainda não sincronizado.
+		// Re-submissions com status "completed" não geram linha duplicada na planilha.
+		alreadySynced := existingCenso != nil && existingCenso.SheetSyncedAt != nil
+		if !alreadySynced {
+			go func(c models.CensusResponse) {
+				if app.sheets == nil {
+					return
+				}
+				school, err := app.models.Schools.Get(c.SchoolID)
+				if err != nil {
+					app.logger.Println("Erro ao buscar escola para planilha:", err)
+					return
+				}
+				if err = app.sheets.AppendCenso(c, *school); err != nil {
+					app.logger.Println("Erro ao salvar na planilha:", err)
+					return
+				}
+				if err = app.models.Census.MarkSheetSynced(c.ID); err != nil {
+					app.logger.Println("Erro ao marcar sheet_synced_at:", err)
+				}
+			}(censo)
+		}
 
 		// 2. Processar Upload da Foto
 		tempDir := "./tmp"
@@ -338,4 +345,47 @@ func (app *application) uploadPhoto(w http.ResponseWriter, r *http.Request) {
 		Data:    "temp_ok",
 	}
 	app.writeJSON(w, http.StatusCreated, payload)
+}
+
+// AdminSyncSheets força a re-sincronização imediata de todos os censos
+// completed que ainda não foram gravados na planilha.
+// Protegido por SYNC_SECRET para evitar uso não autorizado.
+func (app *application) AdminSyncSheets(w http.ResponseWriter, r *http.Request) {
+	secret := os.Getenv("SYNC_SECRET")
+	if secret != "" && r.Header.Get("X-Sync-Secret") != secret {
+		app.errorJSON(w, fmt.Errorf("não autorizado"), http.StatusUnauthorized)
+		return
+	}
+
+	pending, err := app.models.Census.GetPendingSheetSync()
+	if err != nil {
+		app.errorJSON(w, fmt.Errorf("erro ao buscar pendentes: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	synced := 0
+	failed := 0
+	for _, c := range pending {
+		school, err := app.models.Schools.Get(c.SchoolID)
+		if err != nil {
+			app.logger.Printf("adminSync: erro escola %d: %v", c.SchoolID, err)
+			failed++
+			continue
+		}
+		if err = app.sheets.AppendCenso(*c, *school); err != nil {
+			app.logger.Printf("adminSync: erro ao enviar escola %d: %v", c.SchoolID, err)
+			failed++
+			continue
+		}
+		if err = app.models.Census.MarkSheetSynced(c.ID); err != nil {
+			app.logger.Printf("adminSync: erro ao marcar sincronizado %d: %v", c.ID, err)
+		}
+		synced++
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{
+		Error:   false,
+		Message: fmt.Sprintf("Sync concluído: %d sincronizados, %d falhas", synced, failed),
+		Data:    map[string]int{"pending": len(pending), "synced": synced, "failed": failed},
+	})
 }

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -87,6 +87,14 @@ func main() {
 	defer db.Close()
 	logger.Println("Banco conectado!")
 
+	// Migração: garante que a coluna sheet_synced_at existe (bancos antigos não a têm).
+	_, err = db.Exec(`ALTER TABLE census_responses ADD COLUMN IF NOT EXISTS sheet_synced_at TIMESTAMP DEFAULT NULL`)
+	if err != nil {
+		logger.Printf("AVISO: migração sheet_synced_at: %v", err)
+	} else {
+		logger.Println("Migração sheet_synced_at OK")
+	}
+
 	// ... (Resto do seu código permanece igual)
 	sheetsService, err := services.NewSheetsService()
 	if err != nil {
@@ -109,6 +117,10 @@ func main() {
 		sheets: sheetsService,
 		drive:  driveService,
 	}
+
+	// Job de retry: a cada 10 minutos re-sincroniza censos completed que
+	// não chegaram à planilha (goroutine falhou silenciosamente antes).
+	go app.sheetSyncRetryJob()
 
 	srv := &http.Server{
 		Addr:         fmt.Sprintf("0.0.0.0:%s", cfg.port),
@@ -139,6 +151,45 @@ func openDB(cfg config) (*sql.DB, error) {
 	return db, nil
 }
 
+func (app *application) sheetSyncRetryJob() {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		app.syncPendingToSheets()
+	}
+}
+
+func (app *application) syncPendingToSheets() {
+	if app.sheets == nil {
+		return
+	}
+	pending, err := app.models.Census.GetPendingSheetSync()
+	if err != nil {
+		app.logger.Println("sheetSync: erro ao buscar pendentes:", err)
+		return
+	}
+	if len(pending) == 0 {
+		return
+	}
+	app.logger.Printf("sheetSync: %d censo(s) pendente(s) para planilha", len(pending))
+	for _, c := range pending {
+		school, err := app.models.Schools.Get(c.SchoolID)
+		if err != nil {
+			app.logger.Printf("sheetSync: erro escola %d: %v", c.SchoolID, err)
+			continue
+		}
+		if err = app.sheets.AppendCenso(*c, *school); err != nil {
+			app.logger.Printf("sheetSync: erro ao enviar escola %d: %v", c.SchoolID, err)
+			continue
+		}
+		if err = app.models.Census.MarkSheetSynced(c.ID); err != nil {
+			app.logger.Printf("sheetSync: erro ao marcar sincronizado %d: %v", c.ID, err)
+		} else {
+			app.logger.Printf("sheetSync: escola %d sincronizada", c.SchoolID)
+		}
+	}
+}
+
 func (app *application) routes() http.Handler {
 	mux := chi.NewRouter()
 	mux.Use(middleware.Recoverer)
@@ -158,6 +209,8 @@ func (app *application) routes() http.Handler {
 		r.Get("/census", app.GetCenso)
 		r.Post("/census", app.CreateOrUpdateCenso)
 		r.Post("/upload", app.uploadPhoto)
+		// Re-sincroniza manualmente todos os censos completed ainda sem planilha
+		r.Post("/admin/sync-sheets", app.AdminSyncSheets)
 	})
 
 	return mux

--- a/api/internal/models/models.go
+++ b/api/internal/models/models.go
@@ -31,13 +31,14 @@ type School struct {
 }
 
 type CensusResponse struct {
-	ID        int             `json:"id"`
-	SchoolID  int             `json:"school_id"`
-	Year      int             `json:"year"`
-	Status    string          `json:"status"`
-	Data      json.RawMessage `json:"data"`
-	CreatedAt time.Time       `json:"created_at"`
-	UpdatedAt time.Time       `json:"updated_at"`
+	ID             int             `json:"id"`
+	SchoolID       int             `json:"school_id"`
+	Year           int             `json:"year"`
+	Status         string          `json:"status"`
+	Data           json.RawMessage `json:"data"`
+	SheetSyncedAt  *time.Time      `json:"sheet_synced_at,omitempty"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
 }
 
 type SchoolModel struct {
@@ -205,6 +206,7 @@ func (m *SchoolModel) GetAll() ([]*School, error) {
 func (m *CensusModel) Upsert(response CensusResponse) error {
 	// O merge de dados já foi feito na camada de handler (Go), então aqui
 	// sobrescrevemos diretamente sem double-merge no SQL.
+	// sheet_synced_at é preservado — não resetamos ao re-salvar.
 	stmt := `
 		INSERT INTO census_responses (school_id, year, status, data, updated_at)
 		VALUES ($1, $2, $3, $4, NOW())
@@ -223,15 +225,48 @@ func (m *CensusModel) Upsert(response CensusResponse) error {
 	).Scan(&response.ID)
 }
 
-func (m *CensusModel) GetBySchoolID(schoolID int, year int) (*CensusResponse, error) {
+func (m *CensusModel) MarkSheetSynced(id int) error {
+	_, err := m.DB.ExecContext(context.Background(),
+		`UPDATE census_responses SET sheet_synced_at = NOW() WHERE id = $1`, id)
+	return err
+}
+
+// GetPendingSheetSync retorna todos os censos completed que ainda não foram
+// enviados para a planilha. Usado pelo job de retry e pela rota de resync.
+func (m *CensusModel) GetPendingSheetSync() ([]*CensusResponse, error) {
 	stmt := `SELECT id, school_id, year, status, data, created_at, updated_at
+	         FROM census_responses
+	         WHERE status = 'completed' AND sheet_synced_at IS NULL
+	         ORDER BY updated_at`
+
+	rows, err := m.DB.QueryContext(context.Background(), stmt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []*CensusResponse
+	for rows.Next() {
+		var c CensusResponse
+		var data []byte
+		if err := rows.Scan(&c.ID, &c.SchoolID, &c.Year, &c.Status, &data, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, err
+		}
+		c.Data = json.RawMessage(data)
+		results = append(results, &c)
+	}
+	return results, nil
+}
+
+func (m *CensusModel) GetBySchoolID(schoolID int, year int) (*CensusResponse, error) {
+	stmt := `SELECT id, school_id, year, status, data, sheet_synced_at, created_at, updated_at
 	         FROM census_responses WHERE school_id = $1 AND year = $2`
 
 	var c CensusResponse
 	var data []byte
 
 	err := m.DB.QueryRowContext(context.Background(), stmt, schoolID, year).Scan(
-		&c.ID, &c.SchoolID, &c.Year, &c.Status, &data, &c.CreatedAt, &c.UpdatedAt,
+		&c.ID, &c.SchoolID, &c.Year, &c.Status, &data, &c.SheetSyncedAt, &c.CreatedAt, &c.UpdatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/infra/init.sql
+++ b/infra/init.sql
@@ -40,6 +40,8 @@ CREATE TABLE IF NOT EXISTS census_responses (
       REFERENCES schools(id)
       ON DELETE CASCADE,
       
-    CONSTRAINT unique_school_year 
+    sheet_synced_at TIMESTAMP DEFAULT NULL,
+
+    CONSTRAINT unique_school_year
       UNIQUE (school_id, year)
 );


### PR DESCRIPTION
- Adiciona coluna sheet_synced_at em census_responses para saber quais
  censos já foram enviados ao Google Sheets
- Corrige bug de linha duplicada: AppendCenso só é chamado se ainda
  não sincronizado (re-submissions de "completed" não geram duplicatas)
- Goroutine de sheets agora marca sheet_synced_at após sucesso
- Job de retry a cada 10 min re-envia censos completed sem sync
- Rota POST /v1/admin/sync-sheets para re-sync manual imediato
- Migração automática no startup: ADD COLUMN IF NOT EXISTS

https://claude.ai/code/session_01M9KsCGZtTH7trTsVzLFCct