### PR TITLE
docs(dashboard): reconciliar CAR-INFRA-01 e consolidar gráficos mínim…

### DIFF
--- a/docs/dashboard/especificacao-entrega-dados-por-grafico.md
+++ b/docs/dashboard/especificacao-entrega-dados-por-grafico.md
@@ -224,10 +224,10 @@ Dependia de aba auxiliar que expandia a lista de ambientes declarados por escola
 `vw_censo_ambientes`, criada pela migration `0007_vw_censo_ambientes.sql`, com uma linha por `school_id + year + ambiente`.
 
 **View ou transformação necessária**  
-A view existente é suficiente para presença de ambientes. Falta uma query/endpoint sintético dentro de Caracterização, usando `COUNT(DISTINCT school_id) GROUP BY ambiente` e percentual sobre o total do recorte.
+A view existente já é suficiente. O endpoint sintético dentro de Caracterização foi implementado (CAR-INFRA-01), usando `COUNT(DISTINCT school_id) GROUP BY ambiente` e percentual sobre o total do recorte.
 
 **Endpoint necessário**  
-Novo endpoint recomendado: `GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional`.
+Entregue: `GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional`.
 
 **Payload esperado**  
 ```ts
@@ -241,16 +241,16 @@ Novo endpoint recomendado: `GET /v1/admin/analytics/caracterizacao/infraestrutur
 ```
 
 **Frontend necessário**  
-Renderizar em `AbaCaracterizacao.tsx`, anchor `sec-perfil-infra`, como bloco sintético sem duplicar a profundidade da aba Infraestrutura e Segurança.
+Entregue: renderizado em `AbaCaracterizacao.tsx`, anchor `sec-perfil-infra`, como bloco sintético sem duplicar a profundidade da aba Infraestrutura e Segurança.
 
 **Dependências de produto/dados**  
-Confirmar se o gráfico deve exibir todos os ambientes ou apenas Top N.
+Refino futuro: confirmar com produto se o gráfico deve exibir todos os ambientes ou apenas Top N.
 
 **Tipo de lacuna**  
-Backend + Frontend.
+Entregue (CAR-INFRA-01).
 
 **Próxima ação recomendada**  
-Criar endpoint de infraestrutura educacional usando `vw_censo_ambientes` e renderizar gráfico sintético na Caracterização.
+Nenhuma ação obrigatória. Refino futuro de apresentação (Top N vs. todos os ambientes) com a área de produto.
 
 #### 5.2.2 Cobertura de ambientes essenciais — **entregue com lista oficial inicial**
 
@@ -261,13 +261,13 @@ Indicadores de cobertura dos ambientes considerados essenciais: média de essenc
 Dependia de aba auxiliar com marcação de essencialidade ou cálculo equivalente por escola.
 
 **Origem provável do dado no banco**  
-`vw_censo_ambientes` para presença; `vw_censo_enriquecida.porte_escola_nome` se houver recorte por porte. Falta a lista oficial de ambientes essenciais.
+`vw_censo_ambientes` para presença; `vw_censo_enriquecida.porte_escola_nome` para recorte por porte. A lista oficial inicial de ambientes essenciais já foi definida e entregue (ver Status acima).
 
 **View ou transformação necessária**  
-Criar transformação derivada que marque `is_essencial` com base em lista oficial. Depois calcular, por escola: `qtd_ambientes_essenciais_presentes`, `percentual_cobertura_essenciais` e `faixa_cobertura`.
+Entregue: o endpoint marca `is_essencial` com base na lista oficial inicial e calcula, por escola, `qtd_ambientes_essenciais_presentes`, `percentual_cobertura_essenciais` e `faixa_cobertura`.
 
 **Endpoint necessário**  
-`GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional`.
+Entregue: `GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional`.
 
 **Payload esperado**  
 ```ts
@@ -285,16 +285,16 @@ Criar transformação derivada que marque `is_essencial` com base em lista ofici
 ```
 
 **Frontend necessário**  
-Renderizar KPI(s) e distribuição em `AbaCaracterizacao.tsx`, anchor `sec-perfil-infra`.
+Entregue: KPIs + donut de faixas + modal informativo em `AbaCaracterizacao.tsx`, anchor `sec-perfil-infra`.
 
 **Dependências de produto/dados**  
-Definir a lista oficial de ambientes essenciais. Sem essa decisão, qualquer cálculo será arbitrário.
+Refino futuro: revisar a lista oficial de ambientes essenciais com a área de produto. A lista inicial já está em produção.
 
 **Tipo de lacuna**  
-Produto, depois Backend + Frontend.
+Entregue (CAR-INFRA-01).
 
 **Próxima ação recomendada**  
-Abrir task de produto para validar a lista de essenciais antes de implementar SQL.
+Nenhuma ação obrigatória. Refino futuro da lista de essenciais com produto.
 
 #### 5.2.3 Média de ambientes essenciais por porte — **entregue com lista oficial inicial**
 
@@ -305,13 +305,13 @@ Média de ambientes essenciais presentes por escola em cada faixa de porte.
 Dependia do mesmo cálculo intermediário de essencialidade por escola, depois agrupado por porte.
 
 **Origem provável do dado no banco**  
-`vw_censo_ambientes` + `vw_censo_enriquecida.porte_escola_nome`, após existir regra oficial de ambientes essenciais.
+`vw_censo_ambientes` + `vw_censo_enriquecida.porte_escola_nome`, com a regra oficial inicial de ambientes essenciais já aplicada.
 
 **View ou transformação necessária**  
-Transformação por escola com contagem de essenciais presentes e agregação `AVG(qtd_essenciais_presentes) GROUP BY porte_escola_nome`.
+Entregue: contagem de essenciais presentes por escola e agregação `AVG(qtd_essenciais_presentes) GROUP BY porte_escola_nome`.
 
 **Endpoint necessário**  
-`GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional`.
+Entregue: `GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional`.
 
 **Payload esperado**  
 ```ts
@@ -324,16 +324,16 @@ Transformação por escola com contagem de essenciais presentes e agregação `A
 ```
 
 **Frontend necessário**  
-Renderizar tabela compacta ou barra em `AbaCaracterizacao.tsx`, anchor `sec-perfil-infra`.
+Entregue: barra por porte em `AbaCaracterizacao.tsx`, anchor `sec-perfil-infra`.
 
 **Dependências de produto/dados**  
-Mesma lista oficial de ambientes essenciais do item anterior.
+Refino futuro: mesma revisão da lista oficial de essenciais do item anterior.
 
 **Tipo de lacuna**  
-Produto, depois Backend + Frontend.
+Entregue (CAR-INFRA-01).
 
 **Próxima ação recomendada**  
-Implementar somente depois da lista de essenciais e do endpoint sintético de infraestrutura educacional.
+Nenhuma ação obrigatória. Eventual refino acompanha a revisão da lista de essenciais.
 
 ### 5.3 Infraestrutura e Segurança — Energia, Climatização e Capacidade Elétrica
 
@@ -754,6 +754,333 @@ Produto.
 **Próxima ação recomendada**  
 Abrir decisão de produto sobre denominador antes de qualquer alteração backend/frontend.
 
