### PR TITLE
docs(dashboard): registrar implementação da saúde operacional

### DIFF
--- a/docs/dashboard/especificacao-entrega-dados-por-grafico.md
+++ b/docs/dashboard/especificacao-entrega-dados-por-grafico.md
@@ -45,6 +45,151 @@ Antes de implementar, validar se a lacuna continua verdadeira na branch base e r
 - **Porte** deve usar o critério de `vw_censo_enriquecida.porte_escola_nome`, salvo decisão posterior documentada.
 - **Campos multivalorados** devem ser normalizados em formato long antes da agregação sempre que o gráfico contar escolas por valor da lista.
 
+## 4.1 Entrega implementada — Saúde Operacional por escola
+
+### 4.1.1 Identificação
+
+| Item | Implementação |
+|---|---|
+| Grupo no `/admin` | Operacional |
+| Rótulo no menu | Saúde Operacional |
+| Nome oficial | Índice de Saúde Operacional por escola |
+| Endpoint | `GET /v1/admin/analytics/escolas/saude-operacional` |
+| Fonte | PostgreSQL |
+| Backend | `api/cmd/api/analytics_saude_operacional.go` |
+| Frontend | `web/src/components/admin/AbaSaudeOperacionalEscolas.tsx` |
+| Status | Implementada |
+
+O endpoint aceita `?year=AAAA`; na ausência do parâmetro, usa o ano corrente.
+Ele parte de `schools` e retorna **todas as escolas cadastradas**. Apenas um
+censo com `status = 'completed'` no ano de referência alimenta métricas e
+dimensões. Sem censo elegível, a escola continua no payload com status
+`sem_dados`.
+
+### 4.1.2 Payload resumido
+
+```ts
+{
+  total_escolas: number;
+  ano_referencia: number;
+  metodologia: {
+    nome: string;
+    versao: "1.0.0";
+    dimensoes_habilitadas: string[];
+    pesos: {
+      infraestrutura: number;
+      energia: number;
+      merenda: number;
+      seguranca: number;
+      pessoal: number;
+      tecnologia: number;
+      pedagogico: number;
+      governanca: number;
+    };
+  };
+  escolas: Array<{
+    school_id: number;
+    census_id: number | null;
+    codigo_inep: string | null;
+    escola: string;
+    municipio: string;
+    dre: string;
+    zona: string | null;
+    total_alunos: number | null;
+    salas_aula: number | null;
+    alunos_por_sala: number | null;
+    saude: number | null;
+    criticidade: number | null;
+    status: "saudavel" | "atencao" | "critica" | "sem_dados";
+    dimensoes: {
+      infraestrutura: number | null;
+      energia: number | null;
+      merenda: number | null;
+      seguranca: number | null;
+      pessoal: number | null;
+      tecnologia: number | null;
+      pedagogico: null;
+      governanca: null;
+    };
+  }>;
+}
+```
+
+### 4.1.3 Dimensões e metodologia `1.0.0`
+
+Dimensões habilitadas:
+
+- Infraestrutura;
+- Energia;
+- Merenda;
+- Segurança;
+- Pessoal/RH;
+- Tecnologia.
+
+Pedagógico e Governança permanecem `null` na versão `1.0.0`. Elas não recebem
+zero, não participam do denominador da média ponderada e aparecem como `—` na
+tela. Sua ativação exige decisão de fonte, regras próprias, validação e nova
+versão da metodologia.
+
+### 4.1.4 Regras de ausência e status
+
+- `null` não é zero;
+- `0` é valor válido e representa o pior resultado explicitamente mapeado;
+- campo ausente, vazio ou resposta desconhecida não pode ser convertido
+  silenciosamente em zero;
+- `saude = null` implica `criticidade = null` e status `sem_dados`;
+- `saude >= 70` implica `saudavel`;
+- `50 <= saude < 70` implica `atencao`;
+- `saude < 50` implica `critica`.
+
+Auditabilidade de respostas desconhecidas permanece como lacuna futura:
+recomenda-se registrar contagens por campo/mapa sem interromper o endpoint.
+
+### 4.1.5 Comportamento frontend
+
+O componente:
+
+- usa `apiFetch`, `getCached` e `allCached`;
+- faz fetch lazy somente quando a aba é visitada;
+- não adiciona o endpoint ao prefetch global do login;
+- não usa dados fake;
+- não recalcula saúde, criticidade, status, pesos ou metodologia;
+- exibe cards de total, saudáveis, atenção, críticas, sem dados e média de
+  saúde das escolas com nota;
+- oferece busca local por escola, município, DRE e INEP, com normalização de
+  caixa, espaços e acentos;
+- exibe tabela escola a escola com farol, barra de saúde, criticidade e badges
+  das dimensões;
+- renderiza `null` como `—` e preserva zero como `0`/`0,0`;
+- mantém Pedagógico e Governança como `—`.
+
+### 4.1.6 Ordenação
+
+A abertura é por `criticidade` decrescente. Escolas `sem_dados` e valores nulos
+ficam ao final; o desempate local é pelo nome da escola. Os cabeçalhos permitem
+alternar entre ascendente e descendente para campos textuais, métricas e
+dimensões.
+
+No backend, a query atualmente usa `ORDER BY s.nome_escola`. Para garantir
+resultado determinístico antes da ordenação local em casos de escolas
+homônimas, permanece recomendada a inclusão futura de `s.id` como segundo
+critério SQL.
+
+### 4.1.7 Componentes visuais entregues
+
+- cards sintéticos;
+- busca local e contador `Exibindo X de Y escolas`;
+- tabela com rolagem horizontal;
+- farol por status;
+- barra proporcional de saúde;
+- criticidade;
+- badges de Infraestrutura, Energia, Merenda, Segurança, Pessoal e Tecnologia;
+- Pedagógico e Governança como `—`.
+
+Se o universo crescer significativamente, paginação ou virtualização deve ser
+avaliada. Filtros globais e Região de Integração não fazem parte da entrega
+atual.
+
 ## 5. Gráficos pendentes ou parciais — Alta prioridade
 
 ### 5.1 Caracterização da Rede — Organização da Oferta e Funcionamento

