### PR TITLE
fix(admin): ajustar labels de ano nas fontes das abas

### DIFF
--- a/web/src/components/admin/AbaCaracterizacao.tsx
+++ b/web/src/components/admin/AbaCaracterizacao.tsx
@@ -7,6 +7,7 @@ import {
   LayoutGrid, ShieldCheck, Info, X,
 } from "lucide-react";
 import { apiFetch, getCached, allCached } from "./shared/api";
+import { buildPostgresSourceLabel } from "./shared/sourceLabel";
 import { C, PORTE_COLORS, ZONA_COLORS } from "./shared/constants";
 import { StatCard } from "./shared/StatCard";
 import { Donut, PieChart } from "./shared/Donut";
@@ -195,7 +196,7 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
   // falha vira "Sheets fallback (parcial)" para deixar claro ao operador
   // que parte da aba está lendo do legado.
   const sourceLabel =
-    usePerfilPg && useDrePg ? "PostgreSQL · ano corrente · censos concluídos"
+    usePerfilPg && useDrePg ? buildPostgresSourceLabel(filters)
       : !usePerfilPg && !useDrePg ? "Google Sheets · fallback"
         : "Google Sheets · fallback (parcial)";
   const sourceTone = usePerfilPg && useDrePg ? "emerald" : "amber";

--- a/web/src/components/admin/AbaInfraestruturaSeguranca.tsx
+++ b/web/src/components/admin/AbaInfraestruturaSeguranca.tsx
@@ -14,6 +14,7 @@ import { HBarChart } from "./shared/BarChart";
 import type {
   InfraCondicoes, InfraSeguranca, InfraEnergia, DashboardFilters,
 } from "./shared/types";
+import { buildPostgresSourceLabel } from "./shared/sourceLabel";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -136,7 +137,7 @@ export function AbaInfraestruturaSeguranca({
       {/* Badge de fonte */}
       <div className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: PostgreSQL · ano corrente · censos concluídos</span>
+        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* Banners de erro parcial */}

--- a/web/src/components/admin/AbaMerenda.tsx
+++ b/web/src/components/admin/AbaMerenda.tsx
@@ -16,6 +16,7 @@ import type {
   MerendaOferta, MerendaEquipamentos, EquipTotais,
   MerendaCondicoesSanitarias, DashboardFilters,
 } from "./shared/types";
+import { buildPostgresSourceLabel } from "./shared/sourceLabel";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -329,7 +330,7 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
       {/* Badge de fonte */}
       <div className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: PostgreSQL · ano corrente · censos concluídos</span>
+        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* Banners de erro parcial */}

--- a/web/src/components/admin/AbaPessoalGestao.tsx
+++ b/web/src/components/admin/AbaPessoalGestao.tsx
@@ -13,6 +13,7 @@ import { HBarChart } from "./shared/BarChart";
 import type {
   PessoalEstrutura, PessoalCoordenacao, QuadroPessoal, DashboardFilters,
 } from "./shared/types";
+import { buildPostgresSourceLabel } from "./shared/sourceLabel";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -149,7 +150,7 @@ export function AbaPessoalGestao({
       {/* Badge de fonte */}
       <div className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: PostgreSQL · ano corrente · censos concluídos</span>
+        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* ── Estrutura de Gestão Escolar ──────────────────────────── */}

--- a/web/src/components/admin/AbaServicosTerceirizados.tsx
+++ b/web/src/components/admin/AbaServicosTerceirizados.tsx
@@ -15,6 +15,7 @@ import type {
   ServicosVisaoGeral, ServicosGerais, ServicosPortaria,
   ServicosManipuladoresAlimentos, DashboardFilters,
 } from "./shared/types";
+import { buildPostgresSourceLabel } from "./shared/sourceLabel";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -182,7 +183,7 @@ export function AbaServicosTerceirizados({
       {/* Badge de fonte */}
       <div className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: PostgreSQL · ano corrente · censos concluídos</span>
+        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* Banners de erro parcial */}

--- a/web/src/components/admin/AbaTecnologia.tsx
+++ b/web/src/components/admin/AbaTecnologia.tsx
@@ -13,6 +13,7 @@ import { HBarChart } from "./shared/BarChart";
 import type {
   TecnologiaInfra, TecnologiaUso, CategoricStat, DashboardFilters,
 } from "./shared/types";
+import { buildPostgresSourceLabel } from "./shared/sourceLabel";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -183,7 +184,7 @@ export function AbaTecnologia({
       {/* Badge de fonte */}
       <div className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: PostgreSQL · ano corrente · censos concluídos</span>
+        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* Banners de erro parcial */}

--- a/web/src/components/admin/shared/sourceLabel.ts
+++ b/web/src/components/admin/shared/sourceLabel.ts
@@ -1,0 +1,13 @@
+import type { DashboardFilters } from "./types";
+
+// Helpers compartilhados para o label de fonte das abas que consomem
+// PostgreSQL. O ano exibido deve refletir o filtro global selecionado
+// pelo operador; quando nenhum ano é escolhido, o backend usa seu padrão.
+
+export function formatAnoReferencia(filters?: DashboardFilters): string {
+  return filters?.ano ? `ano ${filters.ano}` : "ano padrão do backend";
+}
+
+export function buildPostgresSourceLabel(filters?: DashboardFilters): string {
+  return `PostgreSQL · ${formatAnoReferencia(filters)} · censos concluídos`;
+}


### PR DESCRIPTION
Ajusta os labels de fonte das abas analíticas do dashboard admin para refletirem o ano selecionado nos filtros globais.

Cria helper compartilhado para montar o label da fonte PostgreSQL com base em filters.ano, exibindo "ano 2026" quando houver ano selecionado e "ano padrão do backend" quando nenhum ano estiver definido no frontend.

Substitui o texto fixo "ano corrente" nas abas de Caracterização, Pessoal e Gestão, Tecnologia, Infraestrutura e Segurança, Merenda e Serviços Terceirizados.

Preserva a lógica de fallback da aba Caracterização para Google Sheets e não altera endpoints, payloads, filtros, cache, cálculos, backend ou migrations.