+### 6.5 Tecnologia e Equipamentos — Gráficos mínimos do Data Studio
+
+> **Contexto.** O painel original (Data Studio/Looker Studio) organizava o tema em dois blocos visuais — "Infraestrutura Digital e Capacidade Instalada" e "Uso Pedagógico e Adequação Tecnológica". A aplicação desdobrou o primeiro em **Infraestrutura Digital** + **Parque Tecnológico** e manteve **Uso Pedagógico**. Esta seção detalha tecnicamente os gráficos mínimos do painel original que hoje estão **parciais** (existem como KPI, mas não como distribuição) ou **ausentes**. Vários indicadores já existem como percentual/KPI; a referência mínima do Data Studio exige a distribuição completa, por isso ficam classificados como pendentes. Esta seção é **somente documental** — não implementa endpoints, views nem frontend.
+>
+> Os endpoints existentes (`/v1/admin/analytics/tecnologia/{infraestrutura,uso-pedagogico}`) usam `CategoricStat` com o campo `valor`; novos contratos podem mapear `valor`→`label` no frontend ou padronizar o payload novo. As assinaturas de payload abaixo descrevem o contrato lógico desejado, não o formato atual.
+
+#### 6.5.1 Disponibilidade de internet
+
+**O que o gráfico deve mostrar**  
+Distribuição de escolas com e sem internet (Sim/Não), com contagem e percentual sobre o total de escolas do recorte.
+
+**Como era tratado na planilha/painel original**  
+Exibido como distribuição Sim/Não no bloco "Infraestrutura Digital e Capacidade Instalada", não apenas como KPI percentual.
+
+**Origem provável do dado no banco**  
+`vw_censo_equipamentos_tecnologia.internet_disponivel` (boolean), derivado de `census_responses.data`.
+
+**View ou transformação necessária**  
+A view já expõe o campo booleano. Falta agregar a distribuição Sim/Não no endpoint (hoje só há `percentual_internet` e `escolas_com_internet`).
+
+**Endpoint necessário**  
+Expandir `GET /v1/admin/analytics/tecnologia/infraestrutura`.
+
+**Payload esperado**  
+```ts
+{
+  disponibilidade_internet: Array<{
+    label: "Sim" | "Não";
+    escolas: number;
+    percentual: number;
+  }>;
+}
+```
+
+**Frontend necessário**  
+Renderizar donut/barra Sim/Não em `web/src/components/admin/AbaTecnologia.tsx`, anchor `sec-tecnologia-digital`, sem remover o KPI "Escolas com Internet".
+
+**Dependências de produto/dados**  
+Confirmar tratamento de respostas vazias/não informadas (entram como "Não" ou categoria própria).
+
+**Tipo de lacuna**  
+Backend + Frontend.
+
+**Próxima ação recomendada**  
+Expor a distribuição Sim/Não no payload de infraestrutura e renderizar o donut.
+
+#### 6.5.2 Quantidade mediana de equipamentos por escola
+
+**O que o gráfico deve mostrar**  
+Mediana por escola para Chromebook, Desktop uso de alunos, Desktop administrativo e Notebook.
+
+**Como era tratado na planilha/painel original**  
+Estatística de mediana por escola e por tipo de equipamento, no bloco de capacidade instalada.
+
+**Origem provável do dado no banco**  
+`vw_censo_equipamentos_tecnologia.qtd_chromebooks`, `qtd_desktop_alunos`, `qtd_desktop_adm`, `qtd_notebooks`.
+
+**View ou transformação necessária**  
+A view já expõe as quantidades por escola. Hoje o endpoint só calcula `SUM` por tipo. Cálculo sugerido para a mediana:
+
+```sql
+PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY campo)
+```
+
+por tipo de equipamento, sobre escolas concluídas no recorte.
+
+**Endpoint necessário**  
+Expandir `GET /v1/admin/analytics/tecnologia/infraestrutura`.
+
+**Payload esperado**  
+```ts
+{
+  mediana_equipamentos_por_escola: Array<{
+    label: string;   // ex.: "Chromebook", "Desktop alunos", "Desktop administrativo", "Notebook"
+    mediana: number;
+  }>;
+}
+```
+
+**Frontend necessário**  
+Renderizar barra/tabela em `AbaTecnologia.tsx`, anchor `sec-tecnologia-parque`.
+
+**Dependências de produto/dados**  
+Confirmar se escolas que declararam zero entram no cálculo da mediana ou se há recorte por escolas que possuem o equipamento.
+
+**Tipo de lacuna**  
+Backend + Frontend.
+
+**Próxima ação recomendada**  
+Adicionar a mediana por tipo ao payload de infraestrutura e renderizar.
+
+#### 6.5.3 Distribuição do parque tecnológico (%)
+
+**O que o gráfico deve mostrar**  
+Participação percentual de cada tipo de equipamento no total do parque tecnológico declarado.
+
+**Como era tratado na planilha/painel original**  
+Distribuição percentual (%) do parque por tipo de equipamento.
+
+**Origem provável do dado no banco**  
+Totais de desktops administrativos, desktops de alunos, notebooks e chromebooks, já entregues como `SUM` no endpoint atual.
+
+**View ou transformação necessária**  
+Nenhuma view nova obrigatória. O percentual pode ser calculado a partir dos totais já existentes (no frontend ou no servidor): `quantidade_tipo / soma_total_parque`.
+
+**Endpoint necessário**  
+Pode ser derivado no frontend a partir do payload atual de `GET /v1/admin/analytics/tecnologia/infraestrutura`; alternativamente, expor o percentual já calculado no servidor.
+
+**Payload esperado**  
+```ts
+{
+  distribuicao_parque_tecnologico: Array<{
+    label: string;
+    quantidade: number;
+    percentual: number;
+  }>;
+}
+```
+
+**Frontend necessário**  
+Renderizar donut/barra de participação % em `AbaTecnologia.tsx`, anchor `sec-tecnologia-parque`.
+
+**Dependências de produto/dados**  
+Confirmar quais tipos compõem o "total do parque" (mesma decisão que afeta o denominador de computadores inoperantes).
+
+**Tipo de lacuna**  
+Frontend (e Backend se o percentual for calculado no servidor).
+
+**Próxima ação recomendada**  
+Decidir onde calcular o percentual e renderizar o gráfico de participação.
+
+#### 6.5.4 Equipamentos atendem à demanda
+
+**O que o gráfico deve mostrar**  
+Distribuição Sim / Parcialmente / Não sobre a resposta das escolas.
+
+**Como era tratado na planilha/painel original**  
+Distribuição categórica com três respostas, no bloco "Uso Pedagógico e Adequação Tecnológica".
+
+**Origem provável do dado no banco**  
+`vw_censo_equipamentos_tecnologia.computadores_atendem`.
+
+**View ou transformação necessária**  
+A view já expõe o campo categórico. Hoje o endpoint só calcula `percentual_computadores_atendem` (% de "Sim"). Falta agregar a distribuição completa.
+
+**Endpoint necessário**  
+Expandir `GET /v1/admin/analytics/tecnologia/infraestrutura`.
+
+**Payload esperado**  
+```ts
+{
+  computadores_atendem_demanda: Array<{
+    label: string;   // "Sim" | "Parcialmente" | "Não" (conforme normalização)
+    escolas: number;
+    percentual: number;
+  }>;
+}
+```
+
+**Frontend necessário**  
+Renderizar donut/barra em `AbaTecnologia.tsx`, anchor `sec-tecnologia-pedagogico`, sem remover o KPI atual de "Computadores Atendem".
+
+**Dependências de produto/dados**  
+Confirmar as categorias oficiais e a normalização de variações textuais ("Parcialmente", "Em parte", etc.).
+
+**Tipo de lacuna**  
+Backend + Frontend.
+
+**Próxima ação recomendada**  
+Expor a distribuição Sim/Parcialmente/Não e renderizar.
+
+#### 6.5.5 Projetor multimídia
+
+**O que o gráfico deve mostrar**  
+Distribuição Sim / Não sobre escolas que possuem projetor multimídia.
+
+**Como era tratado na planilha/painel original**  
+Distribuição Sim/Não no bloco de uso pedagógico.
+
+**Origem provável do dado no banco**  
+`vw_censo_equipamentos_tecnologia.possui_projetor` (boolean).
+
+**View ou transformação necessária**  
+A view já expõe o campo. Hoje o endpoint só calcula `percentual_com_projetor`. Falta agregar a distribuição Sim/Não.
+
+**Endpoint necessário**  
+Expandir `GET /v1/admin/analytics/tecnologia/uso-pedagogico`.
+
+**Payload esperado**  
+```ts
+{
+  possui_projetor: Array<{
+    label: "Sim" | "Não";
+    escolas: number;
+    percentual: number;
+  }>;
+}
+```
+
+**Frontend necessário**  
+Renderizar donut Sim/Não em `AbaTecnologia.tsx`, anchor `sec-tecnologia-pedagogico`, sem remover o KPI atual.
+
+**Dependências de produto/dados**  
+Confirmar tratamento de não informado.
+
+**Tipo de lacuna**  
+Backend + Frontend.
+
+**Próxima ação recomendada**  
+Expor a distribuição Sim/Não e renderizar o donut.
+
+#### 6.5.6 Lousa digital
+
+**O que o gráfico deve mostrar**  
+Distribuição Sim / Não sobre escolas que possuem lousa digital.
+
+**Como era tratado na planilha/painel original**  
+Distribuição Sim/Não no bloco de uso pedagógico.
+
+**Origem provável do dado no banco**  
+`vw_censo_equipamentos_tecnologia.possui_lousa_digital` (boolean).
+
+**View ou transformação necessária**  
+A view já expõe o campo. Hoje o endpoint só calcula `percentual_com_lousa_digital`. Falta agregar a distribuição Sim/Não.
+
+**Endpoint necessário**  
+Expandir `GET /v1/admin/analytics/tecnologia/uso-pedagogico`.
+
+**Payload esperado**  
+```ts
+{
+  possui_lousa_digital: Array<{
+    label: "Sim" | "Não";
+    escolas: number;
+    percentual: number;
+  }>;
+}
+```
+
+**Frontend necessário**  
+Renderizar donut Sim/Não em `AbaTecnologia.tsx`, anchor `sec-tecnologia-pedagogico`, sem remover o KPI atual.
+
+**Dependências de produto/dados**  
+Confirmar tratamento de não informado.
+
+**Tipo de lacuna**  
+Backend + Frontend.
+
+**Próxima ação recomendada**  
+Expor a distribuição Sim/Não e renderizar o donut.
+
+#### 6.5.7 Quantidade média de projetores por escola
+
+**O que o gráfico deve mostrar**  
+Média de projetores por escola no recorte.
+
+**Como era tratado na planilha/painel original**  
+Média por escola exibida como indicador no bloco de uso pedagógico.
+
+**Origem provável do dado no banco**  
+`vw_censo_equipamentos_tecnologia.qtd_projetores`.
+
+**View ou transformação necessária**  
+A view já expõe a quantidade por escola. Hoje o endpoint entrega `total_projetores` e `percentual_com_projetor`, mas não a média. Cálculo sugerido:
+
+```sql
+AVG(qtd_projetores)
+```
+
+sobre escolas concluídas no recorte (denominador — total de escolas — já disponível no backend).
+
+**Endpoint necessário**  
+Expandir `GET /v1/admin/analytics/tecnologia/uso-pedagogico`.
+
+**Payload esperado**  
+```ts
+{
+  media_projetores_por_escola: number;
+}
+```
+
+**Frontend necessário**  
+Renderizar KPI em `AbaTecnologia.tsx`, anchor `sec-tecnologia-pedagogico`, ao lado de "Total de Projetores".
+
+**Dependências de produto/dados**  
+Confirmar se a média considera todas as escolas concluídas ou apenas escolas que possuem projetor.
+
+**Tipo de lacuna**  
+Backend + Frontend.
+
+**Próxima ação recomendada**  
+Expor `media_projetores_por_escola` no payload e renderizar KPI.
+
+#### 6.5.8 Computadores inoperantes
+
+**O que o gráfico deve mostrar**  
+Número de escolas com computadores inoperantes e, se aprovado, percentual correspondente.
+
+**Como era tratado na planilha/painel original**  
+Indicador de escolas com computadores inoperantes no bloco de uso pedagógico/adequação tecnológica.
+
+**Origem provável do dado no banco**  
+`vw_censo_equipamentos_tecnologia.qtd_computadores_inoperantes`.
+
+**View ou transformação necessária**  
+O número absoluto de escolas já é entregue (`escolas_com_computadores_inoperantes`). O percentual depende de decisão de produto sobre o denominador. Ver também §6.4.1, que trata do percentual de computadores inoperantes sobre o parque.
+
+**Endpoint necessário**  
+Número absoluto já entregue por `GET /v1/admin/analytics/tecnologia/infraestrutura`; percentual exigiria expansão após decisão de produto.
+
+**Payload esperado**  
+```ts
+{
+  escolas_com_computadores_inoperantes: number;
+  percentual_computadores_inoperantes?: number; // se aprovado
+}
+```
+
+**Dependências de produto/dados**  
+Definir se o percentual deve usar como denominador todas as escolas ou apenas escolas com algum computador declarado.
+
+**Tipo de lacuna**  
+Presente (número absoluto) / Produto (percentual).
+
+**Próxima ação recomendada**  
+Manter o número absoluto; decidir o denominador antes de expor o percentual.
+
 ## 7. Itens fora da rodada PostgreSQL atual
 
 ### 7.1 Perfil dos Alunos e Resultados
