### PR TITLE
feat(dashboard): filtrar preenchimento por DRE

### DIFF
--- a/api/cmd/api/analytics_preenchimento.go
+++ b/api/cmd/api/analytics_preenchimento.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// PreenchimentoDreRow descreve o andamento do preenchimento do censo de uma DRE
+// dentro do recorte global: total de escolas, quantas concluíram, quantas estão
+// em rascunho, quantas ainda não têm censo no ano e o percentual de conclusão.
+type PreenchimentoDreRow struct {
+	DRE                  string `json:"dre"`
+	Total                int    `json:"total"`
+	Completed            int    `json:"completed"`
+	Draft                int    `json:"draft"`
+	Pending              int    `json:"pending"`
+	CompletionPercentage int    `json:"completion_percentage"`
+}
+
+// PreenchimentoDrePayload é a resposta do endpoint de andamento por DRE. Os
+// totais consolidam todas as DREs do recorte. ano_referencia ecoa o ano usado.
+type PreenchimentoDrePayload struct {
+	AnoReferencia  int                   `json:"ano_referencia"`
+	TotalEscolas   int                   `json:"total_escolas"`
+	TotalCompleted int                   `json:"total_completed"`
+	TotalDraft     int                   `json:"total_draft"`
+	TotalPending   int                   `json:"total_pending"`
+	DREs           []PreenchimentoDreRow `json:"dres"`
+}
+
+// preenchimentoDreFilters reúne os filtros globais do dashboard aplicados sobre
+// o cadastro de escolas (schools s). Strings vazias significam "filtro
+// desativado". O ano de referência segue a mesma regra dos demais endpoints
+// analíticos: usa o year enviado quando válido, senão o ano corrente.
+type preenchimentoDreFilters struct {
+	Year             int
+	DRE              string
+	Municipio        string
+	Zona             string
+	RegiaoIntegracao string
+}
+
+// parsePreenchimentoDreFilters lê os filtros globais da query string. Espaços em
+// branco são removidos (um valor só com espaços equivale a ausência de filtro).
+// O ano segue parseAnalyticsFilters: year inválido/ausente cai no ano corrente.
+func parsePreenchimentoDreFilters(q url.Values, now time.Time) preenchimentoDreFilters {
+	f := preenchimentoDreFilters{
+		Year:             now.Year(),
+		DRE:              strings.TrimSpace(q.Get("dre")),
+		Municipio:        strings.TrimSpace(q.Get("municipio")),
+		Zona:             strings.TrimSpace(q.Get("zona")),
+		RegiaoIntegracao: strings.TrimSpace(q.Get("regiao_integracao")),
+	}
+	if y, err := strconv.Atoi(strings.TrimSpace(q.Get("year"))); err == nil && y > 0 {
+		f.Year = y
+	}
+	return f
+}
+
+// preenchimentoDreSelectSQL agrega o andamento do preenchimento por DRE partindo
+// de schools s (não de census_responses), de modo que escolas sem censo no ano
+// permaneçam no recorte e sejam contadas como pendentes via LEFT JOIN.
+//
+// A CTE latest_census colapsa eventuais respostas duplicadas por escola/ano em
+// uma única linha (DISTINCT ON school_id, mantendo a mais recente). Há a
+// constraint unique_school_year que já garante unicidade; o DISTINCT ON é uma
+// salvaguarda defensiva caso isso mude.
+//
+// Os filtros globais incidem sobre schools s e por isso este endpoint NÃO
+// reutiliza AnalyticsFilters.WhereSQL(), que exige status = 'completed' AND
+// census_id IS NOT NULL — o que excluiria rascunhos e pendentes que precisamos
+// contar. A comparação usa UPPER(TRIM(...)) para tolerar caixa e espaços.
+const preenchimentoDreSelectSQL = `
+	WITH latest_census AS (
+		SELECT DISTINCT ON (school_id)
+			school_id,
+			status
+		FROM census_responses
+		WHERE year = $1
+		ORDER BY school_id, updated_at DESC, id DESC
+	)
+	SELECT
+		COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre,
+		COUNT(*) AS total,
+		COUNT(*) FILTER (WHERE cr.status = 'completed') AS completed,
+		COUNT(*) FILTER (WHERE cr.status = 'draft') AS draft
+	FROM schools s
+	LEFT JOIN latest_census cr ON cr.school_id = s.id
+	WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))
+	GROUP BY COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado')
+	ORDER BY dre
+`
+
+// buildPreenchimentoDreQuery devolve a query e os argumentos posicionais na
+// ordem esperada por preenchimentoDreSelectSQL: $1=year, $2=dre, $3=municipio,
+// $4=zona, $5=regiao_integracao.
+func buildPreenchimentoDreQuery(f preenchimentoDreFilters) (string, []any) {
+	return preenchimentoDreSelectSQL, []any{
+		f.Year,
+		f.DRE,
+		f.Municipio,
+		f.Zona,
+		f.RegiaoIntegracao,
+	}
+}
+
+// completionPercentage devolve o percentual inteiro de conclusão (completed /
+// total * 100), arredondado, espelhando o que a UI atual já faz com Math.round.
+// Retorna 0 quando não há escolas no recorte.
+func completionPercentage(completed, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	return int(math.Round(float64(completed) / float64(total) * 100))
+}
+
+// buildPreenchimentoDreRow monta uma linha do payload calculando pendentes e
+// percentual a partir dos totais agregados no banco.
+func buildPreenchimentoDreRow(dre string, total, completed, draft int) PreenchimentoDreRow {
+	pending := total - completed - draft
+	if pending < 0 {
+		pending = 0
+	}
+	return PreenchimentoDreRow{
+		DRE:                  dre,
+		Total:                total,
+		Completed:            completed,
+		Draft:                draft,
+		Pending:              pending,
+		CompletionPercentage: completionPercentage(completed, total),
+	}
+}
+
+// AdminAnalyticsPreenchimentoDre retorna o andamento do preenchimento do censo
+// por DRE, respeitando os filtros globais (year, dre, municipio, zona,
+// regiao_integracao). Recorte vazio devolve payload válido com totais zerados.
+func (app *application) AdminAnalyticsPreenchimentoDre(w http.ResponseWriter, r *http.Request) {
+	filters := parsePreenchimentoDreFilters(r.URL.Query(), time.Now())
+	query, args := buildPreenchimentoDreQuery(filters)
+
+	rows, err := app.models.Schools.DB.QueryContext(r.Context(), query, args...)
+	if err != nil {
+		app.errorJSON(w, fmt.Errorf("consultar preenchimento por DRE: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	payload := PreenchimentoDrePayload{
+		AnoReferencia: filters.Year,
+		DREs:          make([]PreenchimentoDreRow, 0),
+	}
+
+	for rows.Next() {
+		var dre string
+		var total, completed, draft int
+		if err := rows.Scan(&dre, &total, &completed, &draft); err != nil {
+			app.errorJSON(w, fmt.Errorf("ler linha de preenchimento por DRE: %v", err), http.StatusInternalServerError)
+			return
+		}
+		row := buildPreenchimentoDreRow(dre, total, completed, draft)
+		payload.DREs = append(payload.DREs, row)
+		payload.TotalEscolas += row.Total
+		payload.TotalCompleted += row.Completed
+		payload.TotalDraft += row.Draft
+		payload.TotalPending += row.Pending
+	}
+	if err := rows.Err(); err != nil {
+		app.errorJSON(w, fmt.Errorf("iterar preenchimento por DRE: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: payload})
+}

--- a/api/cmd/api/analytics_preenchimento_test.go
+++ b/api/cmd/api/analytics_preenchimento_test.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPreenchimentoParseFiltersDefaultYear cobre o ano padrão: ausente ou
+// inválido cai no ano corrente (mesma regra de parseAnalyticsFilters).
+func TestPreenchimentoParseFiltersDefaultYear(t *testing.T) {
+	now := time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC)
+
+	t.Run("year ausente usa ano corrente", func(t *testing.T) {
+		got := parsePreenchimentoDreFilters(url.Values{}, now)
+		if got.Year != 2026 {
+			t.Fatalf("year = %d; want 2026 (ano corrente)", got.Year)
+		}
+	})
+
+	for _, invalid := range []string{"", "abc", "0", "-5", "  "} {
+		t.Run("year invalido "+invalid, func(t *testing.T) {
+			q := url.Values{"year": {invalid}}
+			got := parsePreenchimentoDreFilters(q, now)
+			if got.Year != 2026 {
+				t.Fatalf("year inválido %q = %d; want 2026 (ano corrente)", invalid, got.Year)
+			}
+		})
+	}
+}
+
+// TestPreenchimentoParseFiltersValidYear garante que um year válido é usado.
+func TestPreenchimentoParseFiltersValidYear(t *testing.T) {
+	now := time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC)
+	got := parsePreenchimentoDreFilters(url.Values{"year": {"2025"}}, now)
+	if got.Year != 2025 {
+		t.Fatalf("year = %d; want 2025", got.Year)
+	}
+	// Espaços ao redor do year são tolerados.
+	got = parsePreenchimentoDreFilters(url.Values{"year": {" 2024 "}}, now)
+	if got.Year != 2024 {
+		t.Fatalf("year com espaços = %d; want 2024", got.Year)
+	}
+}
+
+// TestPreenchimentoParseFiltersStrings cobre a leitura dos filtros globais
+// textuais: valores são lidos, espaços removidos e ausência vira string vazia.
+func TestPreenchimentoParseFiltersStrings(t *testing.T) {
+	now := time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC)
+
+	t.Run("todos preenchidos", func(t *testing.T) {
+		q := url.Values{
+			"dre":               {"CASTANHAL"},
+			"municipio":         {"BELEM"},
+			"zona":              {"Urbana"},
+			"regiao_integracao": {"GUAJARA"},
+		}
+		got := parsePreenchimentoDreFilters(q, now)
+		if got.DRE != "CASTANHAL" || got.Municipio != "BELEM" ||
+			got.Zona != "Urbana" || got.RegiaoIntegracao != "GUAJARA" {
+			t.Fatalf("parsePreenchimentoDreFilters = %+v; filtros não lidos", got)
+		}
+	})
+
+	t.Run("ausentes viram vazio", func(t *testing.T) {
+		got := parsePreenchimentoDreFilters(url.Values{}, now)
+		if got.DRE != "" || got.Municipio != "" || got.Zona != "" || got.RegiaoIntegracao != "" {
+			t.Fatalf("filtros ausentes = %+v; want strings vazias", got)
+		}
+	})
+
+	t.Run("espacos sao removidos (filtro desativado)", func(t *testing.T) {
+		q := url.Values{
+			"dre":               {"  "},
+			"municipio":         {"  Castanhal  "},
+			"zona":              {""},
+			"regiao_integracao": {"\t"},
+		}
+		got := parsePreenchimentoDreFilters(q, now)
+		if got.DRE != "" || got.Municipio != "Castanhal" || got.Zona != "" || got.RegiaoIntegracao != "" {
+			t.Fatalf("filtros com espaços = %+v; want apenas municipio=Castanhal", got)
+		}
+	})
+}
+
+// TestPreenchimentoBuildQueryArgs garante que cada filtro global é posicionado
+// no argumento correto ($1=year, $2=dre, $3=municipio, $4=zona,
+// $5=regiao_integracao) e combinado por AND sobre schools s.
+func TestPreenchimentoBuildQueryArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters preenchimentoDreFilters
+		want    []any
+	}{
+		{
+			name:    "sem filtros",
+			filters: preenchimentoDreFilters{Year: 2026},
+			want:    []any{2026, "", "", "", ""},
+		},
+		{
+			name:    "filtro por dre",
+			filters: preenchimentoDreFilters{Year: 2026, DRE: "CASTANHAL"},
+			want:    []any{2026, "CASTANHAL", "", "", ""},
+		},
+		{
+			name:    "filtro por municipio",
+			filters: preenchimentoDreFilters{Year: 2026, Municipio: "BELEM"},
+			want:    []any{2026, "", "BELEM", "", ""},
+		},
+		{
+			name:    "filtro por zona",
+			filters: preenchimentoDreFilters{Year: 2026, Zona: "Urbana"},
+			want:    []any{2026, "", "", "Urbana", ""},
+		},
+		{
+			name:    "filtro por regiao_integracao",
+			filters: preenchimentoDreFilters{Year: 2026, RegiaoIntegracao: "GUAJARA"},
+			want:    []any{2026, "", "", "", "GUAJARA"},
+		},
+		{
+			name: "multiplos filtros combinados por AND",
+			filters: preenchimentoDreFilters{
+				Year:             2025,
+				DRE:              "BELEM",
+				Municipio:        "BELEM",
+				Zona:             "Urbana",
+				RegiaoIntegracao: "GUAJARA",
+			},
+			want: []any{2025, "BELEM", "BELEM", "Urbana", "GUAJARA"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, args := buildPreenchimentoDreQuery(tt.filters)
+			if len(args) != len(tt.want) {
+				t.Fatalf("args = %v; want %v", args, tt.want)
+			}
+			for i := range tt.want {
+				if args[i] != tt.want[i] {
+					t.Fatalf("args[%d] = %v; want %v (args=%v)", i, args[i], tt.want[i], args)
+				}
+			}
+			if query != preenchimentoDreSelectSQL {
+				t.Fatalf("query difere de preenchimentoDreSelectSQL")
+			}
+		})
+	}
+}
+
+// TestPreenchimentoQueryShape valida o formato da query: parte de schools s, usa
+// LEFT JOIN, limita census_responses ao ano, conta completed e draft, agrupa por
+// DRE com fallback "Não informado", combina filtros por AND e usa DISTINCT ON
+// como salvaguarda contra múltiplos censos por escola/ano. Não pode exigir
+// status='completed' no WHERE geral nem census_id IS NOT NULL.
+func TestPreenchimentoQueryShape(t *testing.T) {
+	query := preenchimentoDreSelectSQL
+
+	mustContain := []string{
+		"FROM schools s",
+		"LEFT JOIN latest_census cr",
+		"FROM census_responses",
+		"WHERE year = $1",
+		"DISTINCT ON (school_id)",
+		"FILTER (WHERE cr.status = 'completed')",
+		"FILTER (WHERE cr.status = 'draft')",
+		"COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado')",
+		"($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))",
+		"($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))",
+		"($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))",
+		"FROM reg_integracao",
+		"UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))",
+	}
+	for _, fragment := range mustContain {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("query não contém %q", fragment)
+		}
+	}
+
+	// O LEFT JOIN deve ser preservado: escolas sem censo continuam no recorte.
+	if strings.Contains(query, "INNER JOIN") {
+		t.Fatalf("query usa INNER JOIN; o LEFT JOIN deve ser preservado")
+	}
+	// O WHERE geral não pode restringir o universo a censos concluídos nem exigir
+	// census_id — isso eliminaria rascunhos e pendentes que precisamos contar.
+	if strings.Contains(query, "s.status = 'completed'") ||
+		strings.Contains(query, "AND status = 'completed'") {
+		t.Fatalf("query exige status='completed' no WHERE geral; rascunhos/pendentes seriam excluídos")
+	}
+	if strings.Contains(query, "census_id IS NOT NULL") {
+		t.Fatalf("query exige census_id IS NOT NULL; escolas sem censo seriam excluídas")
+	}
+
+	// Os filtros globais devem estar sob a mesma cláusula WHERE (combinados por AND).
+	if strings.Count(query, " AND ($") < 3 {
+		t.Fatalf("filtros globais não parecem combinados por AND: %s", query)
+	}
+}
+
+// TestPreenchimentoDoesNotUseAnalyticsWhereSQL garante, de forma defensiva, que
+// este endpoint não reutiliza o WHERE de AnalyticsFilters, que exige
+// status='completed' AND census_id IS NOT NULL.
+func TestPreenchimentoDoesNotUseAnalyticsWhereSQL(t *testing.T) {
+	if strings.Contains(preenchimentoDreSelectSQL, (AnalyticsFilters{}).WhereSQL()) {
+		t.Fatalf("preenchimentoDreSelectSQL reutiliza AnalyticsFilters.WhereSQL(); use WHERE próprio")
+	}
+}
+
+// TestPreenchimentoCompletionPercentage cobre o cálculo do percentual inteiro.
+func TestPreenchimentoCompletionPercentage(t *testing.T) {
+	tests := []struct {
+		name      string
+		completed int
+		total     int
+		want      int
+	}{
+		{"recorte vazio", 0, 0, 0},
+		{"metade", 5, 10, 50},
+		{"tudo concluido", 10, 10, 100},
+		{"nada concluido", 0, 10, 0},
+		{"arredonda para cima", 2, 3, 67},
+		{"arredonda para baixo", 1, 3, 33},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := completionPercentage(tt.completed, tt.total); got != tt.want {
+				t.Fatalf("completionPercentage(%d, %d) = %d; want %d", tt.completed, tt.total, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPreenchimentoBuildRow cobre o cálculo de pendentes e percentual por linha:
+// pending = total - completed - draft.
+func TestPreenchimentoBuildRow(t *testing.T) {
+	t.Run("conta completed, draft e pending", func(t *testing.T) {
+		row := buildPreenchimentoDreRow("CASTANHAL", 10, 4, 3)
+		if row.DRE != "CASTANHAL" {
+			t.Fatalf("dre = %q; want CASTANHAL", row.DRE)
+		}
+		if row.Total != 10 || row.Completed != 4 || row.Draft != 3 {
+			t.Fatalf("contagens = %+v; want total=10 completed=4 draft=3", row)
+		}
+		if row.Pending != 3 {
+			t.Fatalf("pending = %d; want 3 (10-4-3)", row.Pending)
+		}
+		if row.CompletionPercentage != 40 {
+			t.Fatalf("completion_percentage = %d; want 40", row.CompletionPercentage)
+		}
+	})
+
+	t.Run("pending nunca fica negativo", func(t *testing.T) {
+		// Defensivo: se as contagens forem inconsistentes, pending não fica < 0.
+		row := buildPreenchimentoDreRow("X", 2, 2, 1)
+		if row.Pending != 0 {
+			t.Fatalf("pending = %d; want 0 (clamp em zero)", row.Pending)
+		}
+	})
+
+	t.Run("escola sem censo conta como pendente", func(t *testing.T) {
+		row := buildPreenchimentoDreRow("Y", 5, 0, 0)
+		if row.Pending != 5 || row.CompletionPercentage != 0 {
+			t.Fatalf("row = %+v; want pending=5 e 0%%", row)
+		}
+	})
+}

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -366,6 +366,9 @@ func (app *application) routes() http.Handler {
 			protected.Get("/admin/analytics/servicos-terceirizados/manipuladores-alimentos", app.AdminAnalyticsServicosManipuladoresAlimentos)
 			protected.Get("/admin/analytics/escolas/saude-operacional", app.AdminAnalyticsSaudeOperacionalEscolas)
 
+			// Andamento do preenchimento do censo por DRE.
+			protected.Get("/admin/analytics/preenchimento/dre", app.AdminAnalyticsPreenchimentoDre)
+
 			// Filtros globais do dashboard.
 			protected.Get("/admin/analytics/filtros/opcoes", app.AdminAnalyticsFiltrosOpcoes)
 		})

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -350,7 +350,6 @@ function NavGroup({
 }
 
 function Dashboard({ token, onLogout }: { token: string; onLogout: () => void }) {
-  const [dbData,         setDbData]         = useState<DashboardData | null>(null);
   const [censusPage,     setCensusPage]     = useState<CensusPage | null>(null);
   const [tab,            setTab]            = useState<Tab>("perfil");
   const [filterStatus,   setFilterStatus]   = useState("");
@@ -369,9 +368,13 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
 
   const logout = useCallback(() => { clearToken(); clearApiCache(); onLogout(); }, [onLogout]);
 
+  // O endpoint legado /v1/admin/dashboard segue sendo consultado para gatear o
+  // estado de carregamento/erro do painel operacional. O payload (incl. by_dre)
+  // não é mais armazenado no cliente: a aba "Preenchimento por DRE" agora usa o
+  // endpoint analítico próprio /v1/admin/analytics/preenchimento/dre.
   const loadDb = useCallback(async () => {
     try {
-      setDbData(await apiFetch<DashboardData>("/v1/admin/dashboard", token));
+      await apiFetch<DashboardData>("/v1/admin/dashboard", token);
     } catch (e) {
       if ((e as Error).message === "UNAUTHORIZED") { logout(); return; }
       setErr("Erro ao carregar painel operacional.");
@@ -639,8 +642,10 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
               />
             )}
 
-            {tab === "dre" && dbData && (
-              <AbaPorDre dbData={dbData} />
+            {visited.has("dre") && (
+              <div style={{ display: tab === "dre" ? undefined : "none" }}>
+                <AbaPorDre token={token} onUnauth={logout} filters={filters} />
+              </div>
             )}
           </div>
 

--- a/web/src/components/admin/AbaPorDre.tsx
+++ b/web/src/components/admin/AbaPorDre.tsx
@@ -1,48 +1,137 @@
-import React from "react";
-import { MapPinned } from "lucide-react";
-import { C } from "./shared/constants";
-import type { DashboardData } from "./shared/types";
+"use client";
 
-export function AbaPorDre({ dbData }: { dbData: DashboardData }) {
+import React, { useEffect, useState } from "react";
+import { AlertCircle, Loader2, MapPinned } from "lucide-react";
+import { apiFetch } from "./shared/api";
+import { C } from "./shared/constants";
+import type { DashboardFilters, PreenchimentoDrePayload } from "./shared/types";
+
+const ENDPOINT_BASE = "/v1/admin/analytics/preenchimento/dre";
+// Temporário: o dashboard atual está fixado no ciclo do Censo Escolar 2026.
+const DASHBOARD_REFERENCE_YEAR = 2026;
+
+function buildEndpoint(filters?: DashboardFilters): string {
+  const params = new URLSearchParams({
+    year: String(filters?.ano ?? DASHBOARD_REFERENCE_YEAR),
+  });
+  if (filters?.dre)               params.set("dre", filters.dre);
+  if (filters?.municipio)         params.set("municipio", filters.municipio);
+  if (filters?.zona)              params.set("zona", filters.zona);
+  if (filters?.regiao_integracao) params.set("regiao_integracao", filters.regiao_integracao);
+  return `${ENDPOINT_BASE}?${params.toString()}`;
+}
+
+export function AbaPorDre({
+  token,
+  onUnauth,
+  filters,
+}: {
+  token: string;
+  onUnauth: () => void;
+  filters?: DashboardFilters;
+}) {
+  const [payload, setPayload] = useState<PreenchimentoDrePayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    apiFetch<PreenchimentoDrePayload>(buildEndpoint(filters), token)
+      .then((data) => {
+        if (!cancelled) {
+          setPayload(data);
+          setError("");
+        }
+      })
+      .catch((requestError: unknown) => {
+        const message = (requestError as Error).message;
+        if (message === "UNAUTHORIZED") {
+          if (!cancelled) onUnauth();
+          return;
+        }
+        if (!cancelled) setError(message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, onUnauth, filters]);
+
+  if (loading && payload === null) {
+    return (
+      <div className="flex items-center justify-center py-24 text-slate-400">
+        <Loader2 className="mr-2 animate-spin" size={22} style={{ color: C.primary }} />
+        Carregando andamento por DRE…
+      </div>
+    );
+  }
+
+  if (payload === null) {
+    return (
+      <div className="flex items-start gap-2 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+        <AlertCircle size={16} className="mt-0.5 shrink-0" />
+        {error || "Não foi possível carregar o andamento do preenchimento por DRE."}
+      </div>
+    );
+  }
+
   return (
     <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm animate-fade-in-up">
       <div className="px-6 py-4 border-b flex items-start gap-2" style={{ background: C.primaryLight }}>
         <MapPinned size={16} style={{ color: C.primary }} className="mt-0.5 shrink-0" />
         <div>
           <h2 className="font-semibold text-slate-800 text-sm">Andamento do Preenchimento por Diretoria Regional de Ensino</h2>
-          <p className="text-xs text-slate-500 mt-0.5">Percentual de escolas com censo concluído ou em rascunho, agrupado por DRE.</p>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Percentual de escolas com censo concluído no ano {payload.ano_referencia}, agrupado por DRE e respeitando os filtros globais.
+          </p>
         </div>
       </div>
-      <table className="w-full text-sm">
-        <thead className="bg-slate-50 border-b border-slate-200">
-          <tr>
-            {["DRE","Total","Concluídos","Rascunhos","% Conclusão"].map((h, i) => (
-              <th key={i} className={`px-5 py-3 font-semibold text-slate-600 text-xs uppercase tracking-wide ${i===0?"text-left":"text-center"}`}>{h}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {dbData.by_dre.map((d, i) => {
-            const pct = d.total > 0 ? Math.round((d.completed / d.total) * 100) : 0;
-            return (
-              <tr key={d.dre} className={`transition-colors hover:bg-blue-50/40 ${i%2===0?"bg-white":"bg-slate-50/50"}`}>
-                <td className="px-5 py-3 font-medium text-slate-800">{d.dre}</td>
-                <td className="px-5 py-3 text-center text-slate-600 tabular-nums">{d.total}</td>
-                <td className="px-5 py-3 text-center text-emerald-700 font-semibold tabular-nums">{d.completed}</td>
-                <td className="px-5 py-3 text-center text-amber-600 tabular-nums">{d.draft}</td>
-                <td className="px-5 py-3">
-                  <div className="flex items-center gap-3">
-                    <div className="flex-1 h-2.5 bg-slate-100 rounded-full overflow-hidden">
-                      <div className="h-full rounded-full transition-all duration-500" style={{ width: `${pct}%`, background: C.primary }} />
+
+      {payload.dres.length === 0 ? (
+        <div className="px-6 py-16 text-center">
+          <MapPinned size={28} className="mx-auto mb-3 text-slate-300" />
+          <p className="text-sm font-medium text-slate-600">Nenhuma escola no recorte atual.</p>
+          <p className="mt-1 text-xs text-slate-400">
+            Ajuste os filtros globais para visualizar o andamento por DRE.
+          </p>
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 border-b border-slate-200">
+            <tr>
+              {["DRE", "Total", "Concluídos", "Rascunhos", "Pendentes", "% Conclusão"].map((h, i) => (
+                <th key={i} className={`px-5 py-3 font-semibold text-slate-600 text-xs uppercase tracking-wide ${i === 0 ? "text-left" : "text-center"}`}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {payload.dres.map((d, i) => {
+              const pct = d.completion_percentage;
+              return (
+                <tr key={d.dre} className={`transition-colors hover:bg-blue-50/40 ${i % 2 === 0 ? "bg-white" : "bg-slate-50/50"}`}>
+                  <td className="px-5 py-3 font-medium text-slate-800">{d.dre}</td>
+                  <td className="px-5 py-3 text-center text-slate-600 tabular-nums">{d.total}</td>
+                  <td className="px-5 py-3 text-center text-emerald-700 font-semibold tabular-nums">{d.completed}</td>
+                  <td className="px-5 py-3 text-center text-amber-600 tabular-nums">{d.draft}</td>
+                  <td className="px-5 py-3 text-center text-slate-500 tabular-nums">{d.pending}</td>
+                  <td className="px-5 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1 h-2.5 bg-slate-100 rounded-full overflow-hidden">
+                        <div className="h-full rounded-full transition-all duration-500" style={{ width: `${pct}%`, background: C.primary }} />
+                      </div>
+                      <span className="text-xs font-bold text-slate-700 w-10 text-right tabular-nums">{pct}%</span>
                     </div>
-                    <span className="text-xs font-bold text-slate-700 w-10 text-right tabular-nums">{pct}%</span>
-                  </div>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/web/src/components/admin/shared/types.ts
+++ b/web/src/components/admin/shared/types.ts
@@ -466,6 +466,28 @@ export interface SaudeOperacionalPayload {
   escolas: SaudeOperacionalEscola[];
 }
 
+// Andamento do preenchimento do censo por DRE.
+// Payload de /v1/admin/analytics/preenchimento/dre. Respeita os filtros globais
+// (year, dre, municipio, zona, regiao_integracao). pending = total sem censo no
+// ano (total - completed - draft).
+export interface PreenchimentoDreRow {
+  dre: string;
+  total: number;
+  completed: number;
+  draft: number;
+  pending: number;
+  completion_percentage: number;
+}
+
+export interface PreenchimentoDrePayload {
+  ano_referencia: number;
+  total_escolas: number;
+  total_completed: number;
+  total_draft: number;
+  total_pending: number;
+  dres: PreenchimentoDreRow[];
+}
+
 // Estado global de filtros do dashboard.
 // Passado para cada aba e repassado como query params para os endpoints analíticos.
 export interface DashboardFilters {


### PR DESCRIPTION
## Resumo

Cria um endpoint analítico próprio para a tela **Preenchimento por DRE** e integra a aba aos filtros globais do dashboard.

## Ajustes

- Cria `GET /v1/admin/analytics/preenchimento/dre`.
- Registra a rota no grupo protegido por JWT.
- Aplica filtros globais:
  - ano;
  - DRE;
  - município;
  - zona;
  - Região de Integração.
- Calcula por DRE:
  - total de escolas;
  - censos concluídos;
  - rascunhos;
  - pendentes;
  - percentual de conclusão.
- Parte de `schools` e usa `LEFT JOIN` para preservar escolas sem censo.
- Usa `DISTINCT ON (school_id)` como proteção defensiva contra múltiplas respostas por escola/ano.
- Migra `AbaPorDre` para fetch próprio.
- Adiciona loading, erro, estado vazio e coluna `Pendentes`.
- Remove a dependência de `dbData.by_dre` na tela.

## Fora de escopo

Este PR não altera:

- Registros do Censo;
- Saúde Operacional;
- FiltrosGlobais;
- cascata dos filtros;
- migrations;
- `/dashboard`;
- `dbData.by_dre` no backend;
- demais abas analíticas.

## Validações

- `go test ./cmd/api -run Preenchimento`: passou.
- `go test ./...`: passou.
- `go vet ./...`: passou.
- `npm run build`: passou.
- `npm run lint`: falha apenas por erros preexistentes fora dos arquivos alterados.
- Arquivos alterados: 0 erros de lint.

## Ressalvas

Não há teste de integração com PostgreSQL real nesta etapa. Os testes cobrem parsing, shape SQL, ordem dos argumentos e helpers de cálculo, seguindo o padrão já adotado em outras frentes analíticas.

Recomenda-se validar em homologação:

1. sem filtros globais;
2. por DRE;
3. por município;
4. por Região de Integração;
5. por ano;
6. escola sem censo aparecendo como pendente.