### PR TITLE
docs(dashboard): planejar aba gestao financeira com fonte prodep

### DIFF
--- a/docs/dashboard/gestao-financeira-governanca-prodep.md
+++ b/docs/dashboard/gestao-financeira-governanca-prodep.md
@@ -1,0 +1,274 @@
+# Gestão Financeira e Governança — Planejamento PRODEP
+
+**Status:** documento de planejamento técnico/produto. **Nada implementado.** Esta frente é exclusivamente documental — não cria migration, tabela, script de importação, endpoint, payload, frontend, nem carrega dados.
+
+**Branch de origem:** `docs/gestao-financeira-governanca-prodep` a partir de `develop`.
+
+**Documento companheiro / fonte oficial da matriz:** [matriz-abas-e-graficos.md](matriz-abas-e-graficos.md) §5.8. Em caso de conflito sobre o estado das abas, a matriz prevalece; este documento detalha o planejamento específico da aba Gestão Financeira e Governança.
+
+> **Histórico.** A aba Gestão Financeira e Governança nasceu como **placeholder institucional** (sem fetch, sem endpoint, sem view, sem dado fake) e **continua assim na UI**. Este documento não muda esse estado de implementação — ele apenas registra a passagem de "placeholder conceitual" para **planejamento ativo**, agora ancorado numa fonte administrativa externa concreta (PRODEP) somada aos dados declaratórios do censo.
+
+---
+
+## 1. Objetivo
+
+A aba **Gestão Financeira e Governança** passará a consolidar, para a rede estadual, quatro dimensões hoje dispersas:
+
+1. **Recursos** repassados às escolas (volume recebido por ano e por modalidade);
+2. **Execução** desses recursos e o quanto ficou **reprogramado** (não executado no exercício);
+3. **Prestação de contas** — incluindo o status administrativo de quem **não prestou contas**;
+4. **Governança institucional** das escolas — regularização, conselhos, grêmio, participação comunitária e instrumentos de segurança/convivência.
+
+A novidade desta frente é incorporar uma **fonte administrativa externa** ao censo: a planilha consolidada de recursos do **PRODEP**. Ela traz o lado *administrativo/financeiro* (valores efetivamente repassados e status de prestação de contas), que o formulário do censo só captura de forma **declaratória** (o diretor declara se recebeu, estima valor, informa se há pendência). Combinar as duas fontes permite, além de descrever cada lado, **cruzá-las para detectar divergências** (Bloco D).
+
+Esta aba **não** entra no Índice de Saúde Operacional por escola e **não** altera o formulário do censo.
+
+---
+
+## 2. Fontes de dados previstas
+
+A aba combinará **três fontes**, integradas pela chave `INEP` / `codigo_inep`.
+
+### 2.1 Fonte administrativa externa — PRODEP
+
+Planilha `CONSOLIDADO - PRODEP.xlsx`, aba `CONSOLIDADO`, com **uma linha por escola** e `INEP` como chave.
+
+Campos principais (colunas da planilha):
+
+- `INEP` — chave de integração;
+- `ESCOLA` — nome da escola (na planilha);
+- `DRE` — Diretoria Regional de Ensino (origem);
+- `RI` — Regional Integrada / agrupamento (origem);
+- `MUNICIPIO` — município (origem; contém `#N/A` em parte dos registros);
+- `PRODEP 2023/2024/2025 Geral` — valor recebido, modalidade Geral, por ano;
+- `Reprogramado PRODEP 2023/2024/2025 Geral` — valor reprogramado, modalidade Geral, por ano;
+- `PRODEP 2023/2024/2025 Alimentação` — valor recebido, modalidade Alimentação, por ano;
+- `Reprogramado PRODEP 2023/2024/2025 Alimentação` — valor reprogramado, modalidade Alimentação, por ano.
+
+> **Atenção à modelagem.** As colunas de **reprogramado** podem conter o texto `NÃO PRESTOU CONTAS` no lugar de um número. Portanto esses campos **não são numéricos puros** — carregam um **status textual** que deve ser preservado, não descartado nem convertido silenciosamente para `0`/`NULL`. Ver §4.
+
+As quatro categorias de recurso por ano são:
+
+```txt
+PRODEP Geral
+Reprogramado PRODEP Geral
+PRODEP Alimentação
+Reprogramado PRODEP Alimentação
+```
+
+### 2.2 Fonte declaratória — formulário do censo
+
+Campos já existentes na seção **Gestão, Participação e Política** do censo (`web/src/schemas/steps/gestao.ts`, armazenados em `census_responses.data` JSONB). Servem aos blocos de governança e aos cruzamentos de divergência (Bloco D):
+
+| Campo (JSONB) | Tipo / domínio | Uso planejado |
+|---|---|---|
+| `regularizada_cee` | Sim / Não | Governança — regularização junto ao CEE |
+| `conselho_escolar` | Sim / Não | Governança — conselho constituído |
+| `conselho_ativo` | Sim / Parcialmente / Não | Governança — conselho ativo |
+| `recursos_prodep` | Sim / Não / Não sabe informar | Cruzamento com PRODEP (declarou receber?) |
+| `valor_prodep` | número (opcional) | Cruzamento de valor declarado × administrativo |
+| `execucao_prodep` | Sim, totalmente / Parcialmente / Não executados | Execução declarada |
+| `pendencias_prodep` | Não / Sim, em regularização / Sim, pendente/atrasada | Cruzamento com status de prestação de contas |
+| `recursos_federais` | Sim / Não | Contexto financeiro complementar |
+| `valor_federais` | número (opcional) | Contexto financeiro complementar |
+| `execucao_federais` | Sim, totalmente / Parcialmente / Não executados | Contexto financeiro complementar |
+| `pendencias_federais` | Não / Sim, em regularização / Sim, pendente/atrasada | Contexto financeiro complementar |
+| `gremio_estudantil` | Sim / Não | Participação |
+| `reunioes_comunidade` | Não ocorrem / Eventuais / Regulares / Frequentes | Participação comunitária |
+| `plano_evacuacao` | Sim / Não | Governança / segurança institucional |
+| `politica_bullying` | Sim, formalizada e aplicada / Parcialmente / Não possui | Governança / convivência |
+
+> Os domínios acima são os enums reais validados pelo Zod (`gestaoSchema`). Qualquer leitura desses campos no JSONB deve usar os padrões seguros documentados em `CLAUDE.md` (`NULLIF(data->>'campo','')` para categóricos; cast numérico defensivo para `valor_prodep`/`valor_federais`).
+
+### 2.3 Fonte cadastral — `schools`
+
+Tabela `schools` (`infra/init.sql`), usada para integração territorial e resolução de município. Colunas relevantes:
+
+- `id` (PK; é o `school_id` referenciado em `census_responses`);
+- `codigo_inep` (VARCHAR, `UNIQUE`) — chave de integração com o PRODEP;
+- `nome_escola`;
+- `dre`;
+- `municipio`;
+- `zona`.
+
+> Observação: na tabela `schools` o identificador interno é a coluna `id`; o nome `school_id` aparece como chave estrangeira em `census_responses`. Na modelagem da tabela PRODEP (§4) usamos `school_id` para o vínculo resolvido contra `schools.id`.
+
+---
+
+## 3. Diagnóstico inicial da planilha PRODEP
+
+Registro do que se sabe hoje sobre `CONSOLIDADO - PRODEP.xlsx` (aba `CONSOLIDADO`):
+
+- **~841 linhas/escolas**, uma linha por escola;
+- **`INEP` é a chave principal** de integração;
+- **ausência de duplicidade de `INEP`** — *a confirmar* formalmente no relatório de qualidade da carga (§7, passo 4);
+- **17 registros com `MUNICIPIO = #N/A`** — precisam de saneamento (§5);
+- **presença de `NÃO PRESTOU CONTAS`** em colunas de reprogramado — status textual a preservar (§4);
+- **necessidade de preservar o status textual** em vez de coagir para número.
+
+> Estes números (841 linhas, 17 `#N/A`) são o diagnóstico inicial informado e devem ser **reconfirmados** pelo relatório de qualidade quando a carga real for executada. Nenhuma decisão de modelagem deve assumir que esses contadores estão fechados.
+
+---
+
+## 4. Decisão de modelagem
+
+**Decisão:** os dados do PRODEP vão para uma **tabela própria no PostgreSQL**, separada do JSONB do censo. Eles são dados administrativos externos, com ciclo de atualização e origem distintos do formulário — não cabem como mais um campo declaratório.
+
+Princípios:
+
+- **Criar a estrutura da tabela via migration estrutural** (futuramente) — `CREATE TABLE IF NOT EXISTS`, idempotente, alinhada ao loader `applyMigrations` descrito em `CLAUDE.md`.
+- **Não embutir os dados da planilha na migration.** Migration cria estrutura; **dados entram por carga separada**.
+- **Carga via script/processo controlado**, com tratamento, validação e relatório de qualidade (§7).
+- **Preferir formato longo** (uma linha por escola × ano × categoria), em vez de dezenas de colunas `prodep_2023_geral`, `reprogramado_2024_alimentacao` etc. O formato longo facilita filtros por ano/categoria, agregações e a evolução para novos anos sem alterar o schema.
+- **Preservar status textual.** O valor reprogramado e o status de prestação de contas são campos **distintos**: quando a célula traz `NÃO PRESTOU CONTAS`, `valor_reprogramado` fica `NULL` e `status_prestacao_contas` registra o texto. Nunca tratar `NÃO PRESTOU CONTAS` como `0`.
+
+### Exemplo conceitual de tabela analítica
+
+```txt
+prodep_school_resources
+```
+
+Tabela em **formato longo**. Campos conceituais (nomes finais a confirmar na migration estrutural):
+
+| Campo | Natureza | Observação |
+|---|---|---|
+| `id` | PK | identidade da linha |
+| `codigo_inep` | chave externa (texto) | chave da planilha; integra com `schools.codigo_inep` |
+| `school_id` | FK → `schools.id` | preenchido quando o `INEP` casa; pode ser `NULL` se não resolvido |
+| `ano` | inteiro | 2023 / 2024 / 2025 |
+| `categoria` | texto/enum | `geral` ou `alimentacao` |
+| `valor_recebido` | numérico (NULL-able) | valor PRODEP recebido na categoria/ano |
+| `valor_reprogramado` | numérico (NULL-able) | `NULL` quando a célula é status textual |
+| `status_prestacao_contas` | texto/enum | ex.: `nao_prestou_contas`, `ok`, `nao_informado` — preserva `NÃO PRESTOU CONTAS` |
+| `dre_origem` | texto | DRE como veio da planilha |
+| `ri_origem` | texto | RI como veio da planilha |
+| `municipio_origem` | texto | município **como veio** da planilha (pode ser `#N/A`) |
+| `municipio_resolvido` | texto (NULL-able) | preenchido só quando há segurança (§5) |
+| `fonte_municipio` | enum | `planilha` / `schools` / `manual` / `nao_resolvido` (§5) |
+| `fonte_arquivo` | texto | nome/identificador do arquivo da carga (auditoria) |
+| `data_carga` | timestamp | momento da carga |
+| `created_at` | timestamp | padrão |
+| `updated_at` | timestamp | padrão |
+
+> O formato longo implica, para uma escola, até **6 linhas** (3 anos × 2 categorias). Os campos territoriais (`dre_origem`, `ri_origem`, `municipio_*`) repetem-se entre as linhas da mesma escola; isso é aceitável e simplifica a carga. Uma alternativa (tabela cabeçalho por escola + tabela de valores) pode ser avaliada na fase de migration, mas **não é decisão desta documentação**.
+
+---
+
+## 5. Estratégia de saneamento de municípios
+
+O município (`MUNICIPIO`) vem sujo na planilha (17 registros `#N/A`). A resolução deve ser **em camadas**, sempre preservando a origem e nunca inventando dado:
+
+1. **Resolver automaticamente por `INEP`** usando `schools.codigo_inep` → `schools.municipio`. É a via preferencial: o cadastro `schools` é a fonte canônica de território.
+2. **Se não houver match** por INEP, usar **base/correção manual validada** (lista revisada por humano), não inferência automática.
+3. **Preservar sempre `municipio_origem`** (inclusive `#N/A`), para auditoria e rastreabilidade.
+4. **Preencher `municipio_resolvido` apenas quando houver segurança** — sem chute. Na dúvida, deixar `NULL`.
+5. **Registrar a procedência em `fonte_municipio`:**
+   - `planilha` — município veio íntegro da própria planilha;
+   - `schools` — resolvido por match de INEP no cadastro;
+   - `manual` — resolvido por correção humana validada;
+   - `nao_resolvido` — permanece pendente.
+6. **Não inferir município apenas por DRE ou RI** — DRE/RI agrupam vários municípios; isso geraria atribuição incorreta.
+7. **Pendências de município são qualidade de dado, não bloqueio de carga.** Um registro `#N/A` ainda não resolvido entra na base com `fonte_municipio = nao_resolvido` e é reportado no relatório de qualidade — não impede o restante da carga.
+
+---
+
+## 6. Indicadores planejados da aba
+
+Organização em quatro blocos. **Nenhum implementado** — referência de produto para as fases seguintes.
+
+### Bloco A — Visão Geral Financeira do PRODEP
+
+Fonte: tabela PRODEP.
+
+- Total recebido no ano (KPI, por ano selecionado);
+- Total reprogramado (KPI);
+- Percentual reprogramado (reprogramado ÷ recebido);
+- Escolas contempladas (com recebimento > 0);
+- Escolas com prestação pendente (`status_prestacao_contas = nao_prestou_contas`);
+- Distribuição Geral × Alimentação (donut/barra).
+
+### Bloco B — Execução e Prestação de Contas
+
+Fonte: tabela PRODEP.
+
+- Escolas com reprogramado > 50% (KPI/lista);
+- Escolas com reprogramado > 75% (KPI/lista);
+- Escolas com `NÃO PRESTOU CONTAS` (KPI/lista);
+- Ranking de escolas por valor reprogramado;
+- Ranking de DREs por percentual reprogramado;
+- Tabela escola a escola (recebido, reprogramado, % reprogramado, status).
+
+> Os limiares 50% / 75% são **propostas** e dependem de validação de produto (§7, e §7.3 da matriz).
+
+### Bloco C — Governança Institucional e Participação
+
+Fonte: formulário do censo (declaratório).
+
+- Regularização junto ao CEE (`regularizada_cee`);
+- Conselho Escolar constituído (`conselho_escolar`);
+- Conselho ativo (`conselho_ativo`);
+- Grêmio estudantil (`gremio_estudantil`);
+- Frequência de reuniões com a comunidade (`reunioes_comunidade`);
+- Plano de evacuação (`plano_evacuacao`);
+- Política contra bullying/violência (`politica_bullying`).
+
+### Bloco D — Alertas e Divergências
+
+Cruzamento entre a planilha PRODEP (administrativo) e o formulário do censo (declaratório):
+
+- escola **declarou não receber** PRODEP (`recursos_prodep = Não`), **mas consta valor administrativo** na planilha;
+- escola **declarou receber** PRODEP, **mas não consta valor administrativo**;
+- **divergência relevante** entre valor declarado (`valor_prodep`) e valor administrativo;
+- escola **declarou ausência de pendência** (`pendencias_prodep = Não`), **mas o status administrativo indica `NÃO PRESTOU CONTAS`**;
+- escola com **alto reprogramado** e **conselho inativo ou inexistente** (`conselho_ativo` ≠ Sim).
+
+> Os Blocos C e D dependem de o censo do ano de referência estar concluído para a escola; o cruzamento só é confiável quando há ambos os lados. Escolas sem censo elegível devem aparecer como "sem dado declaratório", não como divergência.
+
+---
+
+## 7. Fluxo futuro de implementação
+
+Sequência recomendada (cada passo é uma frente/PR próprio; **nada além do passo 1 está em escopo agora**):
+
+1. **Documentação desta frente** ← *este PR*.
+2. **Tratamento da planilha** (parsing, normalização de colunas, separação valor × status textual).
+3. **Resolução dos municípios `#N/A`** (estratégia em camadas, §5).
+4. **Relatório de qualidade da carga** (confirmar 841 linhas, unicidade de INEP, contagem de `#N/A` e de `NÃO PRESTOU CONTAS`, taxa de match com `schools`).
+5. **Migration estrutural** (`infra/migrations/NNNN_*` + replicar em `infra/init.sql`), sem dados.
+6. **Script de importação** (carga controlada, idempotente, registrando `fonte_arquivo`/`data_carga`).
+7. **Endpoint backend** sob `/v1/admin/analytics/gestao-financeira/*`, JWT-protegido, queries parametrizadas.
+8. **Payload da aba** (contrato de dados consumido pelo frontend).
+9. **Wireframe/gráficos** (validação visual dos blocos A–D com as áreas finalísticas).
+10. **Frontend** (remodelar `AbaGestaoFinanceiraGovernanca.tsx`, substituindo o placeholder).
+11. **Testes e auditoria** (paridade numérica planilha × banco × tela; trilha de auditoria da carga).
+
+---
+
+## 8. Fora de escopo desta documentação
+
+Este PR é **exclusivamente documental**. Ele **não** implementa nem altera:
+
+- migration;
+- tabela (`prodep_school_resources` ou qualquer outra);
+- script de importação;
+- endpoint;
+- payload;
+- frontend (`AbaGestaoFinanceiraGovernanca.tsx` permanece placeholder);
+- carga de dados / ingestão da planilha;
+- alteração no formulário do censo;
+- alteração no Índice de Saúde Operacional por escola;
+- código em `web/`, `api/` ou `infra/`.
+
+---
+
+## 9. Pontos que exigem validação humana antes da implementação
+
+Antes de avançar do passo 1 para os seguintes (§7), o time/produto precisa decidir:
+
+1. **Status de prestação de contas** — domínio canônico de `status_prestacao_contas` (quais valores além de `nao_prestou_contas`, `ok`, `nao_informado`) e como mapear cada texto encontrado na planilha.
+2. **Limiares de risco** — confirmar 50% / 75% de reprogramado como faixas oficiais (ou outras).
+3. **"Divergência relevante" de valor** (Bloco D) — definir o critério numérico (tolerância absoluta/percentual) entre `valor_prodep` declarado e valor administrativo.
+4. **Base manual de municípios** — quem valida e mantém a correção dos 17 (ou mais) `#N/A` não resolvidos por INEP.
+5. **Anos de referência** — confirmar que 2023–2025 é o recorte e como a aba lidará com a chegada de novos anos.
+6. **Modalidade Alimentação × Merenda** — alinhar se "PRODEP Alimentação" deve dialogar com a aba Merenda Escolar ou permanecer restrito a esta aba.
+7. **Dono da fonte PRODEP** — coordenação responsável pela atualização periódica da planilha e pela governança da carga.