@@ -793,16 +1120,17 @@ A fonte futura deve vir de bases próprias validadas pelas coordenações respon
 
 ## 10. Ordem técnica recomendada
 
+> Caracterização / Infraestrutura Educacional já foi entregue (CAR-INFRA-01), incluindo a lista oficial inicial de ambientes essenciais. Não consta mais como decisão de produto bloqueante nem como tarefa de implementação futura — apenas refino opcional da lista com produto.
+
 1. Validar decisões de produto bloqueantes:
-   - ambientes essenciais;
-   - denominador de computadores inoperantes;
-   - escala de avaliação dos serviços.
+   - denominador de computadores inoperantes (Tecnologia);
+   - escala de avaliação dos serviços (Serviços Terceirizados).
 
 2. Implementar backend de Caracterização / Oferta e Funcionamento.
 
 3. Implementar frontend de Caracterização / Oferta e reposicionar Detalhamento por DRE.
 
-4. Implementar backend de Caracterização / Infraestrutura Educacional após lista de essenciais.
+4. Implementar Tecnologia conforme Data Studio (§6.5): distribuições Sim/Não (internet, projetor, lousa) e Sim/Parcialmente/Não (atendem à demanda), mediana e distribuição (%) do parque, média de projetores por escola.
 
 5. Implementar backend/frontend de Energia e Climatização.
 