--- a/docs/dashboard/lacunas-backend-frontend-por-bloco.md
+++ b/docs/dashboard/lacunas-backend-frontend-por-bloco.md
@@ -36,22 +36,28 @@ Frontend:
 - `web/src/components/admin/AbaServicosTerceirizados.tsx`
 - `web/src/components/admin/AbaPerfilAlunos.tsx`
 - `web/src/components/admin/AbaGestaoFinanceiraGovernanca.tsx`
+- `web/src/components/admin/AbaSaudeOperacionalEscolas.tsx`
 - `web/src/components/admin/shared/types.ts`
 
 Backend e banco:
 
 - `api/cmd/api/main.go`
+- `api/cmd/api/analytics_saude_operacional.go`
 - `api/cmd/api/analytics.go`
 - `api/cmd/api/analytics_pessoal_tecnologia.go`
 - `api/cmd/api/analytics_infra_merenda_servicos.go`
 - `infra/migrations/0001_vw_censo_base.sql` a `infra/migrations/0013_performance_indexes.sql`
 
-Observação metodológica: a auditoria foi feita por leitura estática do código e das migrations. Não houve execução dos endpoints contra banco local/homologação nesta rodada.
+Observação metodológica: a auditoria foi feita por leitura estática do código e
+das migrations. Para Saúde Operacional, o backend foi conferido em `develop` e
+o frontend na entrega `feat/frontend-saude-operacional-escolas`. Não houve
+execução dos endpoints contra banco local/homologação nesta rodada.
 
 ## 3. Resumo executivo
 
 | Prioridade | Aba | Bloco | Lacuna principal | Tipo | Próxima ação |
 |---|---|---|---|---|---|