--- a/docs/dashboard/matriz-abas-e-graficos.md
+++ b/docs/dashboard/matriz-abas-e-graficos.md
@@ -20,7 +20,7 @@
 
 ## 1. Objetivo
 
-Consolidar, em um único lugar, a **matriz oficial** de abas / blocos / gráficos do `/admin`, refletindo o estado real da branch `develop` (pós-merge das Frentes 1, 2 e 3 backend + integração visual das 5 abas temáticas + placeholder institucional de Gestão Financeira e Governança).
+Consolidar, em um único lugar, a **matriz oficial** de abas / blocos / gráficos do `/admin`, refletindo o estado real da branch `develop` (pós-merge das Frentes 1, 2 e 3 backend + integração visual das 5 abas temáticas + placeholder institucional de Gestão Financeira e Governança — esta última agora com **frente documental de planejamento ativa**, ver §5.8 e [gestao-financeira-governanca-prodep.md](gestao-financeira-governanca-prodep.md)).
 
 A matriz tem três usos:
 
@@ -42,9 +42,9 @@ Decisões registradas pelo time, válidas para todo o trabalho a partir desta br
    - Organização da Oferta e Funcionamento;
    - Infraestrutura Educacional.
 3. **Perfil dos Alunos e Resultados** permanece com a implementação atual/legada (consome `/v1/admin/indicadores-metrics`, alimentado por Google Sheets). Será remodelada futuramente, provavelmente a partir de uma planilha própria — fora desta rodada.