--- a/docs/dashboard/lacunas-backend-frontend-por-bloco.md
+++ b/docs/dashboard/lacunas-backend-frontend-por-bloco.md
@@ -59,7 +59,8 @@ Observação metodológica: a auditoria foi feita por leitura estática do códi
 | Média | Merenda Escolar | Estrutura Física | Condições da cozinha e refeitório existem; tamanho da cozinha está na view, mas não no payload/frontend. | Backend + Frontend | Expor `tamanho_cozinha` no endpoint de oferta/estrutura e renderizar distribuição. |
 | Média | Caracterização da Rede | Dimensão e Perfil da Rede | Conteúdo principal existe, mas a tabela Detalhamento por DRE aparece depois dos anchors vazios de Oferta/Infra, não dentro do bloco correto. | Frontend | Reorganizar a posição/ancoragem da tabela sem mudar backend. |
 | Média | Pessoal e Gestão Escolar | Coordenação Pedagógica | Gráfico e KPI existem; a lista/tabela de áreas declaradas não existe separadamente. | Frontend | Decidir se o gráfico atual substitui a lista; se não, adicionar tabela simples. |
-| Média | Tecnologia e Equipamentos | Parque Tecnológico | Total de computadores inoperantes existe; percentual de inoperantes não é renderizado como KPI próprio. | Produto | Definir denominador oficial do percentual; depois ajustar frontend ou payload. |
+| Média/Alta | Tecnologia e Equipamentos | Parque Tecnológico | Gráficos mínimos do Data Studio ainda não totalmente refletidos: mediana por tipo e distribuição do parque tecnológico (%). Computadores inoperantes existem em nº de escolas; percentual depende de denominador. | Backend + Frontend / Produto | Calcular mediana por tipo e participação %; definir denominador do percentual de inoperantes. |
+| Média/Alta | Tecnologia e Equipamentos | Uso Pedagógico | Indicadores existem como KPIs, mas faltam distribuições Sim/Não (projetor, lousa) ou Sim/Parcialmente/Não (atendem à demanda) e média de projetores por escola. | Backend + Frontend | Expor distribuições e média de projetores; renderizar donuts/KPI. |
 | Baixa | Perfil dos Alunos e Resultados | Aba futura/externa | Implementação atual/legada por Google Sheets mantida. | Histórico/legado | Não incluir na rodada PostgreSQL do formulário. |
 | Baixa | Gestão Financeira e Governança | Aba futura/externa | Placeholder institucional sem fetch, endpoint ou view. | Fonte externa | Aguardar fonte validada pelas coordenações responsáveis. |
 
@@ -112,8 +113,8 @@ Diagnóstico B1:
 
 Endpoints recomendados para próxima rodada:
 
-- `GET /v1/admin/analytics/caracterizacao/oferta-funcionamento`
-- `GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional`
+- `GET /v1/admin/analytics/caracterizacao/oferta-funcionamento` (recomendado)
+- `GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional` — **já entregue (CAR-INFRA-01)**, listado aqui apenas para referência.
 
 ## 6. B2 — Abas temáticas integradas
 
@@ -136,20 +137,21 @@ Endpoints recomendados para próxima rodada:
 
 ### 6.2 Tecnologia e Equipamentos
 
+> **Referência mínima do Data Studio.** O painel original organizava o tema em "Infraestrutura Digital e Capacidade Instalada" e "Uso Pedagógico e Adequação Tecnológica". A aplicação desdobrou o primeiro em **Infraestrutura Digital** + **Parque Tecnológico** e manteve **Uso Pedagógico**. A auditoria abaixo foi revista para preservar os gráficos mínimos do painel original: indicadores que hoje existem apenas como KPI percentual, mas que no Data Studio eram distribuições, ficam classificados como **Parcial** (não "Sem lacuna"). Ver detalhamento técnico em `docs/dashboard/especificacao-entrega-dados-por-grafico.md` §6.5.
+
 | Bloco | Item mínimo | Menu/anchor | Frontend | Backend/payload | View/campo | Tipo de lacuna | Próxima ação | Frente sugerida |
 |---|---|---|---|---|---|---|---|---|