+| Entregue | Saúde Operacional | Índice de Saúde Operacional por escola | Backend e frontend implementados: endpoint protegido, metodologia `1.0.0`, cards, busca local e tabela escola a escola. | Backend + Frontend | Manter; tratar as lacunas futuras de auditabilidade, filtros e escala apenas em PRs próprios. |
 | Alta | Caracterização da Rede | Organização da Oferta e Funcionamento | Menu/anchor existem, mas o bloco está vazio e `/caracterizacao/perfil` não entrega etapas, modalidades ou turnos. | Backend + Frontend | Criar recorte analítico recomendado `GET /v1/admin/analytics/caracterizacao/oferta-funcionamento` e renderizar o bloco. |
 | ~~Alta~~ Entregue (1ª versão) | Caracterização da Rede | Infraestrutura Educacional | Endpoint `GET /v1/admin/analytics/caracterizacao/infraestrutura-educacional` entregue, consumindo `vw_censo_ambientes` + `vw_censo_enriquecida`. Lista oficial inicial de essenciais definida (CAR-INFRA-01). Bloco renderizado em `AbaCaracterizacao.tsx`. | — | Entregue. Refino futuro: revisar lista de essenciais com a área de produto. |
 | Alta | Infraestrutura e Segurança | Energia, Climatização e Capacidade Elétrica | Bloco existe como empty state; campos existem em views, mas não são expostos nos endpoints nem renderizados. | Backend + Frontend | Expandir endpoint ou criar endpoint dedicado e substituir empty state por KPIs/gráficos. |
@@ -87,6 +93,41 @@ Status:
 - Vazio: anchor/bloco existe sem conteúdo analítico.
 - Planejado: previsto pela matriz, sem implementação nesta rodada.
 - Fora de escopo: não pertence à rodada analítica PostgreSQL do formulário.
+
+## 4.1 Saúde Operacional por escola — implementada
+
+**Status:** entregue no backend e no frontend.
+
+| Camada | Entrega |
+|---|---|
+| Menu | Item **Saúde Operacional** no grupo Operacional, entre Operacional e Todos os Censos |
+| Nome oficial | **Índice de Saúde Operacional por escola** |
+| Backend | `GET /v1/admin/analytics/escolas/saude-operacional` protegido por JWT |
+| Fonte | PostgreSQL: todas as escolas cadastradas, com `census_responses` concluído do ano de referência quando disponível |
+| Metodologia | Versão `1.0.0`; seis dimensões habilitadas |
+| Frontend | `AbaSaudeOperacionalEscolas.tsx`, com fetch lazy, cache da API, cards, busca e tabela ordenável |
+| Apresentação | Farol, saúde com barra, criticidade e badges de dimensão |
+
+Regras entregues:
+
+- o endpoint retorna todas as escolas cadastradas;
+- escola sem censo concluído do ano aparece como `sem_dados`;
+- `null` representa ausência de informação e não é convertido em zero;
+- `0` é uma nota válida e permanece visível;
+- Pedagógico e Governança permanecem `null` na metodologia `1.0.0`;
+- o frontend não recalcula saúde, criticidade, status, pesos ou metodologia;
+- não há dados fake;
+- o endpoint não foi incluído no prefetch global do login.
+
+Lacunas futuras, não bloqueantes para a entrega atual:
+
+1. **Auditabilidade de valores desconhecidos:** expor ou registrar contagens de respostas não reconhecidas pelos mapas categóricos, sem convertê-las silenciosamente em zero.
+2. **Ordenação SQL determinística:** acrescentar `s.id` como desempate ao `ORDER BY s.nome_escola` para escolas homônimas.
+3. **Filtros globais:** a tela ainda não participa de um contrato global de filtros por ano, DRE, município, zona ou porte.
+4. **Região de Integração:** não há campo/filtro correspondente no payload ou na UI.
+5. **Pedagógico:** ativação futura depende de fonte oficial, regras de aplicabilidade e nova versão metodológica.
+6. **Governança:** ativação futura depende de fonte oficial e nova versão metodológica.
+7. **Escala da tabela:** avaliar paginação ou virtualização se o universo crescer a ponto de afetar renderização e interação.
 
 ## 5. B1 — Caracterização da Rede
 