-4. **Gestão Financeira e Governança** é **placeholder institucional**. Sem fetch, sem endpoint, sem view SQL, sem dado fake.
-5. **Gestão Financeira e Governança não deve consumir o banco PostgreSQL do formulário do censo** nesta rodada.
-6. A **fonte futura** de "Gestão Financeira / Governança" virá de **bases próprias validadas pelas coordenações responsáveis**, não do banco do censo operacional.
+4. **Gestão Financeira e Governança** segue **placeholder institucional na UI** (sem fetch, sem endpoint, sem view SQL, sem dado fake), mas passou de "placeholder conceitual" para **planejamento ativo** numa frente documental dedicada — ver §5.8 e [gestao-financeira-governanca-prodep.md](gestao-financeira-governanca-prodep.md). Nenhum código, migration, endpoint ou frontend foi implementado ainda.
+5. **A fonte primária dessa aba é administrativa externa:** a planilha consolidada de recursos do **PRODEP** (`CONSOLIDADO - PRODEP.xlsx`), a ser carregada em **tabela própria no PostgreSQL** via script/processo controlado — **não** derivada das views analíticas do censo. A integração é por `INEP`/`codigo_inep`.
+6. O planejamento prevê **combinar três fontes**: (a) dados administrativos do PRODEP (tabela própria); (b) dados **declaratórios** do formulário do censo (seção Gestão, Participação e Política — para blocos de governança e para cruzamentos de divergência); (c) cadastro `schools` para integração territorial. Isso **atualiza** a orientação anterior de "não consumir o banco do censo": os dados declaratórios do censo passam a ser fonte legítima de blocos específicos e de alertas, sem que a aba dependa do banco do censo como fonte financeira principal.
 7. As **5 abas temáticas já integradas em primeira versão** (Pessoal e Gestão Escolar, Tecnologia e Equipamentos, Infraestrutura e Segurança, Merenda Escolar, Serviços Terceirizados) **não devem receber gráficos inéditos** (fora do escopo do painel original) antes desta matriz mínima ser validada com as áreas finalísticas da SEDUC. **Exceção:** gráficos mínimos que já existiam no painel original (Data Studio/Looker Studio) e ainda não estão refletidos na aplicação podem ser **documentados como lacunas** nesta matriz e **implementados após diagnóstico técnico**, mesmo antes da validação — eles não são novidade de escopo, e sim recuperação da referência mínima. O caso de Tecnologia e Equipamentos (ver §5.3) foi o primeiro a seguir esse caminho; **Merenda Escolar (ver §5.5) é o segundo**, alinhado neste PR documental.
 8. **Recursos Humanos da Merenda (merendeiras/manipuladores de alimentos) saiu da aba Merenda Escolar como bloco finalístico.** O Data Studio mantinha uma subaba "Recursos Humanos" dentro de Merenda; por decisão de produto, esses indicadores (total de merendeiras por vínculo, adequação do quantitativo, média por escola, empresas e supervisão) agora ficam no menu **Serviços Terceirizados**, em bloco próprio **"Manipulador de Alimentos"**, junto de Serviços Gerais e Portaria. **MER-RH-01 entregue:** `sec-merenda-rh` foi removido de `AbaMerenda.tsx`, `sec-servicos-manipuladores` foi adicionado em `AbaServicosTerceirizados.tsx`, o endpoint novo `/servicos-terceirizados/manipuladores-alimentos` foi criado e `/merenda/recursos-humanos` permanece legado. A avaliação do serviço das merendeiras segue como pendência futura/produto por falta de fonte/escala consolidada nesta entrega.
 9. **Saúde Operacional foi implementada como aba transversal no grupo Operacional.** O nome oficial é **"Índice de Saúde Operacional por escola"**, com rótulo reduzido **"Saúde Operacional"** no menu, após Operacional e antes de Todos os Censos. A fonte é PostgreSQL via `GET /v1/admin/analytics/escolas/saude-operacional`; a tela usa fetch lazy e não participa do prefetch global do login.