-| Infraestrutura Digital | Escolas com internet | Menu e `sec-tecnologia-digital` OK | KPI no resumo executivo | `/tecnologia/infraestrutura` entrega `percentual_internet` e `escolas_com_internet` | `vw_censo_equipamentos_tecnologia.internet_disponivel` | Sem lacuna | Manter | — |
-| Infraestrutura Digital | Provedor de internet | Menu e anchor OK | Barra renderizada | `/tecnologia/infraestrutura` entrega `por_provedor` | `vw_censo_equipamentos_tecnologia.provedor_internet` | Sem lacuna | Manter | — |
-| Infraestrutura Digital | Qualidade da internet | Menu e anchor OK | Donut renderizado | `/tecnologia/infraestrutura` entrega `por_qualidade` | `vw_censo_equipamentos_tecnologia.qualidade_internet` | Sem lacuna | Manter | — |
-| Infraestrutura Digital | Computadores atendem à demanda | Menu e anchor OK | KPI no resumo executivo | `/tecnologia/infraestrutura` entrega `percentual_computadores_atendem` | `vw_censo_equipamentos_tecnologia.computadores_atendem` | Sem lacuna | Manter | — |
-| Parque Tecnológico | Desktops administrativos | Menu e `sec-tecnologia-parque` OK | KPI renderizado | `/tecnologia/infraestrutura` entrega `total_desktops_adm` | `vw_censo_equipamentos_tecnologia.qtd_desktop_adm` | Sem lacuna | Manter | — |
-| Parque Tecnológico | Desktops de alunos | Menu e anchor OK | KPI renderizado | `/tecnologia/infraestrutura` entrega `total_desktops_alunos` | `vw_censo_equipamentos_tecnologia.qtd_desktop_alunos` | Sem lacuna | Manter | — |
-| Parque Tecnológico | Notebooks | Menu e anchor OK | KPI renderizado | `/tecnologia/infraestrutura` entrega `total_notebooks` | `vw_censo_equipamentos_tecnologia.qtd_notebooks` | Sem lacuna | Manter | — |
-| Parque Tecnológico | Chromebooks | Menu e anchor OK | KPI renderizado | `/tecnologia/infraestrutura` entrega `total_chromebooks` | `vw_censo_equipamentos_tecnologia.qtd_chromebooks` | Sem lacuna | Manter | — |
-| Parque Tecnológico | Computadores inoperantes | Menu e anchor OK | Total renderizado; percentual não renderizado | Payload traz total e totais do parque, mas não percentual oficial | `qtd_computadores_inoperantes` + equipamentos | Produto | Definir denominador do percentual; depois renderizar KPI percentual ou expor no payload | Produto/Dados |
-| Uso Pedagógico | Escolas com projetor | Menu e `sec-tecnologia-pedagogico` OK | KPI renderizado | `/tecnologia/uso-pedagogico` entrega `percentual_com_projetor` | `vw_censo_equipamentos_tecnologia.possui_projetor` | Sem lacuna | Manter | — |
-| Uso Pedagógico | Total de projetores | Menu e anchor OK | KPI renderizado | `/tecnologia/uso-pedagogico` entrega `total_projetores` | `vw_censo_equipamentos_tecnologia.qtd_projetores` | Sem lacuna | Manter | — |
-| Uso Pedagógico | Escolas com lousa digital | Menu e anchor OK | KPI renderizado | `/tecnologia/uso-pedagogico` entrega `percentual_com_lousa_digital` | `vw_censo_equipamentos_tecnologia.possui_lousa_digital` | Sem lacuna | Manter | — |
+| Infraestrutura Digital | Disponibilidade de internet — distribuição Sim/Não | Menu e `sec-tecnologia-digital` OK | Apenas KPI % no resumo executivo; sem distribuição Sim/Não | `/tecnologia/infraestrutura` entrega `percentual_internet` e `escolas_com_internet`, mas não a distribuição | `vw_censo_equipamentos_tecnologia.internet_disponivel` | Parcial — Backend + Frontend | Expor distribuição Sim/Não e renderizar donut/barra | Backend |
+| Infraestrutura Digital | Provedor de internet | Menu e anchor OK | Donut renderizado | `/tecnologia/infraestrutura` entrega `por_provedor` | `vw_censo_equipamentos_tecnologia.provedor_internet` | Sem lacuna | Manter | — |
+| Infraestrutura Digital | Qualidade da internet | Menu e anchor OK | Donut renderizado | `/tecnologia/infraestrutura` entrega `por_qualidade` | `vw_censo_equipamentos_tecnologia.qualidade_internet` | Sem lacuna | Manter; confirmar normalização das opções | — |
+| Parque Tecnológico | Quantidade mediana de equipamentos por escola | Menu e `sec-tecnologia-parque` OK | Não renderizado | Endpoint entrega apenas `SUM` por tipo, não mediana | `vw_censo_equipamentos_tecnologia.qtd_chromebooks`, `qtd_desktop_alunos`, `qtd_desktop_adm`, `qtd_notebooks` | Ausente — Backend + Frontend | Calcular `PERCENTILE_CONT(0.5)` por tipo e renderizar | Backend |
+| Parque Tecnológico | Distribuição do parque tecnológico (%) | Menu e anchor OK | Não renderizado | Totais por tipo existem; percentuais de participação não calculados | totais de desktops adm/alunos, notebooks, chromebooks | Ausente — Frontend (e Backend se calculado no servidor) | Calcular participação % de cada tipo e renderizar | Frontend |
+| Parque Tecnológico | Totais por tipo de equipamento | Menu e anchor OK | KPIs renderizados | `/tecnologia/infraestrutura` entrega `total_desktops_adm`, `total_desktops_alunos`, `total_notebooks`, `total_chromebooks` | `qtd_desktop_adm`, `qtd_desktop_alunos`, `qtd_notebooks`, `qtd_chromebooks` | Sem lacuna | Manter | — |
+| Parque Tecnológico | Computadores inoperantes — número absoluto e eventual percentual | Menu e anchor OK | Nº de escolas renderizado; percentual não renderizado | Payload traz nº de escolas (`escolas_com_computadores_inoperantes`), mas não percentual oficial | `qtd_computadores_inoperantes` + equipamentos | Parcial — Produto | Definir denominador do percentual; depois renderizar KPI percentual ou expor no payload | Produto/Dados |
+| Uso Pedagógico | Equipamentos atendem à demanda — distribuição Sim/Parcialmente/Não | Menu e `sec-tecnologia-pedagogico` OK | Apenas KPI % de "Sim" no resumo executivo | `/tecnologia/infraestrutura` entrega só `percentual_computadores_atendem` (% de "Sim") | `vw_censo_equipamentos_tecnologia.computadores_atendem` | Parcial — Backend + Frontend | Expor distribuição Sim/Parcialmente/Não e renderizar | Backend |
+| Uso Pedagógico | Projetor multimídia — distribuição Sim/Não | Menu e anchor OK | Apenas KPI % | `/tecnologia/uso-pedagogico` entrega só `percentual_com_projetor` | `vw_censo_equipamentos_tecnologia.possui_projetor` | Parcial — Backend + Frontend | Expor distribuição Sim/Não e renderizar donut | Backend |
+| Uso Pedagógico | Lousa digital — distribuição Sim/Não | Menu e anchor OK | Apenas KPI % | `/tecnologia/uso-pedagogico` entrega só `percentual_com_lousa_digital` | `vw_censo_equipamentos_tecnologia.possui_lousa_digital` | Parcial — Backend + Frontend | Expor distribuição Sim/Não e renderizar donut | Backend |
+| Uso Pedagógico | Quantidade média de projetores por escola | Menu e anchor OK | Não renderizado | Endpoint entrega `total_projetores` e `percentual_com_projetor`, mas não a média por escola | `vw_censo_equipamentos_tecnologia.qtd_projetores` | Ausente — Backend + Frontend (denominador já disponível) | Calcular `AVG(qtd_projetores)` e renderizar KPI | Backend |
 
 ### 6.3 Infraestrutura e Segurança
 
@@ -258,16 +260,19 @@ As tasks de implementação devem ser abertas a partir de `docs/dashboard/especi
 ### 8.1 Backend
 
 - Criar `GET /v1/admin/analytics/caracterizacao/oferta-funcionamento`, com etapas, modalidades, distribuição por turnos e média de turnos por porte.
-- Criar `GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional`, reaproveitando `vw_censo_ambientes` após definição de ambientes essenciais.
+- Expandir `/tecnologia/infraestrutura` e `/tecnologia/uso-pedagogico` para refletir os gráficos mínimos do Data Studio (§6.2 e especificação §6.5): distribuição Sim/Não de internet, distribuição Sim/Parcialmente/Não de "atendem à demanda", distribuições Sim/Não de projetor e lousa, mediana por tipo de equipamento, distribuição (%) do parque e média de projetores por escola.
 - Expor energia/climatização/capacidade elétrica na aba Infraestrutura, preferencialmente em endpoint dedicado ou expansão controlada de `/infraestrutura/condicoes`.
 - Expor `tamanho_cozinha` na Merenda, idealmente em recorte de estrutura física.
 - Criar `GET /v1/admin/analytics/servicos-terceirizados/governanca`, cobrindo supervisor por serviço e avaliações.
 - Avaliar padronização de filtros (`year`, `dre`, `municipio`, `zona`, `porte_escola`) nos endpoints de Infraestrutura, Merenda e Serviços.
 
+> Caracterização / Infraestrutura Educacional (`/caracterizacao/infraestrutura-educacional`) já foi entregue em CAR-INFRA-01, com a lista oficial inicial de ambientes essenciais. Não consta mais como backlog de backend; resta apenas refino futuro da lista com produto.
+
 ### 8.2 Frontend
 
 - Reorganizar a tabela Detalhamento por DRE dentro do bloco Dimensão e Perfil da Rede.
-- Renderizar conteúdo real nos anchors vazios de Caracterização: `sec-perfil-oferta` e `sec-perfil-infra`.
+- Renderizar conteúdo real no anchor vazio de Caracterização `sec-perfil-oferta` (o anchor `sec-perfil-infra` já foi entregue em CAR-INFRA-01).
+- Renderizar as distribuições/medianas de Tecnologia (donuts Sim/Não, distribuição do parque, médias) quando o backend expuser o payload.
 - Substituir empty state de Infraestrutura/Energia por KPIs/gráficos quando o backend expuser payload.
 - Renderizar distribuição de tamanho da cozinha em Merenda.
 - Substituir empty state de Serviços/Governança quando houver endpoint.
@@ -275,9 +280,9 @@ As tasks de implementação devem ser abertas a partir de `docs/dashboard/especi
 
 ### 8.3 Produto/Dados externos
 
