### PR TITLE
fix(dashboard): corrigir paginação da saúde operacional

### DIFF
--- a/api/cmd/api/analytics_saude_operacional.go
+++ b/api/cmd/api/analytics_saude_operacional.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	saudeOperacionalNome   = "Índice de Saúde Operacional por escola"
-	saudeOperacionalVersao = "1.0.0"
+	saudeOperacionalNome            = "Índice de Saúde Operacional por escola"
+	saudeOperacionalVersao          = "1.0.0"
+	saudeOperacionalPageSizeDefault = 10
 )
 
 var saudeOperacionalDimensoesHabilitadas = []string{
@@ -29,6 +30,13 @@ var saudeOperacionalDimensoesHabilitadas = []string{
 	"seguranca",
 	"pessoal",
 	"tecnologia",
+}
+
+var saudeOperacionalPageSizes = map[int]bool{
+	10:   true,
+	50:   true,
+	100:  true,
+	1000: true,
 }
 
 type SaudeOperacionalPesos struct {
@@ -710,9 +718,94 @@ func parseSaudeOperacionalYear(raw string, now time.Time) (int, error) {
 	return year, nil
 }
 
+func parseSaudeOperacionalPageSize(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return saudeOperacionalPageSizeDefault, nil
+	}
+
+	pageSize, err := strconv.Atoi(raw)
+	if err != nil || !saudeOperacionalPageSizes[pageSize] {
+		return 0, fmt.Errorf("page_size inválido: use 10, 50, 100 ou 1000")
+	}
+	return pageSize, nil
+}
+
+func parseSaudeOperacionalDirection(raw string) (string, error) {
+	direction := strings.TrimSpace(raw)
+	if direction == "" {
+		return "desc", nil
+	}
+	if direction != "asc" && direction != "desc" {
+		return "", fmt.Errorf("direction inválido: use asc ou desc")
+	}
+	return direction, nil
+}
+
+func filterSaudeOperacionalEscolas(
+	escolas []SaudeOperacionalEscola,
+	searchQuery string,
+) []SaudeOperacionalEscola {
+	searchQuery = normalizeSaudeSearch(searchQuery)
+	if searchQuery == "" {
+		return append([]SaudeOperacionalEscola(nil), escolas...)
+	}
+
+	filtered := make([]SaudeOperacionalEscola, 0)
+	for _, e := range escolas {
+		inep := ""
+		if e.CodigoINEP != nil {
+			inep = *e.CodigoINEP
+		}
+		if strings.Contains(normalizeSaudeSearch(e.Escola), searchQuery) ||
+			strings.Contains(normalizeSaudeSearch(e.Municipio), searchQuery) ||
+			strings.Contains(normalizeSaudeSearch(e.DRE), searchQuery) ||
+			strings.Contains(strings.ToLower(inep), searchQuery) {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+func buildSaudeOperacionalPage(
+	allEscolas []SaudeOperacionalEscola,
+	searchQuery string,
+	sortKey string,
+	direction string,
+	page int,
+	pageSize int,
+) (
+	pageItems []SaudeOperacionalEscola,
+	resumo SaudeOperacionalResumo,
+	totalFiltrado int,
+	totalPages int,
+	currentPage int,
+) {
+	filtered := filterSaudeOperacionalEscolas(allEscolas, searchQuery)
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return compareSaudeEscola(filtered[i], filtered[j], sortKey, direction) < 0
+	})
+
+	resumo = buildSaudeResumo(filtered)
+	totalFiltrado = len(filtered)
+	if totalFiltrado == 0 {
+		return []SaudeOperacionalEscola{}, resumo, 0, 0, 1
+	}
+
+	totalPages = (totalFiltrado + pageSize - 1) / pageSize
+	currentPage = page
+	if currentPage > totalPages {
+		currentPage = totalPages
+	}
+
+	offset := (currentPage - 1) * pageSize
+	end := min(offset+pageSize, totalFiltrado)
+	return filtered[offset:end], resumo, totalFiltrado, totalPages, currentPage
+}
+
 // AdminAnalyticsSaudeOperacionalEscolas retorna escolas com índice de saúde operacional.
 // Parâmetros opcionais: year, page, page_size, search, sort, direction.
-// Sem page_size (ou page_size=0): retorna todas as escolas (compatibilidade).
+// Sem page_size: usa 10 registros por página.
 func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
@@ -722,13 +815,10 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 		return
 	}
 
-	pageSize := 0
-	if raw := strings.TrimSpace(q.Get("page_size")); raw != "" {
-		pageSize, err = strconv.Atoi(raw)
-		if err != nil || pageSize < 1 || pageSize > 1000 {
-			app.errorJSON(w, fmt.Errorf("page_size inválido: deve ser entre 1 e 1000"), http.StatusBadRequest)
-			return
-		}
+	pageSize, err := parseSaudeOperacionalPageSize(q.Get("page_size"))
+	if err != nil {
+		app.errorJSON(w, err, http.StatusBadRequest)
+		return
 	}
 
 	page := 1
@@ -740,7 +830,7 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 		}
 	}
 
