### PR TITLE
fix: corrige envio de dados para planilha Google Sheets

### DIFF
--- a/api/cmd/api/handlers.go
+++ b/api/cmd/api/handlers.go
@@ -177,10 +177,8 @@ func (app *application) CreateOrUpdateCenso(w http.ResponseWriter, r *http.Reque
 
 	// LÓGICA DE FINALIZAÇÃO: Planilha e Google Drive
 	if req.Status == "completed" {
-		// 1. Enviar para Planilha — apenas se ainda não sincronizado.
-		// Re-submissions com status "completed" não geram linha duplicada na planilha.
-		alreadySynced := existingCenso != nil && existingCenso.SheetSyncedAt != nil
-		if !alreadySynced && app.sheets != nil {
+		// 1. Enviar para Planilha — sempre que status for completed.
+		if app.sheets != nil {
 			// Busca a escola aqui (request context, conexão saudável) para não
 			// depender de DB dentro da goroutine onde a conexão pode estar stale.
 			school, err := app.models.Schools.Get(censo.SchoolID)

--- a/api/internal/models/models.go
+++ b/api/internal/models/models.go
@@ -214,7 +214,8 @@ func (m *CensusModel) Upsert(response *CensusResponse) error {
 		DO UPDATE SET
 			status = EXCLUDED.status,
 			data = EXCLUDED.data,
-			updated_at = NOW()
+			updated_at = NOW(),
+			sheet_synced_at = CASE WHEN EXCLUDED.status = 'completed' THEN NULL ELSE census_responses.sheet_synced_at END
 		RETURNING id`
 
 	return m.DB.QueryRowContext(context.Background(), stmt,


### PR DESCRIPTION
## Resumo

- **Bug principal**: Pool de conexões com `lifetime=1h` sem idle timeout acumulava conexões stale. O Railway mata conexões idle em ~5 min, causando `TCP_INVALID_SYN` nos logs. A goroutine de sync falhava silenciosamente ao buscar a escola no banco antes de chamar `AppendCenso`.
- **Bug secundário**: `Upsert` recebia `CensusResponse` por valor — o `RETURNING id` nunca voltava ao handler, então `MarkSheetSynced` sempre executava com `id = 0`, não marcando nenhuma linha.
- **Melhoria**: Removido o bloqueio de duplicatas — toda submissão com `status = completed` agora sempre gera uma linha na planilha. O `Upsert` reseta `sheet_synced_at` a cada nova submissão completa para garantir que o retry job reenvie se a goroutine falhar.

## Mudanças

- `api/cmd/api/main.go`: pool reduzido (`max 25 conexões`, `idle timeout 2min`, `lifetime 5min`)
- `api/internal/models/models.go`: `Upsert` agora recebe `*CensusResponse` (ponteiro) + reseta `sheet_synced_at` no `ON CONFLICT`
- `api/cmd/api/handlers.go`: escola buscada antes da goroutine; removido bloqueio `alreadySynced`

## Plano de teste após merge

1. Rodar no Railway DB Query:
```sql
UPDATE census_responses SET sheet_synced_at = NULL WHERE status = 'completed' AND updated_at >= '2026-05-06';
```
2. Chamar `POST /v1/admin/sync-sheets` para reenviar registros pendentes
3. No Google Sheets → Dados → Remover duplicatas pela coluna INEP

https://claude.ai/code/session_013GTv5JheebTmvgwwFGgK5H

---
_Generated by [Claude Code](https://claude.ai/code/session_013GTv5JheebTmvgwwFGgK5H)_