### PR TITLE
feat: aba Perfil dos Alunos e Resultados + leitura Indicadores_Flags

### DIFF
--- a/api/cmd/api/admin.go
+++ b/api/cmd/api/admin.go
@@ -368,6 +368,20 @@ func (app *application) AdminSheetMetrics(w http.ResponseWriter, r *http.Request
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: metrics})
 }
 
+// AdminIndicadoresMetrics retorna métricas de perfil dos alunos da aba Indicadores_Flags.
+func (app *application) AdminIndicadoresMetrics(w http.ResponseWriter, r *http.Request) {
+	if app.sheets == nil {
+		app.errorJSON(w, fmt.Errorf("serviço de planilhas não configurado"), http.StatusServiceUnavailable)
+		return
+	}
+	metrics, err := app.sheets.GetIndicadoresMetrics()
+	if err != nil {
+		app.errorJSON(w, fmt.Errorf("erro ao ler Indicadores_Flags: %v", err), http.StatusInternalServerError)
+		return
+	}
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: metrics})
+}
+
 // AdminGetCensusByID retorna o JSON completo de uma resposta de censo específica.
 // Usado pelo botão "Ver JSON" no painel admin.
 func (app *application) AdminGetCensusByID(w http.ResponseWriter, r *http.Request) {

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -217,6 +217,7 @@ func (app *application) routes() http.Handler {
 			protected.Use(app.requireAdminAuth)
 			protected.Get("/admin/dashboard", app.AdminDashboard)
 			protected.Get("/admin/sheet-metrics", app.AdminSheetMetrics)
+			protected.Get("/admin/indicadores-metrics", app.AdminIndicadoresMetrics)
 			protected.Get("/admin/census", app.AdminGetCensus)
 			protected.Get("/admin/census/{id}", app.AdminGetCensusByID)
 			protected.Post("/admin/sync-sheets", app.AdminSyncSheets)

--- a/api/internal/services/sheets.go
+++ b/api/internal/services/sheets.go
@@ -469,6 +469,161 @@ func (s *SheetsService) GetSheetMetrics() (*SheetMetrics, error) {
 	}, nil
 }
 
+// ─── Indicadores_Flags metrics ────────────────────────────────────────────────
+
+type BenefStat struct {
+	Faixa string `json:"faixa"`
+	Count int    `json:"count"`
+}
+type AbandonoStat struct {
+	Faixa string  `json:"faixa"`
+	Count int     `json:"count"`
+}
+type DreAbandonoStat struct {
+	Dre   string  `json:"dre"`
+	Media float64 `json:"media"`
+	Count int     `json:"count"`
+}
+type IndicadoresMetrics struct {
+	EscolasRiscoFluxo    int               `json:"escolas_risco_fluxo"`
+	PorFaixaBenef        []BenefStat       `json:"por_faixa_benef"`
+	PorFaixaAbandono     []AbandonoStat    `json:"por_faixa_abandono"`
+	TopDreAbandono       []DreAbandonoStat `json:"top_dre_abandono"`
+}
+
+// findCol retorna o índice (0-based) do primeiro header que contenha algum dos padrões.
+func findCol(headers []interface{}, patterns ...string) int {
+	for _, pat := range patterns {
+		patL := strings.ToLower(strings.TrimSpace(pat))
+		for i, h := range headers {
+			if strings.ToLower(strings.TrimSpace(fmt.Sprint(h))) == patL {
+				return i
+			}
+		}
+	}
+	// segunda passagem: contains
+	for _, pat := range patterns {
+		patL := strings.ToLower(strings.TrimSpace(pat))
+		for i, h := range headers {
+			if strings.Contains(strings.ToLower(fmt.Sprint(h)), patL) {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+var benefOrder = []string{"Até 25%", "26% a 50%", "51% a 75%", "Acima de 75%", "Não informado"}
+var abandonoOrder = []string{"Até 2%", "2% a 5%", "5% a 10%", "Acima de 10%"}
+
+// GetIndicadoresMetrics lê Indicadores_Flags e agrega os dados de perfil dos alunos.
+func (s *SheetsService) GetIndicadoresMetrics() (*IndicadoresMetrics, error) {
+	resp, err := s.srv.Spreadsheets.Values.Get(
+		s.censusSpreadsheetID,
+		"Indicadores_Flags!A1:DZ1023",
+	).Do()
+	if err != nil {
+		return nil, fmt.Errorf("erro ao ler Indicadores_Flags: %v", err)
+	}
+	if len(resp.Values) < 2 {
+		return &IndicadoresMetrics{}, nil
+	}
+
+	headers := resp.Values[0]
+
+	// Localiza colunas por nome (flexível)
+	colDre         := findCol(headers, "dre")
+	colBenef       := findCol(headers, "faixa_beneficiarios", "faixa_benef", "beneficiarios_faixa", "beneficiarios")
+	colFxAbandono  := findCol(headers, "faixa_abandono", "abandono_faixa")
+	colTxAbandono  := findCol(headers, "taxa_abandono", "tx_abandono", "abandono")
+	colRiscoFluxo  := findCol(headers, "flag_risco_fluxo", "risco_fluxo", "flag_fluxo", "risco_de_fluxo")
+
+	benefCount    := map[string]int{}
+	abandonoCount := map[string]int{}
+	dreAbandono   := map[string][]float64{} // dre → lista de taxas
+	riscoFluxo    := 0
+
+	for _, row := range resp.Values[1:] {
+		if len(row) == 0 { continue }
+
+		dre := ""
+		if colDre >= 0 && colDre < len(row) { dre = strings.TrimSpace(fmt.Sprint(row[colDre])) }
+
+		// Faixa Beneficiários
+		if colBenef >= 0 && colBenef < len(row) {
+			v := strings.TrimSpace(fmt.Sprint(row[colBenef]))
+			if v == "" || v == "0" || strings.EqualFold(v, "não informado") {
+				v = "Não informado"
+			}
+			benefCount[v]++
+		}
+
+		// Faixa / Taxa de Abandono
+		fxAbandono := ""
+		if colFxAbandono >= 0 && colFxAbandono < len(row) {
+			fxAbandono = strings.TrimSpace(fmt.Sprint(row[colFxAbandono]))
+		}
+		if fxAbandono != "" {
+			abandonoCount[fxAbandono]++
+		}
+
+		// Taxa abandono numérica para média por DRE
+		if colTxAbandono >= 0 && colTxAbandono < len(row) && dre != "" {
+			raw := strings.TrimSpace(fmt.Sprint(row[colTxAbandono]))
+			raw = strings.ReplaceAll(raw, ",", ".")
+			raw = strings.ReplaceAll(raw, "%", "")
+			if f, err := strconv.ParseFloat(raw, 64); err == nil {
+				dreAbandono[dre] = append(dreAbandono[dre], f)
+			}
+		}
+
+		// Risco de Fluxo
+		if colRiscoFluxo >= 0 && colRiscoFluxo < len(row) {
+			v := strings.TrimSpace(fmt.Sprint(row[colRiscoFluxo]))
+			if v == "1" || strings.EqualFold(v, "sim") || strings.EqualFold(v, "true") {
+				riscoFluxo++
+			}
+		}
+	}
+
+	// Ordena faixas de beneficiários
+	var benefStats []BenefStat
+	for _, f := range benefOrder {
+		benefStats = append(benefStats, BenefStat{Faixa: f, Count: benefCount[f]})
+	}
+	// Adiciona faixas não previstas
+	for f, c := range benefCount {
+		known := false
+		for _, o := range benefOrder { if o == f { known = true; break } }
+		if !known { benefStats = append(benefStats, BenefStat{Faixa: f, Count: c}) }
+	}
+
+	// Ordena faixas de abandono
+	var abandonoStats []AbandonoStat
+	for _, f := range abandonoOrder {
+		abandonoStats = append(abandonoStats, AbandonoStat{Faixa: f, Count: abandonoCount[f]})
+	}
+
+	// Top 10 DREs por taxa média de abandono
+	var dreStats []DreAbandonoStat
+	for dre, taxas := range dreAbandono {
+		if dre == "" || len(taxas) == 0 { continue }
+		sum := 0.0
+		for _, t := range taxas { sum += t }
+		media := math.Round((sum/float64(len(taxas)))*100) / 100
+		dreStats = append(dreStats, DreAbandonoStat{Dre: dre, Media: media, Count: len(taxas)})
+	}
+	sort.Slice(dreStats, func(i, j int) bool { return dreStats[i].Media > dreStats[j].Media })
+	if len(dreStats) > 10 { dreStats = dreStats[:10] }
+
+	return &IndicadoresMetrics{
+		EscolasRiscoFluxo: riscoFluxo,
+		PorFaixaBenef:     benefStats,
+		PorFaixaAbandono:  abandonoStats,
+		TopDreAbandono:    dreStats,
+	}, nil
+}
+
 func (s *SheetsService) ensureAndAppendDeficit(sheetTitle string, questionText string, value interface{}, school models.School) error {
 	spreadsheet, err := s.srv.Spreadsheets.Get(s.censusSpreadsheetID).Do()
 	if err != nil {

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -2,10 +2,10 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
-  Building2, CheckCircle2, FileText, RefreshCw, LogOut, Search,
+  Building2, CheckCircle2, FileText, LogOut, Search,
   Eye, X, LayoutDashboard, Database, MapPinned, Lock, User as UserIcon,
   AlertCircle, Loader2, Copy, Download, Filter, CloudUpload, Clock,
-  TrendingUp, Users, GraduationCap, BarChart2,
+  TrendingUp, Users, GraduationCap, BarChart2, Activity, AlertTriangle,
 } from "lucide-react";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -27,6 +27,15 @@ interface SheetMetrics {
   total_escolas: number; total_alunos: number; total_alunos_pcd: number;
   media_alunos_por_escola: number;
   por_zona: ZonaStat[]; por_porte: PorteStat[]; por_dre: DreSheetsStats[];
+}
+interface BenefStat     { faixa: string; count: number; }
+interface AbandonoStat  { faixa: string; count: number; }
+interface DreAbandono   { dre: string; media: number; count: number; }
+interface IndicadoresMetrics {
+  escolas_risco_fluxo: number;
+  por_faixa_benef:     BenefStat[];
+  por_faixa_abandono:  AbandonoStat[];
+  top_dre_abandono:    DreAbandono[];
 }
 interface CensusFull extends CensusRow { data: unknown; created_at: string; }
 
@@ -128,6 +137,46 @@ function Donut({
           );
         })}
       </ul>
+    </div>
+  );
+}
+
+// ─── Vertical bar chart (estilo Looker Studio) ────────────────────────────────
+
+function VBarChart({
+  rows,
+  color = C.primary,
+  showPct = true,
+}: {
+  rows: { label: string; value: number }[];
+  color?: string;
+  showPct?: boolean;
+}) {
+  const total = rows.reduce((s, r) => s + r.value, 0);
+  const max   = Math.max(...rows.map((r) => r.value), 1);
+  return (
+    <div className="flex items-end justify-around gap-3 w-full h-52 pt-6 relative">
+      {rows.map((r) => {
+        const pct    = total > 0 ? ((r.value / total) * 100).toFixed(1) : "0.0";
+        const height = total > 0 ? (r.value / max) * 100 : 0;
+        return (
+          <div key={r.label} className="flex flex-col items-center gap-1 flex-1 min-w-0">
+            {/* label acima da barra */}
+            <span className="text-xs font-bold tabular-nums" style={{ color }}>
+              {showPct ? `${pct}%` : r.value.toLocaleString("pt-BR")}
+            </span>
+            {/* barra */}
+            <div className="w-full max-w-[56px] flex items-end" style={{ height: "120px" }}>
+              <div
+                className="w-full rounded-t-md transition-all duration-500"
+                style={{ height: `${Math.max(height, 2)}%`, background: color }}
+              />
+            </div>
+            {/* rótulo abaixo */}
+            <span className="text-xs text-slate-500 text-center leading-tight line-clamp-2 w-full">{r.label}</span>
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -474,6 +523,147 @@ function PerfilDaRede({ token, onUnauth }: { token: string; onUnauth: () => void
   );
 }
 
+// ─── Perfil dos Alunos e Resultados ──────────────────────────────────────────
+
+function PerfilAlunos({ token, onUnauth }: { token: string; onUnauth: () => void }) {
+  const [metrics, setMetrics] = useState<IndicadoresMetrics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr]         = useState("");
+
+  useEffect(() => {
+    apiFetch<IndicadoresMetrics>("/v1/admin/indicadores-metrics", token)
+      .then(setMetrics)
+      .catch((e) => {
+        if ((e as Error).message === "UNAUTHORIZED") { onUnauth(); return; }
+        setErr((e as Error).message);
+      })
+      .finally(() => setLoading(false));
+  }, [token, onUnauth]);
+
+  if (loading) return (
+    <div className="flex items-center justify-center py-24 text-slate-400">
+      <Loader2 className="animate-spin mr-2" size={22} style={{ color: C.primary }} /> Lendo Indicadores_Flags…
+    </div>
+  );
+  if (err) return (
+    <div className="flex items-start gap-2 bg-rose-50 border border-rose-200 text-rose-700 rounded-xl px-4 py-3 text-sm">
+      <AlertCircle size={16} /> {err}
+    </div>
+  );
+  if (!metrics) return null;
+
+  const totalBenef   = metrics.por_faixa_benef.reduce((s, r) => s + r.count, 0);
+  const totalAbandono = metrics.por_faixa_abandono.reduce((s, r) => s + r.count, 0);
+
+  return (
+    <div className="space-y-5">
+      {/* Label do subtab — igual Looker Studio */}
+      <div className="bg-orange-50 border border-orange-200 rounded-xl px-5 py-3">
+        <p className="text-sm text-orange-800 italic font-medium">
+          Qual é o perfil socioeconômico dos estudantes e como está a permanência e o fluxo escolar na rede?
+        </p>
+      </div>
+
+      {/* Stat card de risco — big number */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <StatCard
+          label="Escolas com Risco de Fluxo"
+          value={metrics.escolas_risco_fluxo}
+          Icon={AlertTriangle}
+          tone="orange"
+          sub="flag ativa de risco"
+        />
+        <StatCard
+          label="Escolas Analisadas (Beneficiários)"
+          value={totalBenef}
+          Icon={Users}
+          tone="blue"
+        />
+        <StatCard
+          label="Escolas Analisadas (Abandono)"
+          value={totalAbandono}
+          Icon={Activity}
+          tone="amber"
+        />
+      </div>
+
+      {/* Linha 1: dois gráficos de barra vertical */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
+          <h3 className="font-semibold text-slate-800 text-sm mb-1">
+            Distribuição por Faixa de Beneficiários
+          </h3>
+          <p className="text-xs text-slate-400 mb-4">% escolas por faixa de beneficiários sociais</p>
+          {metrics.por_faixa_benef.some((r) => r.count > 0) ? (
+            <VBarChart
+              rows={metrics.por_faixa_benef.filter((r) => r.count > 0).map((r) => ({
+                label: r.faixa,
+                value: r.count,
+              }))}
+              color={C.primary}
+              showPct={true}
+            />
+          ) : (
+            <p className="text-sm text-slate-400 text-center py-10">Dados não encontrados na planilha.</p>
+          )}
+        </div>
+
+        <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
+          <h3 className="font-semibold text-slate-800 text-sm mb-1">
+            Distribuição da Taxa de Abandono
+          </h3>
+          <p className="text-xs text-slate-400 mb-4">% escolas por faixa de taxa de abandono</p>
+          {metrics.por_faixa_abandono.some((r) => r.count > 0) ? (
+            <VBarChart
+              rows={metrics.por_faixa_abandono.filter((r) => r.count > 0).map((r) => ({
+                label: r.faixa,
+                value: r.count,
+              }))}
+              color={C.primary}
+              showPct={true}
+            />
+          ) : (
+            <p className="text-sm text-slate-400 text-center py-10">Dados não encontrados na planilha.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Linha 2: Top 10 DREs + card risco */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        <div className="lg:col-span-2 bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
+          <h3 className="font-semibold text-slate-800 text-sm mb-1">
+            Top 10 DREs com maior taxa média de abandono
+          </h3>
+          <p className="text-xs text-slate-400 mb-4">taxa média de abandono (%)</p>
+          {metrics.top_dre_abandono.length > 0 ? (
+            <VBarChart
+              rows={metrics.top_dre_abandono.map((d) => ({
+                label: d.dre,
+                value: d.media,
+              }))}
+              color={C.primary}
+              showPct={false}
+            />
+          ) : (
+            <p className="text-sm text-slate-400 text-center py-10">Dados não encontrados.</p>
+          )}
+        </div>
+
+        {/* Escolas com Risco de Fluxo — big number estilo Looker */}
+        <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm flex flex-col items-center justify-center text-center">
+          <h3 className="font-semibold text-slate-700 text-sm mb-2">Escolas com Risco de Fluxo</h3>
+          <p className="text-7xl font-bold text-slate-900 tabular-nums my-4">
+            {metrics.escolas_risco_fluxo}
+          </p>
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-orange-50 text-orange-700 border border-orange-200">
+            <AlertTriangle size={12} /> flag ativa
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ─── Login ────────────────────────────────────────────────────────────────────
 
 function LoginForm({ onLogin }: { onLogin: (t: string) => void }) {
@@ -546,7 +736,7 @@ function LoginForm({ onLogin }: { onLogin: (t: string) => void }) {
 
 // ─── Dashboard ────────────────────────────────────────────────────────────────
 
-type Tab = "perfil" | "operacional" | "census" | "dre";
+type Tab = "perfil" | "alunos" | "operacional" | "census" | "dre";
 
 function Dashboard({ token, onLogout }: { token: string; onLogout: () => void }) {
   const [dbData,       setDbData]       = useState<DashboardData | null>(null);
@@ -606,10 +796,11 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
   const filteredCensus  = (allCensus       ?? []).filter((r) => !search || match(r, search));
 
   const tabs: { id: Tab; label: string; Icon: React.ComponentType<{ size?: number; strokeWidth?: number }> }[] = [
-    { id: "perfil",      label: "Dimensão e Perfil da Rede", Icon: BarChart2      },
-    { id: "operacional", label: "Operacional",               Icon: LayoutDashboard },
-    { id: "census",      label: "Todos os Censos",           Icon: Database       },
-    { id: "dre",         label: "Por DRE",                   Icon: MapPinned      },
+    { id: "perfil",      label: "Caracterização da Rede",         Icon: BarChart2      },
+    { id: "alunos",      label: "Perfil dos Alunos e Resultados", Icon: Activity       },
+    { id: "operacional", label: "Operacional",                    Icon: LayoutDashboard },
+    { id: "census",      label: "Todos os Censos",                Icon: Database       },
+    { id: "dre",         label: "Por DRE",                        Icon: MapPinned      },
   ];
 
   if (loading) return (
@@ -670,9 +861,14 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
           </div>
         )}
 
-        {/* ── Perfil da Rede (Looker-style) ─────────────────────── */}
+        {/* ── Caracterização da Rede ────────────────────────────── */}
         {tab === "perfil" && (
           <PerfilDaRede token={token} onUnauth={logout} />
+        )}
+
+        {/* ── Perfil dos Alunos e Resultados ───────────────────── */}
+        {tab === "alunos" && (
+          <PerfilAlunos token={token} onUnauth={logout} />
         )}
 
         {/* ── Operacional (DB stats + envios recentes) ───────────── */}


### PR DESCRIPTION
## Resumo

Implementação da segunda aba do painel admin, replicando a tela "Perfil dos Alunos e Resultados" do Looker Studio SEDUC-PA, com dados lidos diretamente da aba `Indicadores_Flags` da planilha Google Sheets.

---

## Backend

- `GetIndicadoresMetrics()` lê `Indicadores_Flags` (1.023 linhas × 105 colunas) com **detecção dinâmica de colunas por nome** — robusto a variações de header (busca exata + contains)
- Agrega: escolas com risco de fluxo, distribuição por faixa de beneficiários, distribuição da taxa de abandono, Top 10 DREs por taxa média de abandono
- Novo endpoint `GET /v1/admin/indicadores-metrics` (JWT protegido)

---

## Frontend

### Nova aba — "Perfil dos Alunos e Resultados"

| Elemento | Detalhe |
|----------|---------|
| Caixa temática | Pergunta descritiva em fundo laranja — igual ao Looker Studio |
| 3 stat cards | Escolas c/ Risco de Fluxo, Escolas analisadas (beneficiários e abandono) |
| VBarChart | Distribuição por Faixa de Beneficiários (% acima de cada barra) |
| VBarChart | Distribuição da Taxa de Abandono |
| VBarChart | Top 10 DREs com maior taxa média de abandono |
| Big number | "Escolas com Risco de Fluxo" — número grande centralizado |

### Componente VBarChart
Novo componente de barras verticais com % exibida acima e rótulo abaixo — estilo idêntico ao Looker Studio original.

### Tabs atualizadas
- "Caracterização da Rede" (era "Dimensão e Perfil da Rede")
- "Perfil dos Alunos e Resultados" ← nova
- "Operacional", "Todos os Censos", "Por DRE" — mantidas

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfWCnnavaXWRZLQeKERqnh)_