### PR TITLE
fix(api): padronizar normalizacao dos filtros analiticos

### DIFF
--- a/api/cmd/api/analytics_filtros.go
+++ b/api/cmd/api/analytics_filtros.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -20,15 +22,22 @@ type AnalyticsFilters struct {
 }
 
 func parseAnalyticsFilters(r *http.Request) AnalyticsFilters {
-	qs := r.URL.Query()
+	return parseAnalyticsFiltersFromValues(r.URL.Query(), time.Now())
+}
+
+// parseAnalyticsFiltersFromValues is the testable core of parseAnalyticsFilters.
+// Textual filters are trimmed of surrounding whitespace; absent filters become
+// "". Year falls back to now.Year() when missing, blank, non-numeric, zero or
+// negative.
+func parseAnalyticsFiltersFromValues(q url.Values, now time.Time) AnalyticsFilters {
 	f := AnalyticsFilters{
-		Year:             time.Now().Year(),
-		DRE:              qs.Get("dre"),
-		Municipio:        qs.Get("municipio"),
-		Zona:             qs.Get("zona"),
-		RegiaoIntegracao: qs.Get("regiao_integracao"),
+		Year:             now.Year(),
+		DRE:              strings.TrimSpace(q.Get("dre")),
+		Municipio:        strings.TrimSpace(q.Get("municipio")),
+		Zona:             strings.TrimSpace(q.Get("zona")),
+		RegiaoIntegracao: strings.TrimSpace(q.Get("regiao_integracao")),
 	}
-	if y, err := strconv.Atoi(qs.Get("year")); err == nil && y > 0 {
+	if y, err := strconv.Atoi(strings.TrimSpace(q.Get("year"))); err == nil && y > 0 {
 		f.Year = y
 	}
 	return f
@@ -42,10 +51,14 @@ func (f AnalyticsFilters) WhereSQL() string {
 	return `status = 'completed'
       AND year = $1
       AND census_id IS NOT NULL
-      AND ($2 = '' OR dre = $2)
-      AND ($3 = '' OR municipio = $3)
-      AND ($4 = '' OR zona = $4)
-      AND ($5 = '' OR municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $5))`
+      AND ($2 = '' OR UPPER(TRIM(dre)) = UPPER(TRIM($2)))
+      AND ($3 = '' OR UPPER(TRIM(municipio)) = UPPER(TRIM($3)))
+      AND ($4 = '' OR UPPER(TRIM(zona)) = UPPER(TRIM($4)))
+      AND ($5 = '' OR UPPER(TRIM(municipio)) IN (
+        SELECT UPPER(TRIM(municipio))
+        FROM reg_integracao
+        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+      ))`
 }
 
 // Args returns the five positional arguments that match WhereSQL in order.

--- a/api/cmd/api/analytics_filtros_test.go
+++ b/api/cmd/api/analytics_filtros_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+var fixedNow = time.Date(2025, time.March, 15, 10, 0, 0, 0, time.UTC)
+
+func TestParseAnalyticsFilters_YearMissingUsesCurrent(t *testing.T) {
+	q := url.Values{}
+	f := parseAnalyticsFiltersFromValues(q, fixedNow)
+	if f.Year != fixedNow.Year() {
+		t.Fatalf("expected year %d, got %d", fixedNow.Year(), f.Year)
+	}
+}
+
+func TestParseAnalyticsFilters_YearInvalidUsesCurrent(t *testing.T) {
+	cases := []string{"abc", "0", "-5", "   ", ""}
+	for _, c := range cases {
+		q := url.Values{"year": {c}}
+		f := parseAnalyticsFiltersFromValues(q, fixedNow)
+		if f.Year != fixedNow.Year() {
+			t.Fatalf("year %q: expected fallback %d, got %d", c, fixedNow.Year(), f.Year)
+		}
+	}
+}
+
+func TestParseAnalyticsFilters_YearValidWithSpaces(t *testing.T) {
+	q := url.Values{"year": {"  2024  "}}
+	f := parseAnalyticsFiltersFromValues(q, fixedNow)
+	if f.Year != 2024 {
+		t.Fatalf("expected year 2024, got %d", f.Year)
+	}
+}
+
+func TestParseAnalyticsFilters_TextualFiltersTrimmed(t *testing.T) {
+	q := url.Values{
+		"dre":               {"  DRE Belém  "},
+		"municipio":         {"  Belém "},
+		"zona":              {" Urbana "},
+		"regiao_integracao": {"  Metropolitana "},
+	}
+	f := parseAnalyticsFiltersFromValues(q, fixedNow)
+	if f.DRE != "DRE Belém" {
+		t.Fatalf("dre not trimmed: %q", f.DRE)
+	}
+	if f.Municipio != "Belém" {
+		t.Fatalf("municipio not trimmed: %q", f.Municipio)
+	}
+	if f.Zona != "Urbana" {
+		t.Fatalf("zona not trimmed: %q", f.Zona)
+	}
+	if f.RegiaoIntegracao != "Metropolitana" {
+		t.Fatalf("regiao_integracao not trimmed: %q", f.RegiaoIntegracao)
+	}
+}
+
+func TestParseAnalyticsFilters_AbsentFiltersEmpty(t *testing.T) {
+	q := url.Values{}
+	f := parseAnalyticsFiltersFromValues(q, fixedNow)
+	if f.DRE != "" || f.Municipio != "" || f.Zona != "" || f.RegiaoIntegracao != "" {
+		t.Fatalf("expected empty textual filters, got %+v", f)
+	}
+}
+
+func TestAnalyticsFilters_ArgsOrder(t *testing.T) {
+	f := AnalyticsFilters{
+		Year:             2024,
+		DRE:              "d",
+		Municipio:        "m",
+		Zona:             "z",
+		RegiaoIntegracao: "r",
+	}
+	args := f.Args()
+	if len(args) != 5 {
+		t.Fatalf("expected 5 args, got %d", len(args))
+	}
+	want := []any{2024, "d", "m", "z", "r"}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("arg %d: expected %v, got %v", i, want[i], args[i])
+		}
+	}
+}
+
+func TestAnalyticsFilters_WhereSQL(t *testing.T) {
+	sql := AnalyticsFilters{}.WhereSQL()
+	mustContain := []string{
+		"status = 'completed'",
+		"year = $1",
+		"census_id IS NOT NULL",
+		"UPPER(TRIM(dre)) = UPPER(TRIM($2))",
+		"UPPER(TRIM(municipio)) = UPPER(TRIM($3))",
+		"UPPER(TRIM(zona)) = UPPER(TRIM($4))",
+		"UPPER(TRIM(municipio)) IN",
+		"UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(sql, frag) {
+			t.Fatalf("WhereSQL missing %q\n--- got ---\n%s", frag, sql)
+		}
+	}
+}


### PR DESCRIPTION
Padroniza o parsing e a comparação dos filtros analíticos compartilhados no backend.

Ajusta parseAnalyticsFilters para aparar espaços em year, dre, municipio, zona e regiao_integracao, mantendo fallback para o ano corrente quando o year estiver ausente ou inválido.

Atualiza AnalyticsFilters.WhereSQL para usar UPPER(TRIM(...)) nas comparações textuais de DRE, município, zona e Região de Integração, preservando as regras de status='completed', year=$1 e census_id IS NOT NULL.

Adiciona testes unitários para validar fallback de ano, normalização dos filtros textuais, ordem dos argumentos e presença das cláusulas essenciais no SQL.

Escopo restrito ao helper analítico compartilhado; não altera frontend, migrations, Saúde Operacional, Preenchimento por DRE, Perfil dos Alunos, Indicadores_Flags ou Google Sheets.