### PR TITLE
fix(admin): reorganizar abas do grupo Operacional

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -5,7 +5,7 @@ import {
   LogOut, Search, RefreshCw, CloudUpload, Lock, User as UserIcon,
   AlertCircle, Loader2, PanelLeftClose, Eye, EyeOff, ArrowRight,
   BarChart2, UsersRound, MonitorSmartphone, ShieldCheck, Utensils,
-  ClipboardCheck, Activity, Landmark, LayoutDashboard, Database, MapPinned,
+  ClipboardCheck, Activity, Landmark, Database, MapPinned,
   Menu, X, ChevronDown, HeartPulse,
   Sun,
   Moon,
@@ -18,7 +18,6 @@ import {
   apiFetch, saveToken, loadToken, clearToken, clearApiCache, sanitize, prefetchDashboard,
 } from "@/components/admin/shared/api";
 import { JsonModal } from "@/components/admin/shared/JsonModal";
-import { AbaOperacional } from "@/components/admin/AbaOperacional";
 import { AbaTodosCensos } from "@/components/admin/AbaTodosCensos";
 import { AbaPorDre } from "@/components/admin/AbaPorDre";
 import { AbaPerfilAlunos } from "@/components/admin/AbaPerfilAlunos";
@@ -190,7 +189,6 @@ type Tab =
   | "servicos"
   | "alunos"
   | "governanca"
-  | "operacional"
   | "saude"
   | "census"
   | "dre";
@@ -204,10 +202,9 @@ const PAGE_META: Record<Tab, { title: string }> = {
   servicos: { title: "Serviços Terceirizados" },
   alunos: { title: "Perfil dos Alunos e Resultados" },
   governanca: { title: "Gestão Financeira e Governança" },
-  operacional: { title: "Operacional" },
   saude: { title: "Índice de Saúde Operacional por escola" },
-  census: { title: "Todos os Censos" },
-  dre: { title: "Por DRE" },
+  census: { title: "Registros de Preenchimento do Censo" },
+  dre: { title: "Andamento do Preenchimento por DRE" },
 };
 
 type SubItem = { label: string; anchor: string };
@@ -276,10 +273,9 @@ const NAV_INDICATORS: NavItem[] = [
 ];
 
 const NAV_OPERACIONAL: NavItem[] = [
-  { id: "operacional", label: "Operacional", Icon: LayoutDashboard },
   { id: "saude", label: "Saúde Operacional", Icon: HeartPulse },
-  { id: "census", label: "Todos os Censos", Icon: Database },
-  { id: "dre", label: "Por DRE", Icon: MapPinned },
+  { id: "census", label: "Registros do Censo", Icon: Database },
+  { id: "dre", label: "Preenchimento por DRE", Icon: MapPinned },
 ];
 
 function NavGroup({
@@ -428,7 +424,6 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
       r.municipio.toLowerCase().includes(l) || r.dre.toLowerCase().includes(l);
   };
 
-  const filteredRecent = (dbData?.recent ?? []).filter((r) => !search || match(r, search));
   const filteredCensus = (censusPage?.rows ?? []).filter((r) => !search || match(r, search));
 
   const handleNav = (id: Tab) => { setTab(id); setSearch(""); setVisited((prev) => new Set([...prev, id])); setMobileNavOpen(false); };
@@ -616,17 +611,6 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
               <div style={{ display: tab === "saude" ? undefined : "none" }}>
                 <AbaSaudeOperacionalEscolas token={token} onUnauth={logout} filters={filters} />
               </div>
-            )}
-
-            {tab === "operacional" && dbData && (
-              <AbaOperacional
-                dbData={dbData}
-                search={search}
-                setSearch={setSearch}
-                filteredRecent={filteredRecent}
-                onView={setViewId}
-                formatDate={fmtDate}
-              />
             )}
 
             {tab === "census" && (

--- a/web/src/components/admin/AbaPorDre.tsx
+++ b/web/src/components/admin/AbaPorDre.tsx
@@ -6,9 +6,12 @@ import type { DashboardData } from "./shared/types";
 export function AbaPorDre({ dbData }: { dbData: DashboardData }) {
   return (
     <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm animate-fade-in-up">
-      <div className="px-6 py-4 border-b flex items-center gap-2" style={{ background: C.primaryLight }}>
-        <MapPinned size={16} style={{ color: C.primary }} />
-        <h2 className="font-semibold text-slate-800 text-sm">Andamento por Diretoria Regional de Ensino</h2>
+      <div className="px-6 py-4 border-b flex items-start gap-2" style={{ background: C.primaryLight }}>
+        <MapPinned size={16} style={{ color: C.primary }} className="mt-0.5 shrink-0" />
+        <div>
+          <h2 className="font-semibold text-slate-800 text-sm">Andamento do Preenchimento por Diretoria Regional de Ensino</h2>
+          <p className="text-xs text-slate-500 mt-0.5">Percentual de escolas com censo concluído ou em rascunho, agrupado por DRE.</p>
+        </div>
       </div>
       <table className="w-full text-sm">
         <thead className="bg-slate-50 border-b border-slate-200">

--- a/web/src/components/admin/AbaTodosCensos.tsx
+++ b/web/src/components/admin/AbaTodosCensos.tsx
@@ -1,6 +1,10 @@
 import React from "react";
-import { Filter, Search, Loader2, ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  Filter, Search, Loader2, ChevronLeft, ChevronRight,
+  Building2, CheckCircle2, FileText, CloudUpload,
+} from "lucide-react";
 import { CensusTable } from "./shared/CensusTable";
+import { StatCard } from "./shared/StatCard";
 import { sanitize } from "./shared/api";
 import type { CensusRow, CensusPage, DashboardData } from "./shared/types";
 
@@ -46,6 +50,16 @@ export function AbaTodosCensos({
 
   return (
     <div className="space-y-4">
+      {/* Cards de resumo */}
+      {dbData && (
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 animate-fade-in-up">
+          <StatCard label="Escolas Cadastradas" value={dbData.total_schools}      Icon={Building2}    tone="blue"   />
+          <StatCard label="Censos Concluídos"   value={dbData.completed_censuses} Icon={CheckCircle2} tone="green"  />
+          <StatCard label="Rascunhos"            value={dbData.draft_censuses}     Icon={FileText}     tone="amber"  />
+          <StatCard label="Pendente na Planilha" value={dbData.pending_sync}       Icon={CloudUpload}  tone="orange" />
+        </div>
+      )}
+
       {/* Filtros */}
       <div className="bg-white rounded-2xl border border-slate-200 p-4 shadow-sm flex flex-wrap items-center gap-3">
         <Filter size={15} className="text-slate-500" />


### PR DESCRIPTION
Remove a aba "Operacional" (redundante com a lista de censos) e renomeia as demais para nomes mais claros à gestão:

- "Todos os Censos" -> "Registros do Censo"
- "Por DRE" -> "Preenchimento por DRE"

Os cards de resumo (Escolas Cadastradas, Censos Concluídos, Rascunhos, Pendente na Planilha) passam a ser exibidos no topo da aba Registros do Censo, antes dos filtros, para não perder a informação útil.

Ajusta títulos em PAGE_META e o título interno da aba Por DRE, com subtítulo explicativo. Remove o tipo/rota "operacional", o item de menu, a renderização de AbaOperacional e imports não utilizados.