--- a/docs/dashboard/matriz-abas-e-graficos.md
+++ b/docs/dashboard/matriz-abas-e-graficos.md
@@ -47,12 +47,18 @@ Decisões registradas pelo time, válidas para todo o trabalho a partir desta br
 6. A **fonte futura** de "Gestão Financeira / Governança" virá de **bases próprias validadas pelas coordenações responsáveis**, não do banco do censo operacional.
 7. As **5 abas temáticas já integradas em primeira versão** (Pessoal e Gestão Escolar, Tecnologia e Equipamentos, Infraestrutura e Segurança, Merenda Escolar, Serviços Terceirizados) **não devem receber gráficos inéditos** (fora do escopo do painel original) antes desta matriz mínima ser validada com as áreas finalísticas da SEDUC. **Exceção:** gráficos mínimos que já existiam no painel original (Data Studio/Looker Studio) e ainda não estão refletidos na aplicação podem ser **documentados como lacunas** nesta matriz e **implementados após diagnóstico técnico**, mesmo antes da validação — eles não são novidade de escopo, e sim recuperação da referência mínima. O caso de Tecnologia e Equipamentos (ver §5.3) foi o primeiro a seguir esse caminho; **Merenda Escolar (ver §5.5) é o segundo**, alinhado neste PR documental.
 8. **Recursos Humanos da Merenda (merendeiras/manipuladores de alimentos) saiu da aba Merenda Escolar como bloco finalístico.** O Data Studio mantinha uma subaba "Recursos Humanos" dentro de Merenda; por decisão de produto, esses indicadores (total de merendeiras por vínculo, adequação do quantitativo, média por escola, empresas e supervisão) agora ficam no menu **Serviços Terceirizados**, em bloco próprio **"Manipulador de Alimentos"**, junto de Serviços Gerais e Portaria. **MER-RH-01 entregue:** `sec-merenda-rh` foi removido de `AbaMerenda.tsx`, `sec-servicos-manipuladores` foi adicionado em `AbaServicosTerceirizados.tsx`, o endpoint novo `/servicos-terceirizados/manipuladores-alimentos` foi criado e `/merenda/recursos-humanos` permanece legado. A avaliação do serviço das merendeiras segue como pendência futura/produto por falta de fonte/escala consolidada nesta entrega.
+9. **Saúde Operacional foi implementada como aba transversal no grupo Operacional.** O nome oficial é **"Índice de Saúde Operacional por escola"**, com rótulo reduzido **"Saúde Operacional"** no menu, após Operacional e antes de Todos os Censos. A fonte é PostgreSQL via `GET /v1/admin/analytics/escolas/saude-operacional`; a tela usa fetch lazy e não participa do prefetch global do login.
 
 ---
 
-## 3. Estado atual das abas (pós-merge em `develop`)
+## 3. Estado consolidado das abas
 
-Snapshot real da branch `develop`, atualizado neste PR. Suplanta a seção 2.1 de [plano-trabalho-paralelo.md](plano-trabalho-paralelo.md).
+Snapshot consolidado das entregas funcionais concluídas. O backend de Saúde
+Operacional já integra `develop`; o frontend foi confirmado na entrega
+`feat/frontend-saude-operacional-escolas`. Esta documentação registra o estado
+pós-implementação e deve acompanhar a incorporação da entrega frontend à base.
+O snapshot suplanta a seção 2.1 de
+[plano-trabalho-paralelo.md](plano-trabalho-paralelo.md).
 
 | # | Aba | Estado | Fonte | Componente React |
 |---|---|---|---|---|