@@ -69,7 +69,7 @@ O snapshot suplanta a seção 2.1 de
 | 5 | Merenda Escolar | Integrada (1ª versão) | PostgreSQL `/v1/admin/analytics/merenda/{oferta,equipamentos,recursos-humanos}` | `AbaMerenda.tsx` |
 | 6 | Serviços Terceirizados | Integrada (1ª versão) | PostgreSQL `/v1/admin/analytics/servicos-terceirizados/{visao-geral,servicos-gerais,portaria,manipuladores-alimentos}` | `AbaServicosTerceirizados.tsx` |
 | 7 | Perfil dos Alunos e Resultados | Implementação atual/legada mantida | Google Sheets `/v1/admin/indicadores-metrics` | `AbaPerfilAlunos.tsx` |
-| 8 | Gestão Financeira e Governança | Placeholder institucional | — (sem fetch) | `AbaGestaoFinanceiraGovernanca.tsx` |
+| 8 | Gestão Financeira e Governança | Placeholder institucional (UI) · **planejamento ativo** (frente documental PRODEP) | — (sem fetch; fonte planejada: PRODEP + declaratório do censo + `schools`) | `AbaGestaoFinanceiraGovernanca.tsx` |
 | 9 | Operacional | Integrada | PostgreSQL `/v1/admin/dashboard` | `AbaOperacional.tsx` |
 | 10 | Saúde Operacional | **Implementada** | PostgreSQL `/v1/admin/analytics/escolas/saude-operacional` | `AbaSaudeOperacionalEscolas.tsx` |
 | 11 | Todos os Censos | Integrada | PostgreSQL `/v1/admin/census` | `AbaTodosCensos.tsx` |
