### PR TITLE
fix(admin): aplicar animacao de hover aos cards da Saude Operacional

### DIFF
--- a/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
+++ b/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
@@ -151,18 +151,18 @@ function SummaryCard({
   sub?: string;
 }) {
   return (
-    <div className="bg-white border border-slate-200 rounded-2xl p-4 shadow-sm">
+    <div className="bg-white border border-slate-200 rounded-2xl p-4 shadow-sm hover:shadow-lg hover:-translate-y-1 hover:border-slate-300 transition-all duration-300 group cursor-default animate-fade-in-up">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-[11px] text-slate-500 font-medium uppercase tracking-wide">
+          <p className="text-[11px] text-slate-500 font-medium uppercase tracking-wide group-hover:text-slate-700 transition-colors">
             {label}
           </p>
-          <p className="text-2xl font-bold text-slate-900 mt-2 tabular-nums">
+          <p className="text-2xl font-bold text-slate-900 mt-2 tabular-nums group-hover:scale-105 origin-left transition-transform">
             {typeof value === "number" ? value.toLocaleString("pt-BR") : value}
           </p>
-          {sub && <p className="text-[11px] text-slate-400 mt-1">{sub}</p>}
+          {sub && <p className="text-[11px] text-slate-400 mt-1 group-hover:text-slate-500 transition-colors">{sub}</p>}
         </div>
-        <div className={`w-10 h-10 rounded-xl flex shrink-0 items-center justify-center ring-1 ${SUMMARY_TONES[tone]}`}>
+        <div className={`w-10 h-10 rounded-xl flex shrink-0 items-center justify-center ring-1 group-hover:scale-110 group-hover:rotate-3 transition-transform ${SUMMARY_TONES[tone]}`}>
           <Icon size={19} strokeWidth={2} />
         </div>
       </div>


### PR DESCRIPTION
## Resumo

Este PR ajusta os cards de resumo da aba **Saúde Operacional** para manter consistência visual com os cards das demais telas do painel administrativo.

## Alterações realizadas

- Adicionada animação de entrada `animate-fade-in-up`.
- Adicionado efeito de hover com:
  - leve elevação;
  - aumento de sombra;
  - destaque da borda;
  - transição suave.
- Adicionada leve escala no valor do card.
- Adicionada leve escala e rotação no ícone.
- Adicionadas transições de cor no label e no subtítulo.

## Escopo preservado

Este PR altera apenas classes visuais do componente local `SummaryCard` em:

`web/src/components/admin/AbaSaudeOperacionalEscolas.tsx`

Não foram alterados:

- backend;
- banco de dados;
- migrations;
- endpoints;
- payloads;
- regras de cálculo;
- metodologia;
- filtros globais;
- autenticação;
- demais abas do painel;
- componente compartilhado `StatCard`.

## Validação

Foi executado:

```bash
npm run lint