### PR TITLE
fix(admin): remover barra de busca e botao de sync do header

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -533,34 +533,11 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
               </div>
             </div>
             <div className="ca-topbar-right">
-              <div className="ca-search">
-                <Search size={14} />
-                <input
-                  placeholder="Buscar indicadores, escolas, DREs…"
-                  value={search}
-                  onChange={(e) => updateSearch(e.target.value)}
-                />
-                <kbd>⌘ /</kbd>
-              </div>
-              <button
-                className="ca-icon-btn"
-                title={syncing ? "Sincronizando…" : "Sync Planilha"}
-                onClick={handleSync}
-                disabled={syncing}
-              >
-                {syncing
-                  ? <Loader2 size={16} className="animate-spin" />
-                  : <CloudUpload size={16} />}
+              <button className="ca-icon-btn" title="Mudar tema" onClick={() => setDark(!dark)}>
+                {dark ? <Sun size={16} /> : <Moon size={16} />}
               </button>
               <button className="ca-icon-btn" title="Sair" onClick={logout}>
                 <LogOut size={16} />
-              </button>
-              <button className="ca-icon-btn" title="Mudar tema" onClick={() => setDark(!dark)}>
-                {
-                  dark
-                    ? <Sun size={16} />
-                    : <Moon size={16} />
-                }
               </button>
             </div>
           </div>


### PR DESCRIPTION
A barra de busca global do header nunca chegou a funcionar de forma integrada com as abas analiticas — a busca real ja existe dentro da aba "Todos os Censos". O botao de sync manual tambem foi removido por ser uma operacao de manutencao interna que nao pertence a barra superior do painel.

O botao de tema escuro foi movido para antes do botao de sair, deixando o logout sempre como ultima acao da barra.