@@ -65,8 +71,9 @@ Snapshot real da branch `develop`, atualizado neste PR. Suplanta a seção 2.1 d
 | 7 | Perfil dos Alunos e Resultados | Implementação atual/legada mantida | Google Sheets `/v1/admin/indicadores-metrics` | `AbaPerfilAlunos.tsx` |
 | 8 | Gestão Financeira e Governança | Placeholder institucional | — (sem fetch) | `AbaGestaoFinanceiraGovernanca.tsx` |
 | 9 | Operacional | Integrada | PostgreSQL `/v1/admin/dashboard` | `AbaOperacional.tsx` |
-| 10 | Todos os Censos | Integrada | PostgreSQL `/v1/admin/census` | `AbaTodosCensos.tsx` |
-| 11 | Por DRE | Integrada | PostgreSQL `/v1/admin/dashboard.by_dre` | `AbaPorDre.tsx` |
+| 10 | Saúde Operacional | **Implementada** | PostgreSQL `/v1/admin/analytics/escolas/saude-operacional` | `AbaSaudeOperacionalEscolas.tsx` |
+| 11 | Todos os Censos | Integrada | PostgreSQL `/v1/admin/census` | `AbaTodosCensos.tsx` |
+| 12 | Por DRE | Integrada | PostgreSQL `/v1/admin/dashboard.by_dre` | `AbaPorDre.tsx` |
 
 > **Importante.** A redação anterior em `plano-trabalho-paralelo.md` (Frente 1 backend pendente, abas 2–6 como placeholder) está superada por este snapshot. As views `0003_*` a `0012_*` e os handlers `analytics_pessoal_tecnologia.go` e `analytics_infra_merenda_servicos.go` já estão em `develop`, e os 5 componentes `Aba*.tsx` correspondentes consomem esses endpoints.
 
@@ -331,10 +338,19 @@ As abas a seguir são intencionalmente **fora da matriz analítica** — servem 
 | Aba | Conteúdo | Fonte | Componente React |
 |---|---|---|---|
 | Operacional | KPIs de progresso do censo (preenchimento, taxa de conclusão, andamento por DRE) | PG `/v1/admin/dashboard` | `AbaOperacional.tsx` |
+| Saúde Operacional | **Índice de Saúde Operacional por escola**: cards sintéticos, busca local, tabela escola a escola, farol, barra de saúde e badges de dimensão | PG `/v1/admin/analytics/escolas/saude-operacional` | `AbaSaudeOperacionalEscolas.tsx` |
 | Todos os Censos | Listagem paginada de censos com filtro/busca, modal "ver JSON" | PG `/v1/admin/census` | `AbaTodosCensos.tsx` |
 | Por DRE | Visão tabular por DRE (totais e progresso) | PG `/v1/admin/dashboard.by_dre` | `AbaPorDre.tsx` |
 
-Estas abas **não recebem alteração nesta rodada**. Aparecem aqui para que a leitura do `/admin` seja completa.
+Saúde Operacional está implementada como visão transversal de priorização. O
+endpoint lista todas as escolas cadastradas; somente censo concluído do ano de
+referência alimenta as notas. Escola sem censo elegível permanece na tabela com
+status `sem_dados`.
+
+Na metodologia `1.0.0`, as dimensões habilitadas são Infraestrutura, Energia,
+Merenda, Segurança, Pessoal e Tecnologia. Pedagógico e Governança permanecem
+`null` e aparecem como `—`. O frontend preserva `null` diferente de zero, não
+recalcula saúde, criticidade, status ou pesos e não usa dados fake.
 
 ---
 


### PR DESCRIPTION
git commit -m "docs(dashboard): registrar implementação da saúde operacional" -m "Atualiza a documentação do dashboard para registrar a implementação da tela Índice de Saúde Operacional por escola.

Documenta endpoint, payload, metodologia v1.0.0, dimensões habilitadas, regras de null versus zero, fetch lazy, cards, tabela, busca, farol, ordenação e lacunas futuras.

Registra Pedagógico e Governança como dimensões nulas na versão inicial e mantém como pendências futuras auditabilidade, filtros globais, Região de Integração, desempate SQL e virtualização.

Não altera backend, frontend, migrations, views SQL ou formulário."