-- Definir lista oficial de ambientes essenciais.
 - Definir denominador oficial do percentual de computadores inoperantes.
 - Definir escala oficial de avaliação de supervisão/serviços terceirizados.
+- Refino futuro (não bloqueante): revisar a lista oficial inicial de ambientes essenciais já entregue em CAR-INFRA-01.
 - Definir fonte futura de Perfil dos Alunos e Resultados.
 - Definir fonte futura de Gestão Financeira e Governança.
 
@@ -292,8 +297,10 @@ As tasks de implementação devem ser abertas a partir de `docs/dashboard/especi
 | Frente | Responsável sugerido | Escopo | Arquivos prováveis | Dependências |
 |---|---|---|---|---|
 | Backend Caracterização Oferta | Backend | Endpoint de oferta/funcionamento; parsing/normalização de etapas, modalidades e turnos | `api/cmd/api/analytics.go`, possíveis migrations novas, espelhos em `api/cmd/api/migrations/` | Definir cálculo de média de turnos por porte |
-| Backend Caracterização Infra | Backend + Produto | Endpoint de infraestrutura educacional baseado em ambientes | `api/cmd/api/analytics.go`, `infra/migrations/0007_*` ou migration nova | Lista oficial de ambientes essenciais |
-| Frontend Caracterização | Frontend | Reorganizar Detalhamento por DRE e renderizar blocos Oferta/Infra quando houver payload | `web/src/components/admin/AbaCaracterizacao.tsx` | Endpoints de Caracterização |
+| ~~Backend Caracterização Infra~~ **Entregue (CAR-INFRA-01)** | Backend + Produto | Endpoint de infraestrutura educacional baseado em ambientes — entregue, com lista oficial inicial de essenciais | `api/cmd/api/analytics.go` | Refino futuro da lista com produto (não bloqueante) |
+| Backend Tecnologia (Data Studio) | Backend | Distribuições Sim/Não e Sim/Parcialmente/Não, mediana por tipo, distribuição (%) do parque, média de projetores | `api/cmd/api/analytics_pessoal_tecnologia.go` | Denominador do percentual de computadores inoperantes (produto) |
+| Frontend Caracterização | Frontend | Reorganizar Detalhamento por DRE e renderizar o bloco Oferta quando houver payload (Infra já entregue) | `web/src/components/admin/AbaCaracterizacao.tsx` | Endpoint de oferta/funcionamento |
+| Frontend Tecnologia (Data Studio) | Frontend | Renderizar donuts/distribuições/médias de Tecnologia | `web/src/components/admin/AbaTecnologia.tsx` | Payload expandido de Tecnologia |
 | Backend Infra Energia | Backend | Expor rede elétrica, estrutura de climatização e climatização das salas | `api/cmd/api/analytics_infra_merenda_servicos.go`, possivelmente migrations/views | Confirmar semântica dos campos elétricos |
 | Frontend Infra Energia | Frontend | Substituir empty state por KPIs/gráficos | `web/src/components/admin/AbaInfraestruturaSeguranca.tsx` | Payload de energia/climatização |
 | Backend Merenda Estrutura | Backend | Expor distribuição de tamanho da cozinha | `api/cmd/api/analytics_infra_merenda_servicos.go` | Campo já existe em `vw_censo_equipamentos_merenda` |
@@ -304,11 +311,12 @@ As tasks de implementação devem ser abertas a partir de `docs/dashboard/especi
 
 ## 10. Próxima ordem recomendada
 
-1. Validar com produto a lista de ambientes essenciais, o denominador de computadores inoperantes e a escala de avaliação de serviços.
+1. Validar com produto o denominador de computadores inoperantes (Tecnologia) e a escala de avaliação de serviços. (A lista de ambientes essenciais já foi definida e entregue em CAR-INFRA-01; resta apenas refino opcional.)
 2. Fazer PR backend pequeno para `caracterizacao/oferta-funcionamento`.
 3. Fazer PR frontend para preencher o bloco Organização da Oferta e reposicionar Detalhamento por DRE.
-4. Fazer PR backend pequeno para Energia/Climatização em Infraestrutura.
-5. Fazer PR frontend para substituir o empty state de Energia.
-6. Fazer PR backend/frontend para `tamanho_cozinha` em Merenda.
-7. Fazer PR backend/frontend para Governança/Supervisão de Serviços Terceirizados após decisão da escala.
-8. Manter Perfil dos Alunos e Gestão Financeira/Governança fora da rodada PostgreSQL até definição de fonte externa.
+4. Fazer PR backend/frontend de Tecnologia conforme Data Studio (distribuições, mediana, distribuição do parque, média de projetores).
+5. Fazer PR backend pequeno para Energia/Climatização em Infraestrutura.
+6. Fazer PR frontend para substituir o empty state de Energia.
+7. Fazer PR backend/frontend para `tamanho_cozinha` em Merenda.
+8. Fazer PR backend/frontend para Governança/Supervisão de Serviços Terceirizados após decisão da escala.
+9. Manter Perfil dos Alunos e Gestão Financeira/Governança fora da rodada PostgreSQL até definição de fonte externa.

--- a/docs/dashboard/matriz-abas-e-graficos.md
+++ b/docs/dashboard/matriz-abas-e-graficos.md
@@ -45,7 +45,7 @@ Decisões registradas pelo time, válidas para todo o trabalho a partir desta br
 4. **Gestão Financeira e Governança** é **placeholder institucional**. Sem fetch, sem endpoint, sem view SQL, sem dado fake.
 5. **Gestão Financeira e Governança não deve consumir o banco PostgreSQL do formulário do censo** nesta rodada.
 6. A **fonte futura** de "Gestão Financeira / Governança" virá de **bases próprias validadas pelas coordenações responsáveis**, não do banco do censo operacional.