@@ -92,7 +92,7 @@ Visão consolidada das abas, **com foco analítico**. As abas operacionais (Oper
 | Merenda Escolar | Integrada (1ª versão) | PostgreSQL | Oferta e Adequação da Merenda · Estrutura Física · Equipamentos da Merenda · Condições Sanitárias e Segurança | Endpoints `/merenda/*`. Blocos oficiais realinhados aos gráficos mínimos do Data Studio (ver §5.5). Os quatro blocos finalísticos estão entregues (MER-01A/B/C); "Condições Sanitárias e Segurança" foi entregue em MER-01C via `/merenda/condicoes-sanitarias`. **Recursos Humanos / merendeiras migra conceitualmente para Serviços Terceirizados** (§2.8), não é mais bloco finalístico de Merenda. |
 | Serviços Terceirizados | Integrada (1ª versão) | PostgreSQL | Visão Geral · Serviços Gerais · Portaria · Manipulador de Alimentos · Governança / Supervisão | Endpoints `/servicos-terceirizados/*`. Bloco "Manipulador de Alimentos" entregue em MER-RH-01 sobre `vw_censo_rh_merendeiras`; "Governança / Supervisão" depende de campos de supervisão/avaliação (ver §5.6). |
 | Perfil dos Alunos e Resultados | Implementação atual mantida | Sheets `/indicadores-metrics` | Perfil Socioeducacional e Permanência (futuro) · Resultados e Desempenho (futuro) | Remodelagem futura, **fora desta rodada**. |
-| Gestão Financeira e Governança | Placeholder institucional | — | Governança Institucional e Regularização (futuro) · Execução Financeira e Prestação de Contas (futuro) · Participação Comunitária e Risco de Governança (futuro) | Sem fetch. Fonte futura: base própria das coordenações, **fora do banco do censo**. |
+| Gestão Financeira e Governança | Placeholder institucional (UI) · planejamento ativo | — (sem fetch) | Governança Institucional e Regularização (futuro) · Execução Financeira e Prestação de Contas (futuro) · Participação Comunitária e Risco de Governança (futuro) | Sem fetch/endpoint/frontend funcional. **Planejada — fonte administrativa PRODEP + dados declaratórios do censo + `schools`.** Detalhamento em [gestao-financeira-governanca-prodep.md](gestao-financeira-governanca-prodep.md). |
 
 ---
 
@@ -314,20 +314,25 @@ A renderização atual permanece inalterada — qualquer mudança vem em **rodad
 
 ### 5.8 Gestão Financeira e Governança
 
-**Status:** placeholder institucional. **Sem fetch, sem endpoint, sem view SQL, sem dado fake.** Renderiza apenas `EmptyStatePlaceholder` com seções nomeadas.
+**Status:** placeholder institucional **na UI** (`EmptyStatePlaceholder` com seções nomeadas) — **sem fetch, sem endpoint, sem view SQL, sem dado fake**. Em paralelo, há **frente documental de planejamento ativa** que define a arquitetura de dados e os indicadores desta aba a partir de uma fonte administrativa externa (PRODEP) combinada com dados declaratórios do censo. **Planejada, não implementada.** O documento de referência é [gestao-financeira-governanca-prodep.md](gestao-financeira-governanca-prodep.md).
 
-Blocos futuros sugeridos (referência, não compromisso):
+**Fonte planejada (não é placeholder conceitual):**
+- **administrativa externa** — planilha `CONSOLIDADO - PRODEP.xlsx` (recursos PRODEP 2023/2024/2025, Geral e Alimentação, valores recebidos e reprogramados, status de prestação de contas), a ser carregada em **tabela própria no PostgreSQL** via script controlado;
+- **declaratória** — seção Gestão, Participação e Política do formulário do censo;
+- **cadastral** — `schools` (integração territorial por `codigo_inep`).
+
+Blocos planejados (referência da frente documental, ainda sem compromisso de PR):
 - Governança Institucional e Regularização
 - Execução Financeira e Prestação de Contas
 - Participação Comunitária e Risco de Governança
 
-| Bloco (futuro) | Gráficos sugeridos | Fonte futura provável | Status | Lacuna backend | Lacuna frontend | Observações |
+| Bloco (futuro) | Gráficos sugeridos | Fonte planejada | Status | Lacuna backend | Lacuna frontend | Observações |
 |---|---|---|---|---|---|---|
-| Governança Institucional e Regularização | CNPJ válido, estatuto atualizado, conselhos ativos | Base externa das coordenações | futuro | Definir fonte (não é o banco do censo) | Remodelar `AbaGestaoFinanceiraGovernanca.tsx` | Decisão de produto pendente: qual base e quem é o "dono". |
-| Execução Financeira e Prestação de Contas | Recursos recebidos, executados, % prestado de contas, prazos | Base externa | futuro | Idem | Idem | Idem. |
-| Participação Comunitária e Risco de Governança | Frequência de reuniões, % escolas com conselho ativo, indicador composto de risco | Base externa | futuro | Idem | Idem | Idem. |
+| Governança Institucional e Regularização | Regularização CEE, conselho escolar constituído/ativo, grêmio estudantil | Declaratório do censo (`regularizada_cee`, `conselho_escolar`, `conselho_ativo`, `gremio_estudantil`) + `schools` | planejado (doc) | Definir view/endpoint sobre declaratório; nenhuma view criada | Remodelar `AbaGestaoFinanceiraGovernanca.tsx` | Detalhado no doc PRODEP §6 (Bloco C). |
+| Execução Financeira e Prestação de Contas | Total recebido/reprogramado, % reprogramado, escolas com `NÃO PRESTOU CONTAS`, rankings | Tabela PRODEP própria (a criar) | planejado (doc) | Migration estrutural + script de carga + endpoint — **nenhum implementado** | Idem | Detalhado no doc PRODEP §4 e §6 (Blocos A e B). |
+| Participação Comunitária e Risco de Governança | Frequência de reuniões, planos/políticas, alertas cruzados PRODEP × declaratório | Declaratório do censo (`reunioes_comunidade`, `plano_evacuacao`, `politica_bullying`) + PRODEP | planejado (doc) | Idem | Idem | Cruzamentos de divergência detalhados no doc PRODEP §6 (Bloco D). |
 
-A aba **não deve consumir o banco PostgreSQL do censo** nesta rodada. Qualquer tentativa de "preencher" essa aba com dados do censo conflita com decisão de produto.
+A aba **continua sem qualquer fetch ou backend funcional** nesta rodada. A frente documental apenas **planeja**: carga de dados, migration, endpoint e frontend ficam **fora de escopo** até as fases seguintes (ver doc PRODEP §7 e §8).
 
 ---
 
@@ -389,7 +394,7 @@ Itens identificados na matriz como `planejado` ou `presente / a confirmar`. Não
 - **Denominador oficial do percentual de computadores inoperantes** (Tecnologia — Parque Tecnológico).
 - **Escala oficial de avaliação** para Governança/Supervisão de Serviços Terceirizados.
 - **Fonte de dados futura para Perfil dos Alunos e Resultados** (planilha própria a indicar).
-- **Fonte de dados futura para Gestão Financeira e Governança** (base externa das coordenações responsáveis).
+- **Gestão Financeira e Governança:** fonte primária definida em planejamento — planilha PRODEP carregada em tabela própria + declaratório do censo + `schools` (ver [gestao-financeira-governanca-prodep.md](gestao-financeira-governanca-prodep.md)). Pendências de produto a resolver antes da implementação: estratégia de saneamento dos 17 municípios `#N/A`, tratamento do status textual `NÃO PRESTOU CONTAS` nas colunas de reprogramado, e validação dos limiares de risco (reprogramado > 50% / > 75%).
 - **Critério oficial de "porte"** já consta em `vw_censo_enriquecida`, mas deve ser revalidado quando a matriz for revisada com SEDUC.
 
 ---


### PR DESCRIPTION
Documenta o planejamento da aba Gestão Financeira e Governança com base na fonte administrativa externa do PRODEP.

Atualiza a matriz de abas para registrar que a aba segue como placeholder na UI, mas passa a ter planejamento ativo com três fontes previstas: dados administrativos do PRODEP, dados declaratórios do formulário do censo e cadastro schools para integração territorial.

Cria documento específico da frente PRODEP, incluindo diagnóstico inicial da planilha, decisão de tabela própria no PostgreSQL, recomendação de formato longo, estratégia de saneamento de municípios, separação entre valor financeiro e status de prestação de contas, blocos planejados de indicadores e fluxo futuro de implementação.

Não altera código, migrations, endpoints, frontend, scripts de importação, formulário ou Índice de Saúde Operacional.