### PR TITLE
feat(admin): adicionar ancoras para modo apresentacao

### DIFF
--- a/web/src/components/admin/AbaPerfilAlunos.tsx
+++ b/web/src/components/admin/AbaPerfilAlunos.tsx
@@ -77,7 +77,7 @@ export function AbaPerfilAlunos({
       )}
 
       {/* Stat card de risco — big number */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 animate-fade-in-up [animation-delay:150ms]">
+      <div id="sec-alunos-visao" className="grid grid-cols-1 sm:grid-cols-3 gap-4 animate-fade-in-up [animation-delay:150ms]">
         <StatCard
           label="Escolas com Risco de Fluxo"
           value={metrics.escolas_risco_fluxo}
@@ -103,7 +103,7 @@ export function AbaPerfilAlunos({
       </div>
 
       {/* Linha 1: dois gráficos de barra vertical */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 animate-fade-in-up [animation-delay:300ms]">
+      <div id="sec-alunos-faixas" className="grid grid-cols-1 lg:grid-cols-2 gap-5 animate-fade-in-up [animation-delay:300ms]">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1">
             Distribuição por Faixa de Beneficiários
@@ -144,7 +144,7 @@ export function AbaPerfilAlunos({
       </div>
 
       {/* Linha 2: Top 10 DREs + card risco */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+      <div id="sec-alunos-abandono" className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         <div className="lg:col-span-2 bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1">
             Top 10 DREs com maior taxa média de abandono

--- a/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
+++ b/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
@@ -417,7 +417,7 @@ export function AbaSaudeOperacionalEscolas({
         </div>
       </header>
 
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-6">
+      <div id="sec-saude-resumo" className="grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-6">
         <SummaryCard
           label="Escolas avaliadas"
           value={escolasAvaliadas}
@@ -502,7 +502,7 @@ export function AbaSaudeOperacionalEscolas({
           </p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div id="sec-saude-escolas" className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
           <div className="overflow-x-auto">
             <table className="min-w-[1900px] w-full text-sm">
               <thead style={{ background: C.primary }} className="text-white">


### PR DESCRIPTION
Adiciona ids estáveis em seções reais das abas Perfil dos Alunos e Saúde Operacional para preparar a navegação por slides do Modo Apresentação.

Mantém o escopo restrito à marcação semântica de elementos existentes, sem alterar lógica, fetch, cache, filtros, labels, payloads, layout estrutural ou componentes compartilhados.

Não altera page.tsx, PresentationMode.tsx, admin.css, helpers shared, backend, migrations ou scripts.