### PR TITLE
fix(dashboard): aplicar filtros globais nos registros do censo

### DIFF
--- a/api/cmd/api/admin.go
+++ b/api/cmd/api/admin.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -388,56 +389,181 @@ func (app *application) AdminDashboard(w http.ResponseWriter, r *http.Request) {
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: s})
 }
 
-type CensusPageResponse struct {
-	Rows  []CensusRow `json:"rows"`
-	Total int         `json:"total"`
-	Page  int         `json:"page"`
-	Limit int         `json:"limit"`
+// CensusSummary resume o recorte global da tela "Registros do Censo". Os cards
+// da aba usam estes números: respeitam os filtros globais (year, dre, municipio,
+// zona, regiao_integracao) mas NÃO os filtros locais da listagem (status, search,
+// page, limit) — status e busca refinam apenas a tabela.
+type CensusSummary struct {
+	TotalSchools      int `json:"total_schools"`
+	CompletedCensuses int `json:"completed_censuses"`
+	DraftCensuses     int `json:"draft_censuses"`
+	PendingSync       int `json:"pending_sync"`
 }
 
-// AdminGetCensus returns paginated census entries with optional status/DRE filters.
-// Query params: status, dre, limit (default 10), page (default 1).
+type CensusPageResponse struct {
+	Rows    []CensusRow   `json:"rows"`
+	Total   int           `json:"total"`
+	Page    int           `json:"page"`
+	Limit   int           `json:"limit"`
+	Summary CensusSummary `json:"summary"`
+}
+
+// censusListAllowedLimits são os tamanhos de página aceitos por /v1/admin/census.
+// Valores fora deste conjunto caem no default (10).
+var censusListAllowedLimits = map[int]bool{10: true, 50: true, 100: true, 1000: true}
+
+// censusListParams reúne os parâmetros de /v1/admin/census: filtros globais do
+// dashboard (Year, DRE, Municipio, Zona, RegiaoIntegracao), filtros locais da
+// aba (Status, Search) e paginação. String vazia e Year=0 significam "filtro
+// desativado" — o endpoint nunca assume ano corrente como default, preservando
+// o comportamento operacional anterior (sem filtro de ano = todos os anos).
+type censusListParams struct {
+	Status           string
+	Year             int
+	DRE              string
+	Municipio        string
+	Zona             string
+	RegiaoIntegracao string
+	Search           string
+	Limit            int
+	Page             int
+}
+
+// parseCensusListParams lê a query string com defaults tolerantes: year ausente
+// ou inválido não filtra, limit fora de {10, 50, 100, 1000} vira 10 e page
+// ausente ou inválida vira 1. Espaços em branco equivalem a filtro desativado.
+func parseCensusListParams(q url.Values) censusListParams {
+	p := censusListParams{
+		Status:           strings.TrimSpace(q.Get("status")),
+		DRE:              strings.TrimSpace(q.Get("dre")),
+		Municipio:        strings.TrimSpace(q.Get("municipio")),
+		Zona:             strings.TrimSpace(q.Get("zona")),
+		RegiaoIntegracao: strings.TrimSpace(q.Get("regiao_integracao")),
+		Search:           strings.TrimSpace(q.Get("search")),
+		Limit:            10,
+		Page:             1,
+	}
+	if v, err := strconv.Atoi(strings.TrimSpace(q.Get("year"))); err == nil && v > 0 {
+		p.Year = v
+	}
+	if v, err := strconv.Atoi(strings.TrimSpace(q.Get("limit"))); err == nil && censusListAllowedLimits[v] {
+		p.Limit = v
+	}
+	if v, err := strconv.Atoi(strings.TrimSpace(q.Get("page"))); err == nil && v > 0 {
+		p.Page = v
+	}
+	return p
+}
+
+// censusListWhereSQL é a cláusula de filtros compartilhada entre o COUNT(*) e a
+// listagem de /v1/admin/census — uma única fonte evita divergência entre total
+// paginado e linhas exibidas. Todos os filtros combinam por AND; UPPER(TRIM())
+// tolera caixa e espaços, espelhando o padrão da Saúde Operacional. A Região de
+// Integração casa schools.municipio contra reg_integracao (mesma ressalva de
+// grafia documentada em saudeOperacionalSelectSQL). A busca textual ($7) roda
+// no banco, sobre escola, INEP, município, DRE, status e ano.
+// Argumentos: $1=status, $2=year, $3=dre, $4=municipio, $5=zona,
+// $6=regiao_integracao, $7=search.
+const censusListWhereSQL = `
+	WHERE ($1 = '' OR cr.status = $1)
+	  AND ($2 = 0 OR cr.year = $2)
+	  AND ($3 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($5)))
+	  AND ($6 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($6))
+	      ))
+	  AND ($7 = ''
+	       OR s.nome_escola ILIKE '%' || $7 || '%'
+	       OR s.codigo_inep ILIKE '%' || $7 || '%'
+	       OR s.municipio ILIKE '%' || $7 || '%'
+	       OR s.dre ILIKE '%' || $7 || '%'
+	       OR cr.status ILIKE '%' || $7 || '%'
+	       OR cr.year::text ILIKE '%' || $7 || '%')`
+
+const censusListCountSQL = `
+	SELECT COUNT(*)
+	FROM census_responses cr
+	JOIN schools s ON s.id = cr.school_id` + censusListWhereSQL
+
+const censusListSelectSQL = `
+	SELECT
+		cr.id, cr.school_id, s.nome_escola, s.codigo_inep, s.municipio, s.dre,
+		cr.year, cr.status, cr.updated_at,
+		(cr.sheet_synced_at IS NOT NULL)
+	FROM census_responses cr
+	JOIN schools s ON s.id = cr.school_id` + censusListWhereSQL + `
+	ORDER BY cr.updated_at DESC
+	LIMIT $8 OFFSET $9`
+
+// whereArgs devolve os argumentos posicionais de censusListWhereSQL na ordem
+// $1=status, $2=year, $3=dre, $4=municipio, $5=zona, $6=regiao_integracao,
+// $7=search.
+func (p censusListParams) whereArgs() []any {
+	return []any{p.Status, p.Year, p.DRE, p.Municipio, p.Zona, p.RegiaoIntegracao, p.Search}
+}
+
+// censusSummarySQL calcula o resumo dos cards da aba. Aplica somente os filtros
+// globais ($1=year, $2=dre, $3=municipio, $4=zona, $5=regiao_integracao) —
+// status e search ficam de fora de propósito (ver CensusSummary).
+// total_schools conta escolas cadastradas no recorte (sem JOIN com censo e sem
+// filtro de ano: o cadastro de escolas não é versionado por ano); os demais
+// contadores contam respostas de censo dentro do recorte e do ano informado.
+const censusSummarySQL = `
+	SELECT
+		(SELECT COUNT(*)
+		 FROM schools s
+		 WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+		   AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+		   AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+		   AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+		         SELECT UPPER(TRIM(municipio))
+		         FROM reg_integracao
+		         WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+		       ))),
+		COUNT(*) FILTER (WHERE cr.status = 'completed'),
+		COUNT(*) FILTER (WHERE cr.status = 'draft'),
+		COUNT(*) FILTER (WHERE cr.status = 'completed' AND cr.sheet_synced_at IS NULL)
+	FROM census_responses cr
+	JOIN schools s ON s.id = cr.school_id
+	WHERE ($1 = 0 OR cr.year = $1)
+	  AND ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))`
+
+// summaryArgs devolve os argumentos posicionais de censusSummarySQL na ordem
+// $1=year, $2=dre, $3=municipio, $4=zona, $5=regiao_integracao.
+func (p censusListParams) summaryArgs() []any {
+	return []any{p.Year, p.DRE, p.Municipio, p.Zona, p.RegiaoIntegracao}
+}
+
+// AdminGetCensus returns paginated census entries for the "Registros do Censo"
+// screen. Filtros globais do dashboard: year, dre, municipio, zona,
+// regiao_integracao. Filtros locais: status, search. Paginação: limit
+// (10/50/100/1000, default 10), page (default 1). O payload inclui um resumo
+// (summary) que respeita apenas os filtros globais.
 func (app *application) AdminGetCensus(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	db := app.models.Schools.DB
 
-	statusFilter := r.URL.Query().Get("status")
-	dreFilter    := r.URL.Query().Get("dre")
-
-	limit := 10
-	page  := 1
-	if v, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && v > 0 {
-		limit = v
-	}
-	if v, err := strconv.Atoi(r.URL.Query().Get("page")); err == nil && v > 0 {
-		page = v
-	}
-	offset := (page - 1) * limit
+	p := parseCensusListParams(r.URL.Query())
+	whereArgs := p.whereArgs()
+	offset := (p.Page - 1) * p.Limit
 
 	var total int
-	if err := db.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM census_responses cr
-		JOIN schools s ON s.id = cr.school_id
-		WHERE ($1 = '' OR cr.status = $1)
-		  AND ($2 = '' OR s.dre = $2)`,
-		statusFilter, dreFilter).Scan(&total); err != nil {
+	if err := db.QueryRowContext(ctx, censusListCountSQL, whereArgs...).Scan(&total); err != nil {
 		app.errorJSON(w, fmt.Errorf("erro ao contar censos"), http.StatusInternalServerError)
 		return
 	}
 
-	rows, err := db.QueryContext(ctx, `
-		SELECT
-			cr.id, cr.school_id, s.nome_escola, s.codigo_inep, s.municipio, s.dre,
-			cr.year, cr.status, cr.updated_at,
-			(cr.sheet_synced_at IS NOT NULL)
-		FROM census_responses cr
-		JOIN schools s ON s.id = cr.school_id
-		WHERE ($1 = '' OR cr.status = $1)
-		  AND ($2 = '' OR s.dre = $2)
-		ORDER BY cr.updated_at DESC
-		LIMIT $3 OFFSET $4`,
-		statusFilter, dreFilter, limit, offset)
+	rows, err := db.QueryContext(ctx, censusListSelectSQL, append(whereArgs, p.Limit, offset)...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro ao listar censos"), http.StatusInternalServerError)
 		return
@@ -458,8 +584,16 @@ func (app *application) AdminGetCensus(w http.ResponseWriter, r *http.Request) {
 		results = []CensusRow{}
 	}
 
+	var summary CensusSummary
+	if err := db.QueryRowContext(ctx, censusSummarySQL, p.summaryArgs()...).Scan(
+		&summary.TotalSchools, &summary.CompletedCensuses,
+		&summary.DraftCensuses, &summary.PendingSync); err != nil {
+		app.errorJSON(w, fmt.Errorf("erro ao resumir censos"), http.StatusInternalServerError)
+		return
+	}
+
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: CensusPageResponse{
-		Rows: results, Total: total, Page: page, Limit: limit,
+		Rows: results, Total: total, Page: p.Page, Limit: p.Limit, Summary: summary,
 	}})
 }
 

--- a/api/cmd/api/admin_census_test.go
+++ b/api/cmd/api/admin_census_test.go
@@ -1,0 +1,351 @@
+package main
+
+// Testes de /v1/admin/census (tela "Registros do Censo").
+//
+// Limitação: o repositório não possui infraestrutura de teste com banco de
+// dados (não há harness de PostgreSQL nos testes — ver
+// analytics_saude_operacional_test.go, que segue o mesmo padrão). Por isso a
+// cobertura aqui é unitária, sobre os helpers que alimentam o handler:
+//
+//   - parseCensusListParams — leitura e defaults dos parâmetros;
+//   - censusListWhereSQL / whereArgs — forma da cláusula compartilhada e ordem
+//     dos argumentos (a presença do valor no placeholder correto comprova que o
+//     filtro incide na query, inclusive no recorte vazio, que é só um recorte
+//     sem linhas correspondentes);
+//   - censusListCountSQL / censusListSelectSQL — COUNT e listagem usam a MESMA
+//     cláusula (mesma constante), logo respeitam os mesmos filtros;
+//   - censusSummarySQL / summaryArgs — o resumo respeita os filtros globais e
+//     não recebe status/search/page/limit.
+//
+// O comportamento fim-a-fim (linhas retornadas, contagens reais, paginação com
+// dados) depende de banco e fica para validação em homologação, como nas demais
+// telas migradas.
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// ─── parseCensusListParams ───────────────────────────────────────────────────
+
+// Cenário 1 da task: sem filtros — tudo desativado, paginação default.
+func TestCensusListParamsDefaults(t *testing.T) {
+	got := parseCensusListParams(url.Values{})
+	want := censusListParams{Limit: 10, Page: 1}
+	if got != want {
+		t.Fatalf("parseCensusListParams(empty) = %+v; want %+v", got, want)
+	}
+}
+
+func TestCensusListParamsParsing(t *testing.T) {
+	q := url.Values{
+		"status":            {"completed"},
+		"year":              {"2026"},
+		"dre":               {"  CASTANHAL  "},
+		"municipio":         {"BELEM"},
+		"zona":              {"Urbana"},
+		"regiao_integracao": {"GUAJARA"},
+		"search":            {"  escola azul  "},
+		"limit":             {"100"},
+		"page":              {"3"},
+	}
+	got := parseCensusListParams(q)
+	want := censusListParams{
+		Status:           "completed",
+		Year:             2026,
+		DRE:              "CASTANHAL",
+		Municipio:        "BELEM",
+		Zona:             "Urbana",
+		RegiaoIntegracao: "GUAJARA",
+		Search:           "escola azul",
+		Limit:            100,
+		Page:             3,
+	}
+	if got != want {
+		t.Fatalf("parseCensusListParams = %+v; want %+v", got, want)
+	}
+}
+
+// Cenário 16 da task: limit inválido volta para 10; só {10,50,100,1000} valem.
+func TestCensusListParamsLimitFallback(t *testing.T) {
+	for _, valid := range []int{10, 50, 100, 1000} {
+		t.Run(fmt.Sprintf("valid_%d", valid), func(t *testing.T) {
+			got := parseCensusListParams(url.Values{"limit": {strconv.Itoa(valid)}})
+			if got.Limit != valid {
+				t.Fatalf("limit = %d; want %d", got.Limit, valid)
+			}
+		})
+	}
+	for _, invalid := range []string{"0", "-5", "25", "999", "1001", "abc", ""} {
+		t.Run("invalid_"+invalid, func(t *testing.T) {
+			got := parseCensusListParams(url.Values{"limit": {invalid}})
+			if got.Limit != 10 {
+				t.Fatalf("limit(%q) = %d; want fallback 10", invalid, got.Limit)
+			}
+		})
+	}
+}
+
+// Cenário 17 da task: page ausente ou inválida volta para 1.
+func TestCensusListParamsPageFallback(t *testing.T) {
+	if got := parseCensusListParams(url.Values{"page": {"4"}}); got.Page != 4 {
+		t.Fatalf("page = %d; want 4", got.Page)
+	}
+	for _, invalid := range []string{"0", "-1", "abc", ""} {
+		t.Run("invalid_"+invalid, func(t *testing.T) {
+			got := parseCensusListParams(url.Values{"page": {invalid}})
+			if got.Page != 1 {
+				t.Fatalf("page(%q) = %d; want fallback 1", invalid, got.Page)
+			}
+		})
+	}
+}
+
+// year ausente/inválido não filtra (Year=0); nunca assume ano corrente.
+func TestCensusListParamsYearFallback(t *testing.T) {
+	if got := parseCensusListParams(url.Values{"year": {"2025"}}); got.Year != 2025 {
+		t.Fatalf("year = %d; want 2025", got.Year)
+	}
+	for _, invalid := range []string{"", "abc", "0", "-2026"} {
+		t.Run("invalid_"+invalid, func(t *testing.T) {
+			got := parseCensusListParams(url.Values{"year": {invalid}})
+			if got.Year != 0 {
+				t.Fatalf("year(%q) = %d; want 0 (sem filtro)", invalid, got.Year)
+			}
+		})
+	}
+}
+
+// Espaços em branco equivalem a filtro desativado.
+func TestCensusListParamsBlankFilters(t *testing.T) {
+	q := url.Values{
+		"status":            {"  "},
+		"dre":               {""},
+		"municipio":         {"\t"},
+		"zona":              {" "},
+		"regiao_integracao": {"  "},
+		"search":            {"   "},
+	}
+	got := parseCensusListParams(q)
+	want := censusListParams{Limit: 10, Page: 1}
+	if got != want {
+		t.Fatalf("parseCensusListParams(blanks) = %+v; want %+v", got, want)
+	}
+}
+
+// ─── whereArgs — cenários 2 a 8 da task ──────────────────────────────────────
+
+// Cada filtro ocupa o placeholder correto de censusListWhereSQL; múltiplos
+// filtros preenchem múltiplos placeholders e a cláusula combina-os por AND.
+func TestCensusListWhereArgsOrder(t *testing.T) {
+	tests := []struct {
+		name   string
+		params censusListParams
+		want   []any
+	}{
+		{
+			name:   "sem filtros",
+			params: censusListParams{Limit: 10, Page: 1},
+			want:   []any{"", 0, "", "", "", "", ""},
+		},
+		{
+			name:   "filtro por status",
+			params: censusListParams{Status: "completed"},
+			want:   []any{"completed", 0, "", "", "", "", ""},
+		},
+		{
+			name:   "filtro por year",
+			params: censusListParams{Year: 2026},
+			want:   []any{"", 2026, "", "", "", "", ""},
+		},
+		{
+			name:   "filtro por DRE",
+			params: censusListParams{DRE: "CASTANHAL"},
+			want:   []any{"", 0, "CASTANHAL", "", "", "", ""},
+		},
+		{
+			name:   "filtro por municipio",
+			params: censusListParams{Municipio: "BELEM"},
+			want:   []any{"", 0, "", "BELEM", "", "", ""},
+		},
+		{
+			name:   "filtro por zona",
+			params: censusListParams{Zona: "Urbana"},
+			want:   []any{"", 0, "", "", "Urbana", "", ""},
+		},
+		{
+			name:   "filtro por regiao de integracao",
+			params: censusListParams{RegiaoIntegracao: "GUAJARA"},
+			want:   []any{"", 0, "", "", "", "GUAJARA", ""},
+		},
+		{
+			name:   "busca textual",
+			params: censusListParams{Search: "escola azul"},
+			want:   []any{"", 0, "", "", "", "", "escola azul"},
+		},
+		{
+			name: "combinacao por AND",
+			params: censusListParams{
+				Status: "draft", Year: 2025, DRE: "BELEM", Municipio: "BELEM",
+				Zona: "Rural", RegiaoIntegracao: "GUAJARA", Search: "inep",
+			},
+			want: []any{"draft", 2025, "BELEM", "BELEM", "Rural", "GUAJARA", "inep"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.params.whereArgs()
+			if len(got) != len(tt.want) {
+				t.Fatalf("args = %v; want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("args[%d] = %v; want %v (args=%v)", i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+// ─── Forma das queries ───────────────────────────────────────────────────────
+
+// A cláusula compartilhada aplica cada filtro no campo certo, combinada por AND.
+func TestCensusListWhereShape(t *testing.T) {
+	mustContain := []string{
+		`($1 = '' OR cr.status = $1)`,
+		`($2 = 0 OR cr.year = $2)`,
+		`($3 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($3)))`,
+		`($4 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($4)))`,
+		`($5 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($5)))`,
+		`FROM reg_integracao`,
+		`UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($6))`,
+	}
+	for _, fragment := range mustContain {
+		if !strings.Contains(censusListWhereSQL, fragment) {
+			t.Fatalf("censusListWhereSQL não contém %q", fragment)
+		}
+	}
+	if strings.Count(censusListWhereSQL, "AND ($") < 6 {
+		t.Fatalf("filtros não parecem combinados por AND: %s", censusListWhereSQL)
+	}
+}
+
+// Cenário 12 da task: a busca textual roda no banco (ILIKE parametrizado) sobre
+// escola, INEP, município, DRE, status e ano — não apenas na página carregada.
+func TestCensusListSearchShape(t *testing.T) {
+	mustContain := []string{
+		`s.nome_escola ILIKE '%' || $7 || '%'`,
+		`s.codigo_inep ILIKE '%' || $7 || '%'`,
+		`s.municipio ILIKE '%' || $7 || '%'`,
+		`s.dre ILIKE '%' || $7 || '%'`,
+		`cr.status ILIKE '%' || $7 || '%'`,
+		`cr.year::text ILIKE '%' || $7 || '%'`,
+	}
+	for _, fragment := range mustContain {
+		if !strings.Contains(censusListWhereSQL, fragment) {
+			t.Fatalf("busca não cobre %q", fragment)
+		}
+	}
+}
+
+// Cenário 9 da task: COUNT(*) e listagem usam a MESMA cláusula (a constante
+// censusListWhereSQL aparece literalmente nas duas queries), então o total
+// paginado respeita exatamente os filtros das linhas exibidas.
+func TestCensusListCountAndSelectShareWhere(t *testing.T) {
+	if !strings.Contains(censusListCountSQL, censusListWhereSQL) {
+		t.Fatalf("COUNT não embute censusListWhereSQL")
+	}
+	if !strings.Contains(censusListSelectSQL, censusListWhereSQL) {
+		t.Fatalf("SELECT não embute censusListWhereSQL")
+	}
+	if !strings.Contains(censusListCountSQL, "SELECT COUNT(*)") {
+		t.Fatalf("censusListCountSQL não é um COUNT: %s", censusListCountSQL)
+	}
+}
+
+// Cenários 10 e 13 da task: a listagem pagina via LIMIT $8 OFFSET $9 — os
+// placeholders vêm DEPOIS dos sete filtros (inclusive search), portanto busca e
+// paginação convivem na mesma query. O COUNT não pagina.
+func TestCensusListPaginationShape(t *testing.T) {
+	if !strings.Contains(censusListSelectSQL, "LIMIT $8 OFFSET $9") {
+		t.Fatalf("SELECT não pagina com LIMIT $8 OFFSET $9: %s", censusListSelectSQL)
+	}
+	if !strings.Contains(censusListSelectSQL, "ORDER BY cr.updated_at DESC") {
+		t.Fatalf("SELECT perdeu a ordenação por updated_at")
+	}
+	if strings.Contains(censusListCountSQL, "LIMIT") {
+		t.Fatalf("COUNT não deve paginar: %s", censusListCountSQL)
+	}
+}
+
+// ─── Resumo dos cards — cenários 14 e 15 da task ─────────────────────────────
+
+// O resumo respeita os filtros globais: year incide sobre cr.year e os filtros
+// territoriais sobre schools s, nas duas partes da query (subquery de escolas e
+// contadores de censo).
+func TestCensusSummaryRespectsGlobalFilters(t *testing.T) {
+	mustContain := []string{
+		`($1 = 0 OR cr.year = $1)`,
+		`($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))`,
+		`($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))`,
+		`($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))`,
+		`UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))`,
+	}
+	for _, fragment := range mustContain {
+		if !strings.Contains(censusSummarySQL, fragment) {
+			t.Fatalf("censusSummarySQL não contém %q", fragment)
+		}
+	}
+	// Os filtros territoriais valem também para total_schools (subquery sobre
+	// schools, que conta escolas — não respostas de censo).
+	if strings.Count(censusSummarySQL, "UPPER(TRIM(s.dre)) = UPPER(TRIM($2))") != 2 {
+		t.Fatalf("filtro de DRE deve aparecer na subquery de escolas e nos contadores")
+	}
+	if !strings.Contains(censusSummarySQL, "(SELECT COUNT(*)\n\t\t FROM schools s") {
+		t.Fatalf("total_schools deve contar escolas (subquery em schools): %s", censusSummarySQL)
+	}
+}
+
+// O resumo NÃO é afetado por status/search/page/limit: a query usa só $1..$5
+// (filtros globais) e os status aparecem apenas como literais fixos dos cards.
+func TestCensusSummaryIgnoresLocalFilters(t *testing.T) {
+	for _, placeholder := range []string{"$6", "$7", "$8", "$9"} {
+		if strings.Contains(censusSummarySQL, placeholder) {
+			t.Fatalf("censusSummarySQL usa %s; resumo só recebe filtros globais", placeholder)
+		}
+	}
+	if strings.Contains(censusSummarySQL, "ILIKE") {
+		t.Fatalf("censusSummarySQL não deve ter busca textual")
+	}
+	if strings.Contains(censusSummarySQL, "LIMIT") {
+		t.Fatalf("censusSummarySQL não deve paginar")
+	}
+	args := censusListParams{
+		Status: "draft", Year: 2026, DRE: "BELEM", Municipio: "BELEM",
+		Zona: "Urbana", RegiaoIntegracao: "GUAJARA", Search: "x", Limit: 50, Page: 9,
+	}.summaryArgs()
+	want := []any{2026, "BELEM", "BELEM", "Urbana", "GUAJARA"}
+	if len(args) != len(want) {
+		t.Fatalf("summaryArgs = %v; want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("summaryArgs[%d] = %v; want %v", i, args[i], want[i])
+		}
+	}
+
+	mustContain := []string{
+		`COUNT(*) FILTER (WHERE cr.status = 'completed')`,
+		`COUNT(*) FILTER (WHERE cr.status = 'draft')`,
+		`COUNT(*) FILTER (WHERE cr.status = 'completed' AND cr.sheet_synced_at IS NULL)`,
+	}
+	for _, fragment := range mustContain {
+		if !strings.Contains(censusSummarySQL, fragment) {
+			t.Fatalf("censusSummarySQL não contém %q", fragment)
+		}
+	}
+}

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -31,7 +31,7 @@ import { AbaGestaoFinanceiraGovernanca } from "@/components/admin/AbaGestaoFinan
 import { AbaSaudeOperacionalEscolas } from "@/components/admin/AbaSaudeOperacionalEscolas";
 import { FiltrosGlobais } from "@/components/admin/FiltrosGlobais";
 import type {
-  CensusRow, CensusPage, DashboardData, DashboardFilters, FiltrosOpcoes,
+  CensusPage, DashboardData, DashboardFilters, FiltrosOpcoes,
 } from "@/components/admin/shared/types";
 
 // ─── Login ────────────────────────────────────────────────────────────────────
@@ -354,7 +354,6 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
   const [censusPage,     setCensusPage]     = useState<CensusPage | null>(null);
   const [tab,            setTab]            = useState<Tab>("perfil");
   const [filterStatus,   setFilterStatus]   = useState("");
-  const [filterDre,      setFilterDre]      = useState("");
   const [search,         setSearch]         = useState("");
   const [err,            setErr]            = useState("");
   const [loading,        setLoading]        = useState(true);
@@ -379,18 +378,32 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
     } finally { setLoading(false); }
   }, [token, logout]);
 
+  // Registros do Censo: filtros globais (ano, DRE, município, zona, Região de
+  // Integração) viram query params; status e busca textual são filtros locais
+  // da aba, mas a busca roda no backend (filtra todo o recorte, não só a página).
   const loadCensus = useCallback(async (limit = censusLimit, page = censusPageNum) => {
     const p = new URLSearchParams();
-    if (filterStatus) p.set("status", filterStatus);
-    if (filterDre) p.set("dre", filterDre);
+    if (filterStatus)              p.set("status", filterStatus);
+    if (filters.ano)               p.set("year", String(filters.ano));
+    if (filters.dre)               p.set("dre", filters.dre);
+    if (filters.municipio)         p.set("municipio", filters.municipio);
+    if (filters.zona)              p.set("zona", filters.zona);
+    if (filters.regiao_integracao) p.set("regiao_integracao", filters.regiao_integracao);
+    if (search)                    p.set("search", search);
     p.set("limit", String(limit));
     p.set("page", String(page));
     try { setCensusPage(await apiFetch<CensusPage>(`/v1/admin/census?${p}`, token)); }
     catch (e) { if ((e as Error).message === "UNAUTHORIZED") logout(); }
-  }, [token, filterStatus, filterDre, censusLimit, censusPageNum, logout]);
+  }, [token, filterStatus, filters, search, censusLimit, censusPageNum, logout]);
 
   useEffect(() => { loadDb(); }, [loadDb]);
-  useEffect(() => { if (tab === "census") loadCensus(); }, [tab, filterStatus, filterDre, censusLimit, censusPageNum, loadCensus]);
+  // Pequeno debounce: a busca textual agora dispara requisição ao backend e o
+  // timeout evita uma chamada por tecla digitada.
+  useEffect(() => {
+    if (tab !== "census") return;
+    const t = setTimeout(() => { loadCensus(); }, 300);
+    return () => clearTimeout(t);
+  }, [tab, loadCensus]);
   useEffect(() => {
     const qs = new URLSearchParams();
     if (filters.dre)               qs.set("dre", filters.dre);
@@ -418,15 +431,12 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
   const fmtDate = (iso: string) =>
     new Date(iso).toLocaleString("pt-BR", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" });
 
-  const match = (r: CensusRow, q: string) => {
-    const l = q.toLowerCase();
-    return r.nome_escola.toLowerCase().includes(l) || r.codigo_inep.includes(l) ||
-      r.municipio.toLowerCase().includes(l) || r.dre.toLowerCase().includes(l);
-  };
+  // Mudanças de recorte (filtros globais, status ou busca) voltam para a página 1.
+  const updateSearch = (s: string) => { setSearch(s); setCensusPageNum(1); };
+  const updateFilterStatus = (s: string) => { setFilterStatus(s); setCensusPageNum(1); };
+  const updateFilters = (f: DashboardFilters) => { setFilters(f); setCensusPageNum(1); };
 
-  const filteredCensus = (censusPage?.rows ?? []).filter((r) => !search || match(r, search));
-
-  const handleNav = (id: Tab) => { setTab(id); setSearch(""); setVisited((prev) => new Set([...prev, id])); setMobileNavOpen(false); };
+  const handleNav = (id: Tab) => { setTab(id); updateSearch(""); setVisited((prev) => new Set([...prev, id])); setMobileNavOpen(false); };
 
   const [dark, setDark] = useState<boolean>(() => {
     if (typeof window !== "undefined") {
@@ -525,7 +535,7 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
                 <input
                   placeholder="Buscar indicadores, escolas, DREs…"
                   value={search}
-                  onChange={(e) => setSearch(e.target.value)}
+                  onChange={(e) => updateSearch(e.target.value)}
                 />
                 <kbd>⌘ /</kbd>
               </div>
@@ -564,7 +574,7 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
             <FiltrosGlobais
               opcoes={filtrosOpcoes}
               filters={filters}
-              onFiltersChange={setFilters}
+              onFiltersChange={updateFilters}
             />
             {/* Renderiza todas as abas já visitadas. Quando volta para uma aba os dados já são carregados*/}
             {visited.has("perfil") && (
@@ -615,15 +625,11 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
 
             {tab === "census" && (
               <AbaTodosCensos
-                dbData={dbData}
                 censusPage={censusPage}
                 filterStatus={filterStatus}
-                setFilterStatus={setFilterStatus}
-                filterDre={filterDre}
-                setFilterDre={setFilterDre}
+                setFilterStatus={updateFilterStatus}
                 search={search}
-                setSearch={setSearch}
-                filteredCensus={filteredCensus}
+                setSearch={updateSearch}
                 censusLimit={censusLimit}
                 setCensusLimit={(l) => { setCensusLimit(l); setCensusPageNum(1); }}
                 censusPageNum={censusPageNum}

--- a/web/src/components/admin/AbaTodosCensos.tsx
+++ b/web/src/components/admin/AbaTodosCensos.tsx
@@ -6,20 +6,16 @@ import {
 import { CensusTable } from "./shared/CensusTable";
 import { StatCard } from "./shared/StatCard";
 import { sanitize } from "./shared/api";
-import type { CensusRow, CensusPage, DashboardData } from "./shared/types";
+import type { CensusPage } from "./shared/types";
 
 const PAGE_SIZE_OPTIONS = [10, 50, 100, 1000];
 
 export function AbaTodosCensos({
-  dbData,
   censusPage,
   filterStatus,
   setFilterStatus,
-  filterDre,
-  setFilterDre,
   search,
   setSearch,
-  filteredCensus,
   censusLimit,
   setCensusLimit,
   censusPageNum,
@@ -27,15 +23,11 @@ export function AbaTodosCensos({
   onView,
   formatDate,
 }: {
-  dbData: DashboardData | null;
   censusPage: CensusPage | null;
   filterStatus: string;
   setFilterStatus: (s: string) => void;
-  filterDre: string;
-  setFilterDre: (s: string) => void;
   search: string;
   setSearch: (s: string) => void;
-  filteredCensus: CensusRow[];
   censusLimit: number;
   setCensusLimit: (l: number) => void;
   censusPageNum: number;
@@ -47,16 +39,18 @@ export function AbaTodosCensos({
   const totalPages = Math.max(1, Math.ceil(total / censusLimit));
   const firstRow   = total === 0 ? 0 : (censusPageNum - 1) * censusLimit + 1;
   const lastRow    = Math.min(censusPageNum * censusLimit, total);
+  const summary    = censusPage?.summary;
 
   return (
     <div className="space-y-4">
-      {/* Cards de resumo */}
-      {dbData && (
+      {/* Cards de resumo — refletem o recorte dos filtros globais (summary),
+          sem serem afetados por status, busca ou paginação da listagem. */}
+      {summary && (
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 animate-fade-in-up">
-          <StatCard label="Escolas Cadastradas" value={dbData.total_schools}      Icon={Building2}    tone="blue"   />
-          <StatCard label="Censos Concluídos"   value={dbData.completed_censuses} Icon={CheckCircle2} tone="green"  />
-          <StatCard label="Rascunhos"            value={dbData.draft_censuses}     Icon={FileText}     tone="amber"  />
-          <StatCard label="Pendente na Planilha" value={dbData.pending_sync}       Icon={CloudUpload}  tone="orange" />
+          <StatCard label="Escolas Cadastradas" value={summary.total_schools}      Icon={Building2}    tone="blue"   />
+          <StatCard label="Censos Concluídos"   value={summary.completed_censuses} Icon={CheckCircle2} tone="green"  />
+          <StatCard label="Rascunhos"            value={summary.draft_censuses}     Icon={FileText}     tone="amber"  />
+          <StatCard label="Pendente na Planilha" value={summary.pending_sync}       Icon={CloudUpload}  tone="orange" />
         </div>
       )}
 
@@ -70,12 +64,6 @@ export function AbaTodosCensos({
           <option value="">Todos os status</option>
           <option value="completed">Concluído</option>
           <option value="draft">Rascunho</option>
-        </select>
-
-        <select value={filterDre} onChange={(e) => setFilterDre(e.target.value)}
-          className="border border-slate-300 bg-white rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 max-w-xs">
-          <option value="">Todas as DREs</option>
-          {(dbData?.by_dre ?? []).map((d) => <option key={d.dre} value={d.dre}>{d.dre}</option>)}
         </select>
 
         <div className="flex items-center gap-2 text-sm text-slate-600">
@@ -103,7 +91,7 @@ export function AbaTodosCensos({
         ? <div className="bg-white rounded-2xl py-14 text-center text-slate-400 text-sm border border-slate-200">
             <Loader2 className="animate-spin mx-auto mb-2" size={18} />Carregando…
           </div>
-        : <CensusTable rows={filteredCensus} onView={onView} formatDate={formatDate} />}
+        : <CensusTable rows={censusPage.rows} onView={onView} formatDate={formatDate} />}
 
       {/* Rodapé de paginação */}
       {censusPage !== null && (

--- a/web/src/components/admin/shared/types.ts
+++ b/web/src/components/admin/shared/types.ts
@@ -101,11 +101,22 @@ export interface CaracterizacaoInfraEducacionalPg {
 
 export interface CensusFull extends CensusRow { data: unknown; created_at: string; }
 
+// Resumo do recorte global da tela "Registros do Censo". Respeita os filtros
+// globais (year, dre, municipio, zona, regiao_integracao), mas não os filtros
+// locais da listagem (status, search, page, limit).
+export interface CensusSummary {
+  total_schools: number;
+  completed_censuses: number;
+  draft_censuses: number;
+  pending_sync: number;
+}
+
 export interface CensusPage {
   rows: CensusRow[];
   total: number;
   page: number;
   limit: number;
+  summary: CensusSummary;
 }
 
 // Frente 2 — Infraestrutura e Segurança.


### PR DESCRIPTION
## Resumo

Integra a tela **Registros do Censo** aos filtros globais do dashboard.

O endpoint `/v1/admin/census` passa a aceitar filtros por ano, DRE, município, zona e Região de Integração, além dos filtros locais de status, busca, limite e página.

## Ajustes

- Aplica filtros globais no backend.
- Garante que `COUNT` e listagem usem a mesma cláusula `WHERE`.
- Move a busca textual para o backend.
- Remove o filtro local de DRE da tela.
- Mantém status como filtro local.
- Adiciona `summary` filtrado ao payload.
- Faz os cards da aba usarem `censusPage.summary`.
- Reseta a página para 1 quando filtros globais, status ou busca mudam.
- Valida `limit` por whitelist: `10`, `50`, `100`, `1000`.

## Fora de escopo

Este PR não altera:

- Preenchimento por DRE;
- Saúde Operacional;
- FiltrosGlobais;
- cascata dos filtros globais;
- migrations;
- demais abas analíticas.

## Validações

- `go test ./cmd/api -run Census`: passou.
- `go test ./...`: passou.
- `go vet ./...`: passou.
- `npm run build`: passou.
- `npm run lint`: falha apenas por erros preexistentes fora dos arquivos alterados.
- Arquivos alterados neste PR: 0 erros de lint.

## Ressalvas

Não há teste de integração com PostgreSQL real nesta etapa. A validação de SQL foi feita por testes de helpers/shape/ordem de argumentos, seguindo o padrão já usado em Saúde Operacional.

Antes do merge, recomenda-se validar em homologação:

1. cards sem filtros contra os números atuais do dashboard;
2. recorte por DRE;
3. recorte por ano;
4. recorte por Região de Integração;
5. busca textual com paginação.