-7. As **5 abas temáticas já integradas em primeira versão** (Pessoal e Gestão Escolar, Tecnologia e Equipamentos, Infraestrutura e Segurança, Merenda Escolar, Serviços Terceirizados) **não devem receber novos gráficos** antes desta matriz mínima ser validada com as áreas finalísticas da SEDUC.
+7. As **5 abas temáticas já integradas em primeira versão** (Pessoal e Gestão Escolar, Tecnologia e Equipamentos, Infraestrutura e Segurança, Merenda Escolar, Serviços Terceirizados) **não devem receber gráficos inéditos** (fora do escopo do painel original) antes desta matriz mínima ser validada com as áreas finalísticas da SEDUC. **Exceção:** gráficos mínimos que já existiam no painel original (Data Studio/Looker Studio) e ainda não estão refletidos na aplicação podem ser **documentados como lacunas** nesta matriz e **implementados após diagnóstico técnico**, mesmo antes da validação — eles não são novidade de escopo, e sim recuperação da referência mínima. O caso de Tecnologia e Equipamentos (ver §5.3) é o primeiro a seguir esse caminho.
 
 ---
 
@@ -153,27 +153,35 @@ Endpoints: `/v1/admin/analytics/pessoal-gestao/{estrutura,coordenacao,quadro-pes
 
 ### 5.3 Tecnologia e Equipamentos
 
-Blocos oficiais:
+Blocos oficiais (3):
 - **Infraestrutura Digital**
 - **Parque Tecnológico**
 - **Uso Pedagógico**
 
 Endpoints: `/v1/admin/analytics/tecnologia/{infraestrutura,uso-pedagogico}` (view `0006_*`).
 
+> **Equivalência com o painel original (Data Studio/Looker Studio).** O painel original organizava o tema em dois blocos visuais — "Infraestrutura Digital e Capacidade Instalada" e "Uso Pedagógico e Adequação Tecnológica". A aplicação desdobrou o primeiro em dois blocos e manteve o segundo:
+>
+> - Data Studio: **Infraestrutura Digital e Capacidade Instalada** → Aplicação: **Infraestrutura Digital** + **Parque Tecnológico**.
+> - Data Studio: **Uso Pedagógico e Adequação Tecnológica** → Aplicação: **Uso Pedagógico**.
+>
+> Os três blocos atuais da aplicação ficam **mantidos**. A matriz mínima abaixo preserva os gráficos que existiam no painel original, distribuídos pelos três blocos. Itens que hoje existem apenas como KPI percentual, mas que no Data Studio eram exibidos como distribuição, ficam classificados como **parcial** (e não "presente"), porque a referência mínima exige a distribuição.
+
+A antiga seção "Infraestrutura Digital e Capacidade Instalada" do Data Studio foi desdobrada em "Infraestrutura Digital" e "Parque Tecnológico" na aplicação. A seção "Uso Pedagógico e Adequação Tecnológica" corresponde ao bloco "Uso Pedagógico".
+
 | Bloco | Gráficos mínimos | Fonte atual | Status | Lacuna backend | Lacuna frontend | Observações |
 |---|---|---|---|---|---|---|
-| Infraestrutura Digital | Escolas com internet (KPI %) | PG `/tecnologia/infraestrutura` | presente | — | — | — |
-| Infraestrutura Digital | Provedor de internet (donut/barra) | PG `/tecnologia/infraestrutura` | presente | — | — | — |
-| Infraestrutura Digital | Qualidade da internet (donut Boa/Regular/Ruim) | PG `/tecnologia/infraestrutura` | presente | Confirmar normalização das opções | — | — |
-| Infraestrutura Digital | Computadores atendem à demanda (KPI %) | PG `/tecnologia/infraestrutura` | presente | — | — | — |
-| Parque Tecnológico | Desktops administrativos (KPI total) | PG `/tecnologia/infraestrutura` | presente | — | — | — |
-| Parque Tecnológico | Desktops de alunos (KPI total) | PG `/tecnologia/infraestrutura` | presente | — | — | — |
-| Parque Tecnológico | Notebooks (KPI total) | PG `/tecnologia/infraestrutura` | presente | — | — | — |
-| Parque Tecnológico | Chromebooks (KPI total) | PG `/tecnologia/infraestrutura` | presente | — | — | — |
-| Parque Tecnológico | Computadores inoperantes (KPI total e %) | PG `/tecnologia/infraestrutura` | presente parcial | Confirmar payload | Confirmar render | — |
-| Uso Pedagógico | Escolas com projetor (KPI %) | PG `/tecnologia/uso-pedagogico` | presente | — | — | — |
-| Uso Pedagógico | Total de projetores (KPI) | PG `/tecnologia/uso-pedagogico` | presente | — | — | — |
-| Uso Pedagógico | Escolas com lousa digital (KPI %) | PG `/tecnologia/uso-pedagogico` | presente | — | — | — |
+| Infraestrutura Digital | Disponibilidade de internet — distribuição Sim/Não | PG `/tecnologia/infraestrutura` (`percentual_internet`, `escolas_com_internet`) | parcial | Endpoint só entrega KPI % e contagem; não há distribuição Sim/Não | Donut/barra Sim/Não a criar | Data Studio mostrava distribuição Sim/Não; hoje só KPI "Escolas com Internet" no resumo executivo. |
+| Infraestrutura Digital | Provedor de internet | PG `/tecnologia/infraestrutura` (`por_provedor`) | presente | — | — | Donut renderizado. |
+| Infraestrutura Digital | Qualidade da internet | PG `/tecnologia/infraestrutura` (`por_qualidade`) | presente | Confirmar normalização das opções | — | Donut renderizado. |
+| Parque Tecnológico | Quantidade mediana de equipamentos por escola | PG | planejado | View/endpoint não calculam mediana (hoje só `SUM` por tipo) | Componente a criar | Data Studio exibia mediana por escola por tipo (chromebook, desktop alunos, desktop adm, notebook). Lacuna backend + frontend. |
+| Parque Tecnológico | Distribuição do parque tecnológico (%) | PG `/tecnologia/infraestrutura` (totais por tipo) | planejado | Percentuais por tipo não calculados (só totais absolutos) | Gráfico de participação % a criar | Pode ser derivado dos totais já entregues; lacuna frontend (e backend se o % for calculado no servidor). |
+| Parque Tecnológico | Totais por tipo de equipamento | PG `/tecnologia/infraestrutura` (`total_desktops_adm`, `total_desktops_alunos`, `total_notebooks`, `total_chromebooks`) | presente | — | — | KPIs renderizados (desktops adm/alunos, notebooks, chromebooks). |
+| Parque Tecnológico | Computadores inoperantes (nº de escolas; % a confirmar) | PG `/tecnologia/infraestrutura` (`escolas_com_computadores_inoperantes`) | presente parcial | Número absoluto de escolas presente; percentual depende de denominador oficial (produto) | KPI % a criar se aprovado | Hoje só nº de escolas que declararam. Percentual = decisão de produto (denominador). |
+| Uso Pedagógico | Equipamentos atendem à demanda — distribuição Sim/Parcialmente/Não | PG `/tecnologia/infraestrutura` (`percentual_computadores_atendem`) | parcial | Endpoint só entrega % de "Sim"; não há distribuição Sim/Parcialmente/Não | Donut/barra de distribuição a criar | Data Studio mostrava as três categorias. |
+| Uso Pedagógico | Projetor multimídia — distribuição Sim/Não | PG `/tecnologia/uso-pedagogico` (`percentual_com_projetor`) | parcial | Endpoint só entrega KPI %; não há distribuição Sim/Não | Donut Sim/Não a criar | Data Studio mostrava distribuição Sim/Não. |
+| Uso Pedagógico | Lousa digital — distribuição Sim/Não | PG `/tecnologia/uso-pedagogico` (`percentual_com_lousa_digital`) | parcial | Endpoint só entrega KPI %; não há distribuição Sim/Não | Donut Sim/Não a criar | Data Studio mostrava distribuição Sim/Não. |
+| Uso Pedagógico | Quantidade média de projetores por escola | PG `/tecnologia/uso-pedagogico` (`total_projetores` + total de escolas) | planejado | Endpoint só entrega total de projetores e % com projetor; média por escola não exposta | KPI média a criar | Denominador (total de escolas do recorte) já disponível no backend; média pode ser calculada no servidor. |
 
 ### 5.4 Infraestrutura e Segurança
 
@@ -319,23 +327,29 @@ Estas abas **não recebem alteração nesta rodada**. Aparecem aqui para que a l
 
 Itens identificados na matriz como `planejado` ou `presente / a confirmar`. Não são compromisso imediato de PR — entram em backlog para a próxima rodada de validação com as áreas finalísticas.
 
-- **Caracterização — Infraestrutura Educacional:** definir critério oficial de "ambientes essenciais" e expor endpoint dedicado (% médio por escola, média por porte).
+- **Caracterização — Infraestrutura Educacional:** **entregue (CAR-INFRA-01)** — endpoint `/caracterizacao/infraestrutura-educacional` em produção com lista oficial inicial de ambientes essenciais. Resta apenas refino futuro da lista com produto (não bloqueante).
 - **Caracterização — Organização da Oferta:** confirmar exposição de etapas, modalidades, turnos no payload analítico atual ou criar recorte específico para a aba Caracterização.
 - **Infraestrutura — Energia/Climatização:** confirmar se `0008_vw_censo_infraestrutura_seguranca` expõe os campos `rede_eletrica_atende_demanda`, `estrutura_permite_climatizacao`, `climatizacao_salas` — caso contrário, expandir view/endpoint.
 - **Merenda — Estrutura Física:** confirmar se `condicoes_cozinha`, `possui_refeitorio`, `tamanho_cozinha` estão no payload atual ou requerem extensão.
 - **Serviços Terceirizados — Governança/Supervisão:** sem endpoint dedicado hoje. Avaliar criação de `/v1/admin/analytics/servicos-terceirizados/governanca` cobrindo presença de supervisor por serviço, avaliação da supervisão e avaliação dos serviços.
+- **Tecnologia — Parque Tecnológico:** gráficos mínimos do Data Studio ainda não totalmente refletidos — falta **mediana de equipamentos por escola** (hoje só `SUM` por tipo) e **distribuição do parque tecnológico (%)** por tipo. Prioridade média/alta.
+- **Tecnologia — Uso Pedagógico:** indicadores existem como KPIs, mas faltam as **distribuições Sim/Não** (projetor, lousa) e **Sim/Parcialmente/Não** (equipamentos atendem à demanda), além da **média de projetores por escola**. Prioridade média/alta.
+- **Tecnologia — Infraestrutura Digital:** "Disponibilidade de internet" hoje só como KPI %; o Data Studio exibia distribuição Sim/Não — backend não entrega a distribuição.
 - **Total de alunos com decimais (legado):** documentado em [criterios-contagem-e-qualidade-dados.md](criterios-contagem-e-qualidade-dados.md) §8; correção retroativa fora desta rodada.
 
 ### 7.2 Lacunas de frontend
 
-- **Caracterização — Infraestrutura Educacional:** criar versão sintética de "presença de ambientes" e KPI "cobertura de ambientes essenciais" dentro da aba Caracterização (sem duplicar conteúdo da aba Infraestrutura).
+- **Tecnologia e Equipamentos:** renderizar as distribuições/medianas mínimas do Data Studio (donuts Sim/Não de internet, projetor e lousa; Sim/Parcialmente/Não de "atendem à demanda"; distribuição (%) do parque; mediana e média de projetores) assim que o backend expuser o payload — ver §5.3.
 - **Confirmações pontuais ("presente / a confirmar"):** auditar visualmente cada Aba\*.tsx para confirmar render dos campos sinalizados na §5.
 - **Subabas como navegação interna:** não implementar nesta rodada. Hoje os blocos são seções verticais — manter assim até a matriz mínima ser validada.
-- **Sem novos gráficos** nas 5 abas temáticas integradas (Pessoal, Tecnologia, Infraestrutura, Merenda, Serviços) antes da validação com as áreas finalísticas.
+- **Sem gráficos inéditos** (fora do escopo do painel original) nas 5 abas temáticas integradas antes da validação com as áreas finalísticas. Gráficos mínimos do Data Studio ainda não refletidos (caso de Tecnologia) são exceção e podem ser implementados após diagnóstico técnico.
+
+> Caracterização — Infraestrutura Educacional **não consta mais** como lacuna de frontend: o bloco sintético de presença de ambientes, os KPIs de cobertura de essenciais e a média por porte já foram entregues em CAR-INFRA-01.
 
 ### 7.3 Lacunas de decisão de produto
 
-- **Definição oficial de "ambientes essenciais"** (Caracterização e Infraestrutura).
+- **Lista de "ambientes essenciais":** a lista oficial **inicial** já foi definida e entregue em CAR-INFRA-01 (Caracterização). Não é mais decisão bloqueante; resta apenas **refino futuro** com produto, que também alimentaria o indicador correlato na aba Infraestrutura e Segurança (§5.4, ainda `planejado`).
+- **Denominador oficial do percentual de computadores inoperantes** (Tecnologia — Parque Tecnológico).
 - **Escala oficial de avaliação** para Governança/Supervisão de Serviços Terceirizados.
 - **Fonte de dados futura para Perfil dos Alunos e Resultados** (planilha própria a indicar).
 - **Fonte de dados futura para Gestão Financeira e Governança** (base externa das coordenações responsáveis).


### PR DESCRIPTION
…os de Tecnologia

Atualiza a aba Tecnologia e Equipamentos com a referência mínima do Data Studio (equivalência de blocos, status presente/parcial/ausente, especificação técnica) e reconcilia os documentos com a entrega já realizada de CAR-INFRA-01.

- Tecnologia: nota de equivalência Data Studio↔aplicação, matriz mínima §5.3, auditoria §6.2, nova especificação §6.5 (8 gráficos), lacunas e ordens técnicas.
- CAR-INFRA-01: §5.2 da especificação e itens de backlog/ordem das lacunas e da matriz marcados como entregues; "ambientes essenciais" deixa de ser decisão bloqueante, permanecendo apenas como refino futuro com produto.
- Decisão geral: gráficos mínimos do Data Studio ainda não refletidos podem ser documentados como lacunas e implementados após diagnóstico técnico.

Tarefa somente documental; nenhum código, endpoint, view ou frontend alterado.