-	searchQuery := normalizeSaudeSearch(q.Get("search"))
+	searchQuery := q.Get("search")
 
 	sortKey := strings.TrimSpace(q.Get("sort"))
 	validSortKeys := map[string]bool{
@@ -753,9 +843,10 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 		sortKey = "criticidade"
 	}
 
-	direction := strings.TrimSpace(q.Get("direction"))
-	if direction != "asc" && direction != "desc" {
-		direction = "desc"
+	direction, err := parseSaudeOperacionalDirection(q.Get("direction"))
+	if err != nil {
+		app.errorJSON(w, err, http.StatusBadRequest)
+		return
 	}
 
 	dbRows, err := app.models.Schools.DB.QueryContext(r.Context(), `
@@ -809,53 +900,14 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 		return
 	}
 
-	resumo := buildSaudeResumo(allEscolas)
-
-	filtered := allEscolas
-	if searchQuery != "" {
-		filtered = filtered[:0:0]
-		for _, e := range allEscolas {
-			inep := ""
-			if e.CodigoINEP != nil {
-				inep = *e.CodigoINEP
-			}
-			if strings.Contains(normalizeSaudeSearch(e.Escola), searchQuery) ||
-				strings.Contains(normalizeSaudeSearch(e.Municipio), searchQuery) ||
-				strings.Contains(normalizeSaudeSearch(e.DRE), searchQuery) ||
-				strings.Contains(strings.ToLower(inep), searchQuery) {
-				filtered = append(filtered, e)
-			}
-		}
-	}
-
-	sort.SliceStable(filtered, func(i, j int) bool {
-		return compareSaudeEscola(filtered[i], filtered[j], sortKey, direction) < 0
-	})
-
-	totalFiltrado := len(filtered)
-	totalPages := 1
-	pageSlice := filtered
-
-	if pageSize > 0 {
-		if totalFiltrado > 0 {
-			totalPages = (totalFiltrado + pageSize - 1) / pageSize
-		} else {
-			totalPages = 0
-		}
-		if page > totalPages && totalPages > 0 {
-			page = totalPages
-		}
-		offset := (page - 1) * pageSize
-		end := offset + pageSize
-		if offset >= len(filtered) {
-			pageSlice = []SaudeOperacionalEscola{}
-		} else {
-			if end > len(filtered) {
-				end = len(filtered)
-			}
-			pageSlice = filtered[offset:end]
-		}
-	}
+	pageSlice, resumo, totalFiltrado, totalPages, page := buildSaudeOperacionalPage(
+		allEscolas,
+		searchQuery,
+		sortKey,
+		direction,
+		page,
+		pageSize,
+	)
 
 	out := SaudeOperacionalPayload{
 		TotalEscolas:  len(allEscolas),

--- a/api/cmd/api/analytics_saude_operacional_test.go
+++ b/api/cmd/api/analytics_saude_operacional_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -509,6 +511,180 @@ func TestSaudeOperacionalYearParsing(t *testing.T) {
 		if _, err := parseSaudeOperacionalYear(invalid, now); err == nil {
 			t.Fatalf("parseSaudeOperacionalYear(%q) succeeded; want error", invalid)
 		}
+	}
+}
+
+func TestSaudeOperacionalPageSizeParsing(t *testing.T) {
+	pageSize, err := parseSaudeOperacionalPageSize("")
+	if err != nil || pageSize != 10 {
+		t.Fatalf("default page_size = %d, err=%v; want 10", pageSize, err)
+	}
+
+	for _, valid := range []int{10, 50, 100, 1000} {
+		t.Run(fmt.Sprintf("valid_%d", valid), func(t *testing.T) {
+			got, err := parseSaudeOperacionalPageSize(strconv.Itoa(valid))
+			if err != nil || got != valid {
+				t.Fatalf("page_size = %d, err=%v; want %d", got, err, valid)
+			}
+		})
+	}
+
+	for _, invalid := range []string{"0", "1", "25", "999", "1001", "invalid"} {
+		t.Run("invalid_"+invalid, func(t *testing.T) {
+			if _, err := parseSaudeOperacionalPageSize(invalid); err == nil {
+				t.Fatalf("parseSaudeOperacionalPageSize(%q) succeeded; want error", invalid)
+			}
+		})
+	}
+}
+
+func TestSaudeOperacionalDirectionParsing(t *testing.T) {
+	direction, err := parseSaudeOperacionalDirection("")
+	if err != nil || direction != "desc" {
+		t.Fatalf("default direction = %q, err=%v; want desc", direction, err)
+	}
+
+	for _, valid := range []string{"asc", "desc"} {
+		got, err := parseSaudeOperacionalDirection(valid)
+		if err != nil || got != valid {
+			t.Fatalf("direction = %q, err=%v; want %q", got, err, valid)
+		}
+	}
+
+	for _, invalid := range []string{"ASC", "descending", "invalid"} {
+		if _, err := parseSaudeOperacionalDirection(invalid); err == nil {
+			t.Fatalf("parseSaudeOperacionalDirection(%q) succeeded; want error", invalid)
+		}
+	}
+}
+
+func TestSaudeOperacionalInvalidPaginationHandler(t *testing.T) {
+	tests := []string{
+		"/v1/admin/analytics/escolas/saude-operacional?page_size=25",
+		"/v1/admin/analytics/escolas/saude-operacional?direction=sideways",
+	}
+
+	for _, target := range tests {
+		t.Run(target, func(t *testing.T) {
+			app := &application{}
+			request := httptest.NewRequest(http.MethodGet, target, nil)
+			recorder := httptest.NewRecorder()
+
+			app.AdminAnalyticsSaudeOperacionalEscolas(recorder, request)
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d; want %d; body=%s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+			}
+			var response jsonResponse
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			if !response.Error {
+				t.Fatalf("error = false; want true; body=%s", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestSaudeOperacionalFilteredSummaryAndPagination(t *testing.T) {
+	allEscolas := make([]SaudeOperacionalEscola, 0, 13)
+	for i := 1; i <= 11; i++ {
+		criticidade := float64(i)
+		saude := 100 - criticidade
+		status := "saudavel"
+		if i > 5 && i <= 8 {
+			status = "atencao"
+		} else if i > 8 {
+			status = "critica"
+		}
+		allEscolas = append(allEscolas, SaudeOperacionalEscola{
+			SchoolID:    i,
+			Escola:      fmt.Sprintf("Escola %02d", i),
+			Municipio:   "Castanhal",
+			Saude:       &saude,
+			Criticidade: &criticidade,
+			Status:      status,
+		})
+	}
+	allEscolas = append(allEscolas,
+		SaudeOperacionalEscola{
+			SchoolID:  12,
+			Escola:    "Escola sem dados",
+			Municipio: "Castanhal",
+			Status:    "sem_dados",
+		},
+		SaudeOperacionalEscola{
+			SchoolID:    13,
+			Escola:      "Escola fora da busca",
+			Municipio:   "Belém",
+			Saude:       floatPointerForTest(0),
+			Criticidade: floatPointerForTest(100),
+			Status:      "critica",
+		},
+	)
+
+	pageItems, resumo, totalFiltrado, totalPages, currentPage := buildSaudeOperacionalPage(
+		allEscolas,
+		"CASTANHAL",
+		"criticidade",
+		"desc",
+		2,
+		10,
+	)
+
+	if totalFiltrado != 12 {
+		t.Fatalf("total_filtrado = %d; want 12", totalFiltrado)
+	}
+	if totalPages != 2 || currentPage != 2 {
+		t.Fatalf("pagination = page %d of %d; want page 2 of 2", currentPage, totalPages)
+	}
+	if len(pageItems) != 2 {
+		t.Fatalf("page items = %d; want 2", len(pageItems))
+	}
+	if pageItems[0].SchoolID != 1 || pageItems[1].Status != "sem_dados" {
+		t.Fatalf("page order = %+v; want lowest criticidade followed by sem_dados", pageItems)
+	}
+	if resumo.Saudaveis != 5 || resumo.Atencao != 3 || resumo.Criticas != 3 || resumo.SemDados != 1 {
+		t.Fatalf("filtered resumo = %+v; want 5/3/3/1", resumo)
+	}
+	if resumo.SaudeMedia == nil || *resumo.SaudeMedia != 94 {
+		t.Fatalf("filtered saude_media = %v; want 94", resumo.SaudeMedia)
+	}
+}
+
+func TestSaudeOperacionalZeroIsNotNullAndSemDadosSortsLast(t *testing.T) {
+	escolas := []SaudeOperacionalEscola{
+		{
+			SchoolID:    1,
+			Escola:      "Zero válido",
+			Saude:       floatPointerForTest(0),
+			Criticidade: floatPointerForTest(100),
+			Status:      "critica",
+		},
+		{
+			SchoolID: 2,
+			Escola:   "Sem dados",
+			Status:   "sem_dados",
+		},
+	}
+
+	pageItems, resumo, totalFiltrado, _, _ := buildSaudeOperacionalPage(
+		escolas,
+		"",
+		"saude",
+		"asc",
+		1,
+		10,
+	)
+
+	if totalFiltrado != 2 || len(pageItems) != 2 {
+		t.Fatalf("items = %d, total = %d; want 2", len(pageItems), totalFiltrado)
+	}
+	if pageItems[0].SchoolID != 1 || pageItems[1].Status != "sem_dados" {
+		t.Fatalf("order = %+v; want zero before sem_dados", pageItems)
+	}
+	if resumo.SaudeMedia == nil || *resumo.SaudeMedia != 0 {
+		t.Fatalf("saude_media = %v; want legitimate zero", resumo.SaudeMedia)
 	}
 }
 

--- a/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
+++ b/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
@@ -26,6 +26,8 @@ import type {
 } from "./shared/types";
 
 const ENDPOINT_BASE = "/v1/admin/analytics/escolas/saude-operacional";
+// Temporário: o dashboard atual está fixado no ciclo do Censo Escolar 2026.
+const DASHBOARD_REFERENCE_YEAR = 2026;
 
 const PAGE_SIZE_OPTIONS = [10, 50, 100, 1000] as const;
 type PageSizeOption = (typeof PAGE_SIZE_OPTIONS)[number];
@@ -118,6 +120,7 @@ function buildEndpoint(
   search: string,
 ): string {
   const params = new URLSearchParams({
+    year: String(DASHBOARD_REFERENCE_YEAR),
     sort: sortKey,
     direction: sortDir,
     page: String(page),
@@ -276,12 +279,21 @@ export function AbaSaudeOperacionalEscolas({
     setSearchInput(value);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
+      if (page !== 1 || value !== serverSearch) setLoading(true);
       setPage(1);
       setServerSearch(value);
     }, 400);
+  }, [page, serverSearch]);
+
+  useEffect(() => () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
   }, []);
 
   function handleSort(key: SortKey) {
+    setLoading(true);
     if (sortKey === key) {
       setSortDir((current) => current === "asc" ? "desc" : "asc");
     } else {
@@ -292,13 +304,20 @@ export function AbaSaudeOperacionalEscolas({
   }
 
   function handlePageSizeChange(size: PageSizeOption) {
+    if (size === pageSize && page === 1) return;
+    setLoading(true);
     setPageSize(size);
     setPage(1);
   }
 
+  function handlePageChange(nextPage: number) {
+    if (nextPage === page) return;
+    setLoading(true);
+    setPage(nextPage);
+  }
+
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
 
     const url = buildEndpoint(sortKey, sortDir, page, pageSize, serverSearch);
 
@@ -561,20 +580,20 @@ export function AbaSaudeOperacionalEscolas({
               )}
               <button
                 type="button"
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page <= 1}
+                onClick={() => handlePageChange(Math.max(1, payload.page - 1))}
+                disabled={payload.page <= 1 || totalPages === 0}
                 className="flex items-center gap-1 rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 <ArrowLeft size={13} />
                 Anterior
               </button>
               <span className="px-2 font-medium text-slate-700">
-                {page} / {totalPages || 1}
+                {totalPages === 0 ? "0 de 0" : `${payload.page} / ${totalPages}`}
               </span>
               <button
                 type="button"
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                disabled={page >= totalPages}
+                onClick={() => handlePageChange(Math.min(totalPages, payload.page + 1))}
+                disabled={totalPages === 0 || payload.page >= totalPages}
                 className="flex items-center gap-1 rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 Próxima


### PR DESCRIPTION
git commit -m "fix(dashboard): corrigir paginação da saúde operacional" -m "Corrige a paginação server-side da tela Saúde Operacional.

Restringe page_size aos valores permitidos, valida direction, ajusta o resumo para respeitar a busca, corrige o contador no frontend, adiciona cleanup do debounce e resolve o erro de lint.

Também explicita o ano enviado ao endpoint e adiciona cobertura de testes para os comportamentos corrigidos.

Não altera migrations, filtros globais, Saúde por DRE, modo apresentação ou formulário."