### PR TITLE
feat(admin): implementar modo apresentacao em deck

### DIFF
--- a/web/src/app/admin/admin.css
+++ b/web/src/app/admin/admin.css
@@ -1332,76 +1332,206 @@
   color: var(--bg);
 }
 
-/* Overlay base */
+/* ── Layout de deck: o dashboard vira a tela do slide ──────────── */
+/* Oculta o cromo normal do painel enquanto a apresentação está ativa. */
+.censo-admin .ca-app.presenting .ca-sidebar,
+.censo-admin .ca-app.presenting .ca-topbar,
+.censo-admin .ca-app.presenting .ca-filters-wrap,
+.censo-admin .ca-app.presenting .ca-nav-overlay,
+.censo-admin .ca-app.presenting .ca-error-note,
+.censo-admin .ca-app.presenting .ca-partners-strip {
+  display: none;
+}
+
+/* Sem coluna de sidebar: a área principal ocupa toda a largura. */
+.censo-admin .ca-app.presenting {
+  grid-template-columns: 1fr;
+  min-height: 100vh;
+  height: 100vh;
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+}
+
+.censo-admin .ca-app.presenting .ca-main {
+  margin-left: 0;
+  width: 100%;
+  height: 100vh;
+  min-height: 0;
+  border-radius: 0;
+  overflow: hidden;
+}
+
+/* Espaço para o header e o footer fixos da apresentação não cobrirem o conteúdo. */
+.censo-admin .ca-app.presenting .admin-page {
+  box-sizing: border-box;
+  height: 100vh;
+  min-height: 0;
+  padding: 96px 40px 72px;
+  gap: 0;
+  overflow: hidden;
+}
+
+/* Wrapper neutro dos filtros — não altera o layout no modo normal. */
+.censo-admin .ca-filters-wrap {
+  display: contents;
+}
+
+/* Apenas o slide ativo participa do layout do deck. */
+.censo-admin .ca-app.presenting [data-pres-hide="true"],
+.censo-admin .ca-app.presenting [data-pres-slide] {
+  display: none !important;
+}
+
+.censo-admin .ca-app.presenting [data-pres-slide].ca-pres-slide-active {
+  display: block !important;
+  width: 100%;
+  min-height: calc(100vh - 184px);
+  max-height: calc(100vh - 184px);
+  overflow: hidden;
+}
+
+/* Tabelas extensas rolam dentro do slide, sem reativar o scroll da página. */
+.censo-admin .ca-app.presenting [data-pres-slide].ca-pres-slide-active [data-pres-table-scroll="true"] {
+  max-height: calc(100vh - 260px);
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.censo-admin .ca-app.presenting [data-pres-slide].ca-pres-slide-active [data-pres-table-scroll="true"] table {
+  font-size: 0.82rem;
+}
+
+/* Compactação restrita ao deck para manter cards e gráficos dentro da tela. */
+.censo-admin .ca-app.presenting [data-pres-slide].ca-pres-slide-active .p-6 {
+  padding: 16px !important;
+}
+
+.censo-admin .ca-app.presenting [data-pres-slide].ca-pres-slide-active .p-5 {
+  padding: 14px !important;
+}
+
+.censo-admin .ca-app.presenting [data-pres-slide].ca-pres-slide-active .gap-5 {
+  gap: 12px !important;
+}
+
+.censo-admin .ca-app.presenting [data-pres-slide].ca-pres-slide-active .gap-4 {
+  gap: 10px !important;
+}
+
+/* ── Camada da apresentação (header + footer fixos) ────────────── */
 .censo-admin .ca-pres-shell {
   position: fixed;
   inset: 0;
   z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
+  pointer-events: none; /* a camada não bloqueia o conteúdo; só os controles. */
 }
 
-.censo-admin .ca-pres-backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(2, 6, 23, 0.55);
-  backdrop-filter: blur(2px);
-}
-
-.censo-admin .ca-pres-panel {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  width: min(720px, 100%);
-  max-height: 100%;
-  background: var(--crd);
-  border: 1px solid var(--bdr);
-  border-radius: var(--rad);
-  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.35);
-  overflow: hidden;
-}
-
-.censo-admin .ca-pres-header {
+/* Header fixo no topo */
+.censo-admin .ca-pres-top {
+  pointer-events: auto;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 18px 20px;
+  gap: 24px;
+  min-height: 78px;
+  padding: 12px 40px;
+  background: var(--frame);
   border-bottom: 1px solid var(--bdr);
+  box-shadow: 0 6px 24px rgba(2, 6, 23, 0.08);
 }
 
-.censo-admin .ca-pres-title {
+.censo-admin .ca-pres-heading {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  min-width: 0;
+}
+
+.censo-admin .ca-pres-kicker {
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 7px;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--accent);
 }
 
-.censo-admin .ca-pres-title strong {
-  display: block;
-  font-size: 15px;
+.censo-admin .ca-pres-title {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
   color: var(--ink);
+  line-height: 1.2;
 }
 
-.censo-admin .ca-pres-title span {
-  display: block;
+.censo-admin .ca-pres-subtitle {
   font-size: 12.5px;
+  font-weight: 500;
   color: var(--muted);
+}
+
+.censo-admin .ca-pres-missing {
+  font-size: 12px;
+  color: #B45309;
+}
+
+.censo-admin .ca-pres-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.censo-admin .ca-pres-counter {
+  min-width: 60px;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.censo-admin .ca-pres-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: var(--rad-sm);
+  color: var(--accent);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.censo-admin .ca-pres-nav-btn:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
 }
 
 .censo-admin .ca-pres-close {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
+  gap: 7px;
+  height: 38px;
+  padding: 0 14px;
   background: transparent;
   border: 1px solid var(--bdr);
   border-radius: var(--rad-sm);
   color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 600;
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
 }
@@ -1411,35 +1541,41 @@
   color: var(--ink);
 }
 
-.censo-admin .ca-pres-body {
-  flex: 1;
-  padding: 24px 20px;
-  overflow: auto;
-}
-
-.censo-admin .ca-pres-card {
-  padding: 24px;
-  background: var(--bg);
-  border: 1px solid var(--bdr);
-  border-radius: var(--rad-sm);
-  text-align: center;
-}
-
-.censo-admin .ca-pres-card h2 {
-  margin: 0 0 8px;
-  font-size: 16px;
-  color: var(--ink);
-}
-
-.censo-admin .ca-pres-card p {
-  margin: 0;
-  font-size: 13px;
-  color: var(--muted);
-}
-
-.censo-admin .ca-pres-actions {
+/* Footer institucional fixo */
+.censo-admin .ca-pres-footer {
+  pointer-events: auto;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
   display: flex;
-  justify-content: flex-end;
-  padding: 16px 20px;
+  align-items: center;
+  justify-content: center;
+  min-height: 58px;
+  padding: 10px 40px;
+  background: var(--frame);
   border-top: 1px solid var(--bdr);
+}
+
+.censo-admin .ca-pres-footer-logo {
+  height: 30px;
+  width: auto;
+  object-fit: contain;
+}
+
+@media (max-width: 640px) {
+  .censo-admin .ca-app.presenting .admin-page {
+    padding-top: 108px;
+    padding-bottom: 68px;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+  .censo-admin .ca-app.presenting [data-pres-slide].ca-pres-slide-active {
+    min-height: calc(100vh - 190px);
+    max-height: calc(100vh - 190px);
+  }
+  .censo-admin .ca-pres-top { padding: 14px 20px; gap: 14px; }
+  .censo-admin .ca-pres-title { font-size: 18px; }
+  .censo-admin .ca-pres-close span { display: none; }
+  .censo-admin .ca-pres-close { padding: 0; width: 38px; justify-content: center; }
 }

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -463,7 +463,7 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
 
   return (
     <div className={`censo-admin${dark ? " dark" : ""}`}>
-      <div className={`ca-app${collapsed ? " collapsed" : ""}${mobileNavOpen ? " nav-open" : ""}`}>
+      <div className={`ca-app${collapsed ? " collapsed" : ""}${mobileNavOpen ? " nav-open" : ""}${presentationMode ? " presenting" : ""}`}>
 
         {/* Overlay da gaveta de navegação — visível apenas no mobile (CSS) */}
         <div className="ca-nav-overlay" onClick={() => setMobileNavOpen(false)} />
@@ -586,11 +586,13 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
               </div>
             )}
 
-            <FiltrosGlobais
-              opcoes={filtrosOpcoes}
-              filters={filters}
-              onFiltersChange={updateFilters}
-            />
+            <div className="ca-filters-wrap">
+              <FiltrosGlobais
+                opcoes={filtrosOpcoes}
+                filters={filters}
+                onFiltersChange={updateFilters}
+              />
+            </div>
             {/* Renderiza todas as abas já visitadas. Quando volta para uma aba os dados já são carregados*/}
             {visited.has("perfil") && (
               <div style={{ display: tab === "perfil" ? undefined : "none" }}>
@@ -677,7 +679,11 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
       )}
 
       {presentationMode && (
-        <PresentationMode onClose={() => setPresentationMode(false)} />
+        <PresentationMode
+          onClose={() => setPresentationMode(false)}
+          onNavigateTab={(tabId) => handleNav(tabId as Tab)}
+          dark={dark}
+        />
       )}
     </div>
   );

--- a/web/src/components/admin/AbaCaracterizacao.tsx
+++ b/web/src/components/admin/AbaCaracterizacao.tsx
@@ -204,7 +204,7 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
   return (
     <div className="space-y-6">
       {/* Indicação discreta da fonte de dados da aba. */}
-      <div className={`flex items-center gap-2 text-xs ${sourceTone === "emerald" ? "text-emerald-700" : "text-amber-700"
+      <div data-pres-hide="true" className={`flex items-center gap-2 text-xs ${sourceTone === "emerald" ? "text-emerald-700" : "text-amber-700"
         }`}>
         <span className={`inline-block w-2 h-2 rounded-full ${sourceTone === "emerald" ? "bg-emerald-500" : "bg-amber-500"
           }`} />
@@ -213,7 +213,7 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
 
       {/* Avisos detalhados de falha — só aparecem se houve fallback. */}
       {(perfilErr || dreErr) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm animate-fade-in">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm animate-fade-in">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>
             Indicadores via PostgreSQL parcialmente indisponíveis
@@ -225,13 +225,14 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
       )}
       {/* Se até a planilha falhou mas o PG funcionou, deixamos só um aviso suave. */}
       {sheetErr && !perfilErr && !dreErr && (
-        <div className="flex items-start gap-2 bg-slate-50 border border-slate-200 text-slate-600 rounded-xl px-4 py-3 text-xs animate-fade-in">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-slate-50 border border-slate-200 text-slate-600 rounded-xl px-4 py-3 text-xs animate-fade-in">
           <AlertCircle size={14} className="shrink-0 mt-0.5" />
           <span>Planilha (fallback) indisponível ({sheetErr}). Operando 100% via PostgreSQL.</span>
         </div>
       )}
 
       {/* ── Dimensão e Perfil da Rede ─────────────────────────── */}
+      <div data-pres-slide="perfil-dimensao-indicadores" className="space-y-6">
       <div id="sec-perfil-dimensao" className="animate-fade-in-up">
         <div className="flex items-center gap-3 mb-4">
           <Building2 size={18} style={{ color: C.primary }} />
@@ -247,7 +248,9 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
         </div>
       </div>
 
+      </div>
       {/* Linha de donuts — Distribuição por Porte e por Zona */}
+      <div data-pres-slide="perfil-dimensao-distribuicao" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 animate-fade-in-up [animation-delay:150ms]">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -265,7 +268,9 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
         </div>
       </div>
 
+      </div>
       {/* Distribuição de Matrículas por Porte — bar chart */}
+      <div data-pres-slide="perfil-dimensao-matriculas" className="space-y-6">
       <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm animate-fade-in-up [animation-delay:300ms]">
         <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
           <Users size={16} style={{ color: C.primary }} />
@@ -274,8 +279,9 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
         <HBarChart rows={matriculasBar} color={C.primary} />
       </div>
 
+      </div>
       {/* ── Organização da Oferta e Funcionamento ─────────────── */}
-      <div id="sec-perfil-oferta" className="animate-fade-in-up [animation-delay:600ms]">
+      <div id="sec-perfil-oferta" data-pres-hide="true" className="animate-fade-in-up [animation-delay:600ms]">
         <div className="flex items-center gap-3 mb-4">
           <Clock size={18} style={{ color: C.primary }} />
           <h2 className="font-semibold text-slate-800 text-base">Organização da Oferta e Funcionamento</h2>
@@ -283,16 +289,14 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
         </div>
       </div>
 
-      <div className="space-y-5">
+      <div data-pres-slide="perfil-oferta-etapas" className="space-y-5">
         {ofertaErr && (
-          <div className="flex items-center gap-2 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
+          <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
             <AlertCircle size={14} /> Oferta e funcionamento indisponível: {ofertaErr}
           </div>
         )}
 
         {ofertaPg && (
-          <>
-            {/* Etapas + Modalidades */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
               <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
                 <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -321,8 +325,10 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
                 />
               </div>
             </div>
-
-            {/* Turnos + Média por porte */}
+        )}
+      </div>
+      <div data-pres-slide="perfil-oferta-turnos" className="space-y-5">
+        {ofertaPg && (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
               <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
                 <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -353,12 +359,11 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
                 />
               </div>
             </div>
-          </>
         )}
       </div>
 
       {/* ── Infraestrutura Educacional ────────────────────────── */}
-      <div id="sec-perfil-infra" className="animate-fade-in-up [animation-delay:750ms]">
+      <div id="sec-perfil-infra" data-pres-hide="true" className="animate-fade-in-up [animation-delay:750ms]">
         <div className="flex items-center gap-3 mb-4">
           <LayoutGrid size={18} style={{ color: C.primary }} />
           <h2 className="font-semibold text-slate-800 text-base">Infraestrutura Educacional</h2>
@@ -372,19 +377,17 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
           </button>
           <div className="flex-1 h-px bg-slate-200" />
         </div>
+      </div>
 
-        <div className="space-y-5">
+      <div data-pres-slide="perfil-infra-indicadores" className="space-y-5">
           {infraErr && !infraPg && (
-            <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+            <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
               <AlertCircle size={15} className="shrink-0 mt-0.5" />
               <span>Infraestrutura Educacional indisponível ({infraErr}).</span>
             </div>
           )}
 
           {infraPg && (
-            <>
-              {/* KPIs de cobertura essencial. "Total de Escolas" não é
-                repetido aqui — já consta no bloco Dimensão e Perfil da Rede. */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <StatCard
                   label="Média de Ambientes Essenciais"
@@ -401,7 +404,11 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
                   sub={`possuem os ${infraPg.cobertura_essenciais.total_essenciais} essenciais`}
                 />
               </div>
+          )}
+      </div>
 
+      <div data-pres-slide="perfil-infra-ambientes" className="space-y-5">
+          {infraPg && (
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
                 {/* Ranking de ambientes mais presentes */}
                 <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
@@ -441,7 +448,11 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
                 </div>
               </div>
 
-              {/* Média de essenciais por porte */}
+          )}
+      </div>
+
+      <div data-pres-slide="perfil-infra-media" className="space-y-5">
+          {infraPg && (
               <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
                 <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
                   <TrendingUp size={16} style={{ color: C.primary }} />
@@ -460,14 +471,13 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
                   <p className="text-sm text-slate-400">Sem dados de porte.</p>
                 )}
               </div>
-            </>
           )}
-        </div>
       </div>
 
       {/* Janela informativa — ambientes essenciais */}
       {infoOpen && (
         <div
+          data-pres-hide="true"
           className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4 animate-fade-in"
           onClick={() => setInfoOpen(false)}
         >
@@ -510,13 +520,14 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
         </div>
       )}
 
+      <div data-pres-slide="perfil-dre-tabela" className="space-y-6">
       {/* Tabela DRE detalhada */}
       <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm animate-fade-in-up [animation-delay:900ms]">
         <div className="px-6 py-4 border-b border-slate-200 flex items-center gap-2" style={{ background: C.primaryLight }}>
           <MapPinned size={16} style={{ color: C.primary }} />
           <h3 className="font-semibold text-slate-800 text-sm">Detalhamento por DRE</h3>
         </div>
-        <div className="overflow-x-auto">
+        <div data-pres-table-scroll="true" className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-slate-50 border-b border-slate-200">
               <tr>
@@ -538,6 +549,7 @@ export function AbaCaracterizacao({ token, onUnauth, filters }: { token: string;
             </tbody>
           </table>
         </div>
+      </div>
       </div>
     </div>
   );

--- a/web/src/components/admin/AbaInfraestruturaSeguranca.tsx
+++ b/web/src/components/admin/AbaInfraestruturaSeguranca.tsx
@@ -135,32 +135,33 @@ export function AbaInfraestruturaSeguranca({
   return (
     <div className="space-y-6">
       {/* Badge de fonte */}
-      <div className="flex items-center gap-2 text-xs text-emerald-700">
+      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
         <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* Banners de erro parcial */}
       {condErr && seguranca && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Condições estruturais indisponíveis ({condErr}). Exibindo apenas os indicadores de segurança.</span>
         </div>
       )}
       {segErr && condicoes && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Segurança física indisponível ({segErr}). Exibindo apenas as condições estruturais.</span>
         </div>
       )}
 
       {/* ── Condições Estruturais e Ambientes ────────────────────── */}
-      <div className="flex items-center gap-3 animate-fade-in-up">
+      <div data-pres-hide="true" className="flex items-center gap-3 animate-fade-in-up">
         <Layers size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Condições Estruturais e Ambientes</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="infra-condicoes-resumo" className="space-y-6">
       {condicoes && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 animate-fade-in-up [animation-delay:150ms]">
           <div className="bg-white border border-slate-200 rounded-2xl p-5 shadow-sm hover:shadow-lg hover:-translate-y-1 hover:border-slate-300 transition-all duration-300 group cursor-default animate-fade-in-up">
@@ -200,6 +201,8 @@ export function AbaInfraestruturaSeguranca({
         </div>
       )}
 
+      </div>
+      <div data-pres-slide="infra-condicoes-situacao" className="space-y-6">
       <div id="sec-infra-condicoes" className="grid grid-cols-1 lg:grid-cols-2 gap-5 animate-fade-in-up [animation-delay:300ms]">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -225,6 +228,8 @@ export function AbaInfraestruturaSeguranca({
         </div>
       </div>
 
+      </div>
+      <div data-pres-slide="infra-condicoes-ambientes" className="space-y-6">
       <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
         <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
           <MapPinned size={16} style={{ color: C.primary }} />
@@ -237,12 +242,14 @@ export function AbaInfraestruturaSeguranca({
         )}
       </div>
 
+      </div>
       {/* ── Energia, Climatização e Capacidade Elétrica ── */}
-      <div id="sec-infra-energia" className="flex items-center gap-3">
+      <div id="sec-infra-energia" data-pres-hide="true" className="flex items-center gap-3">
         <Zap size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Energia, Climatização e Cap. Elétrica</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
+      <div data-pres-slide="infra-energia-distribuicao" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -291,6 +298,8 @@ export function AbaInfraestruturaSeguranca({
         </div>
       </div>
 
+      </div>
+      <div data-pres-slide="infra-energia-tabela" className="space-y-6">
       {/* Tabela: salas climatizadas por faixa */}
       {energia && (energia.tabela_climatizacao ?? []).length > 0 && (() => {
         const rows = energia.tabela_climatizacao;
@@ -299,7 +308,7 @@ export function AbaInfraestruturaSeguranca({
         const totNao = rows.reduce((s, r) => s + r.nao_climatizadas, 0);
         return (
           <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm">
-            <div className="overflow-x-auto">
+            <div data-pres-table-scroll="true" className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="bg-slate-50 border-b border-slate-200">
@@ -333,12 +342,14 @@ export function AbaInfraestruturaSeguranca({
         );
       })()}
 
+      </div>
       {/* ── Segurança Física e Patrimonial ───────────────────────── */}
-      <div className="flex items-center gap-3">
+      <div data-pres-hide="true" className="flex items-center gap-3">
         <ShieldCheck size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Segurança Física e Patrimonial</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
+      <div data-pres-slide="infra-seguranca-indicadores" className="space-y-6">
       <div id="sec-infra-seguranca" className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard
           label="Guarita"
@@ -370,6 +381,8 @@ export function AbaInfraestruturaSeguranca({
         />
       </div>
 
+      </div>
+      <div data-pres-slide="infra-seguranca-acesso" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -399,6 +412,8 @@ export function AbaInfraestruturaSeguranca({
         </div>
       </div>
 
+      </div>
+      <div data-pres-slide="infra-seguranca-iluminacao" className="space-y-6">
       <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm animate-fade-in-up [animation-delay:450ms]">
         <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
           <Lightbulb size={16} style={{ color: "#ec4899" }} />
@@ -431,6 +446,8 @@ export function AbaInfraestruturaSeguranca({
         )}
       </div>
 
+      </div>
+      <div data-pres-slide="infra-seguranca-perimetro" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -468,6 +485,7 @@ export function AbaInfraestruturaSeguranca({
             <NoData />
           )}
         </div>
+      </div>
       </div>
     </div>
   );

--- a/web/src/components/admin/AbaMerenda.tsx
+++ b/web/src/components/admin/AbaMerenda.tsx
@@ -328,38 +328,39 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
   return (
     <div className="space-y-6">
       {/* Badge de fonte */}
-      <div className="flex items-center gap-2 text-xs text-emerald-700">
+      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
         <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* Banners de erro parcial */}
       {ofertaErr && (equip || sanit) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Oferta e estrutura da merenda indisponíveis ({ofertaErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
       {equipErr && (oferta || sanit) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Equipamentos da merenda indisponíveis ({equipErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
       {sanitErr && (oferta || equip) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Condições sanitárias e segurança da merenda indisponíveis ({sanitErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
 
       {/* ── Oferta e Adequação da Merenda ────────────────────────── */}
-      <div id="sec-merenda-oferta" className="flex items-center gap-3">
+      <div id="sec-merenda-oferta" data-pres-hide="true" className="flex items-center gap-3">
         <Utensils size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Oferta e Adequação da Merenda</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="merenda-oferta-resumo" className="space-y-6">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <StatCard
           label="Atende às Necessidades"
@@ -377,6 +378,8 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
         />
       </div>
 
+      </div>
+      <div data-pres-slide="merenda-oferta-graficos" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -389,6 +392,11 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
             <NoData />
           )}
         </div>
+      </div>
+      </div>
+
+      <div data-pres-slide="merenda-oferta-necessidades" className="space-y-6">
+      <div className="grid grid-cols-1 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
             <CheckCircle2 size={16} style={{ color: C.primary }} />
@@ -413,12 +421,14 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
         </div>
       </div>
 
+      </div>
       {/* ── Estrutura Física da Cozinha ──────────────────────────── */}
-      <div id="sec-merenda-estrutura" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-merenda-estrutura" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <ChefHat size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Estrutura Física da Cozinha</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
+      <div data-pres-slide="merenda-estrutura-cozinha" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -442,6 +452,10 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
             <NoData />
           )}
         </div>
+      </div>
+      </div>
+      <div data-pres-slide="merenda-estrutura-refeitorio" className="space-y-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
             <ChefHat size={16} style={{ color: C.primary }} />
@@ -466,13 +480,15 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
         </div>
       </div>
 
+      </div>
       {/* ── Equipamentos da Merenda ──────────────────────────────── */}
-      <div id="sec-merenda-equipamentos" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-merenda-equipamentos" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <Refrigerator size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Equipamentos da Merenda</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="merenda-equipamentos-cards" className="space-y-6">
       <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
         <EquipCard label="Freezers"   dados={equip?.freezers}   Icon={Snowflake}    tone="blue" />
         <EquipCard label="Geladeiras" dados={equip?.geladeiras} Icon={Refrigerator} tone="green" />
@@ -480,7 +496,9 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
         <EquipCard label="Fornos"     dados={equip?.fornos}     Icon={Microwave}    tone="amber" />
         <EquipCard label="Bebedouros" dados={equip?.bebedouros} Icon={GlassWater}   tone="purple" />
       </div>
+      </div>
 
+      <div data-pres-slide="merenda-equipamentos-cobertura" className="space-y-6">
       {/* Gráficos sintéticos de equipamentos */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
@@ -505,6 +523,11 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
             <NoData />
           )}
         </div>
+      </div>
+      </div>
+
+      <div data-pres-slide="merenda-equipamentos-criticidade" className="space-y-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
             <ClipboardList size={16} style={{ color: C.primary }} />
@@ -529,7 +552,9 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
           )}
         </div>
       </div>
+      </div>
 
+      <div data-pres-slide="merenda-equipamentos-conservacao" className="space-y-6">
       {/* Estado de conservação — visão consolidada */}
       <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm">
         <div
@@ -552,7 +577,9 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
           )}
         </div>
       </div>
+      </div>
 
+      <div data-pres-slide="merenda-equipamentos-tabela" className="space-y-6">
       <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm">
         <div
           className="px-6 py-4 border-b flex items-center gap-2"
@@ -563,7 +590,7 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
         </div>
         <div className="p-6">
           {equip && equip.dist_estados.length > 0 ? (
-            <div className="overflow-x-auto">
+            <div data-pres-table-scroll="true" className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="text-left text-xs uppercase tracking-wide text-slate-500 border-b border-slate-200">
@@ -594,13 +621,15 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
           )}
         </div>
       </div>
+      </div>
 
       {/* ── Condições Sanitárias e Segurança ─────────────────────── */}
-      <div id="sec-merenda-sanitarias" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-merenda-sanitarias" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <ShieldCheck size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Condições Sanitárias e Segurança</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
+      <div data-pres-slide="merenda-sanitarias-armazenamento" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
@@ -624,6 +653,11 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
             <NoData />
           )}
         </div>
+      </div>
+      </div>
+
+      <div data-pres-slide="merenda-sanitarias-itens" className="space-y-6">
+      <div className="grid grid-cols-1 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
             <ClipboardList size={16} style={{ color: C.primary }} />
@@ -636,6 +670,11 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
             <NoData />
           )}
         </div>
+      </div>
+      </div>
+
+      <div data-pres-slide="merenda-sanitarias-seguranca" className="space-y-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-5 flex items-center gap-2">
             <FireExtinguisher size={16} style={{ color: C.primary }} />
@@ -658,6 +697,7 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
             <NoData />
           )}
         </div>
+      </div>
       </div>
     </div>
   );

--- a/web/src/components/admin/AbaPerfilAlunos.tsx
+++ b/web/src/components/admin/AbaPerfilAlunos.tsx
@@ -69,7 +69,7 @@ export function AbaPerfilAlunos({
     <div className="space-y-5">
       {/* Label do subtab — igual Looker Studio */}
       {!presentationMode && (
-        <div className="bg-orange-50 border border-orange-200 rounded-xl px-5 py-3 animate-slide-in-right">
+        <div data-pres-hide="true" className="bg-orange-50 border border-orange-200 rounded-xl px-5 py-3 animate-slide-in-right">
           <p className="text-sm text-orange-800 italic font-medium">
             Qual é o perfil socioeconômico dos estudantes e como está a permanência e o fluxo escolar na rede?
           </p>
@@ -77,6 +77,7 @@ export function AbaPerfilAlunos({
       )}
 
       {/* Stat card de risco — big number */}
+      <div data-pres-slide="alunos-visao-indicadores" className="space-y-5">
       <div id="sec-alunos-visao" className="grid grid-cols-1 sm:grid-cols-3 gap-4 animate-fade-in-up [animation-delay:150ms]">
         <StatCard
           label="Escolas com Risco de Fluxo"
@@ -101,8 +102,10 @@ export function AbaPerfilAlunos({
           compact={presentationMode}
         />
       </div>
+      </div>
 
       {/* Linha 1: dois gráficos de barra vertical */}
+      <div data-pres-slide="alunos-faixas-distribuicao" className="space-y-5">
       <div id="sec-alunos-faixas" className="grid grid-cols-1 lg:grid-cols-2 gap-5 animate-fade-in-up [animation-delay:300ms]">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1">
@@ -142,8 +145,10 @@ export function AbaPerfilAlunos({
           )}
         </div>
       </div>
+      </div>
 
       {/* Linha 2: Top 10 DREs + card risco */}
+      <div data-pres-slide="alunos-abandono-risco" className="space-y-5">
       <div id="sec-alunos-abandono" className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         <div className="lg:col-span-2 bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1">
@@ -174,6 +179,7 @@ export function AbaPerfilAlunos({
             <AlertTriangle size={12} /> flag ativa
           </span>
         </div>
+      </div>
       </div>
     </div>
   );

--- a/web/src/components/admin/AbaPessoalGestao.tsx
+++ b/web/src/components/admin/AbaPessoalGestao.tsx
@@ -148,13 +148,13 @@ export function AbaPessoalGestao({
   return (
     <div className="space-y-6">
       {/* Badge de fonte */}
-      <div className="flex items-center gap-2 text-xs text-emerald-700">
+      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
         <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* ── Estrutura de Gestão Escolar ──────────────────────────── */}
-      <div id="sec-pessoal-estrutura" className="flex items-center gap-3">
+      <div id="sec-pessoal-estrutura" data-pres-hide="true" className="flex items-center gap-3">
         <UsersRound size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Estrutura de Gestão Escolar</h2>
         <div className="flex-1 h-px bg-slate-200" />
@@ -162,24 +162,25 @@ export function AbaPessoalGestao({
 
       {/* Banners de erro parcial */}
       {estruturaErr && (coordenacao || quadro) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de estrutura de gestão indisponíveis ({estruturaErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
       {coordenacaoErr && (estrutura || quadro) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de coordenação indisponíveis ({coordenacaoErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
       {quadroErr && (estrutura || coordenacao) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de quadro de pessoal indisponíveis ({quadroErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
 
+      <div data-pres-slide="pessoal-estrutura-resumo" className="space-y-6">
       {/* ── Resumo Executivo ─────────────────────────────────────── */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 animate-fade-in-up">
         <StatCard
@@ -212,6 +213,8 @@ export function AbaPessoalGestao({
         />
       </div>
 
+      </div>
+      <div data-pres-slide="pessoal-estrutura-composicao" className="space-y-6">
       <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm animate-fade-in-up [animation-delay:150ms]">
         <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
           <UsersRound size={16} style={{ color: C.primary }} />
@@ -227,13 +230,15 @@ export function AbaPessoalGestao({
         )}
       </div>
 
+      </div>
       {/* ── Coordenação Pedagógica ───────────────────────────────── */}
-      <div id="sec-pessoal-coordenacao" className="flex items-center gap-3 border-t border-slate-200 pt-4 animate-fade-in-up [animation-delay:300ms]">
+      <div id="sec-pessoal-coordenacao" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4 animate-fade-in-up [animation-delay:300ms]">
         <GraduationCap size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Coordenação Pedagógica</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="pessoal-coordenacao" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         <div className="lg:col-span-2 bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
@@ -251,13 +256,15 @@ export function AbaPessoalGestao({
         </div>
       </div>
 
+      </div>
       {/* ── Quadro de Pessoal ────────────────────────────────────── */}
-      <div id="sec-pessoal-quadro" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-pessoal-quadro" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <Briefcase size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Quadro de Pessoal</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="pessoal-quadro-indicadores" className="space-y-6">
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard
           label="Servidores Administrativos"
@@ -289,6 +296,8 @@ export function AbaPessoalGestao({
         />
       </div>
 
+      </div>
+      <div data-pres-slide="pessoal-quadro-distribuicao" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
@@ -320,6 +329,8 @@ export function AbaPessoalGestao({
         </div>
       </div>
 
+      </div>
+      <div data-pres-slide="pessoal-quadro-dre" className="space-y-6">
       {quadro && quadro.por_dre.length > 0 && (
         <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm">
           <div
@@ -329,7 +340,7 @@ export function AbaPessoalGestao({
             <ClipboardList size={16} className="shrink-0" strokeWidth={2} style={{ color: C.primary }} />
             <h2 className="font-semibold text-slate-800 text-sm">Detalhamento por DRE</h2>
           </div>
-          <div className="p-6 overflow-x-auto">
+          <div data-pres-table-scroll="true" className="p-6 overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="text-left text-xs uppercase tracking-wide text-slate-500 border-b border-slate-200">
@@ -362,6 +373,7 @@ export function AbaPessoalGestao({
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
+++ b/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
@@ -388,7 +388,7 @@ export function AbaSaudeOperacionalEscolas({
 
   return (
     <div className="space-y-6">
-      <header className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm lg:flex-row lg:items-start lg:justify-between">
+      <header data-pres-hide="true" className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm lg:flex-row lg:items-start lg:justify-between">
         <div>
           <div className="mb-2 flex items-center gap-2 text-sm font-semibold" style={{ color: C.primary }}>
             <HeartPulse size={18} />
@@ -417,6 +417,7 @@ export function AbaSaudeOperacionalEscolas({
         </div>
       </header>
 
+      <div data-pres-slide="saude-resumo-indicadores" className="space-y-6">
       <div id="sec-saude-resumo" className="grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-6">
         <SummaryCard
           label="Escolas avaliadas"
@@ -457,8 +458,9 @@ export function AbaSaudeOperacionalEscolas({
           sub="Escolas com nota"
         />
       </div>
+      </div>
 
-      <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+      <div data-pres-hide="true" className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
         <div className="relative w-full sm:max-w-md">
           <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
           <input
@@ -487,144 +489,146 @@ export function AbaSaudeOperacionalEscolas({
       </div>
 
       {loading && (
-        <div className="flex items-center gap-2 text-xs text-slate-400">
+        <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-slate-400">
           <Loader2 className="animate-spin" size={14} style={{ color: C.primary }} />
           Atualizando…
         </div>
       )}
 
-      {payload.total_escolas === 0 ? (
-        <div className="rounded-2xl border border-slate-200 bg-white px-6 py-16 text-center shadow-sm">
-          <CircleHelp size={28} className="mx-auto mb-3 text-slate-300" />
-          <p className="text-sm font-medium text-slate-600">Nenhuma escola disponível.</p>
-          <p className="mt-1 text-xs text-slate-400">
-            O endpoint não retornou registros para o ano de referência.
-          </p>
-        </div>
-      ) : (
-        <div id="sec-saude-escolas" className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-          <div className="overflow-x-auto">
-            <table className="min-w-[1900px] w-full text-sm">
-              <thead style={{ background: C.primary }} className="text-white">
-                <tr>
-                  <th scope="col" className="w-16 px-3 py-3 text-center text-[11px] font-semibold uppercase tracking-wide">
-                    Farol
-                  </th>
-                  <SortHeader label="Escola" sortKey="escola" activeKey={sortKey} direction={sortDir} onSort={handleSort} className="min-w-64" />
-                  <SortHeader label="Município" sortKey="municipio" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="DRE" sortKey="dre" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Zona" sortKey="zona" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Alunos" sortKey="total_alunos" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Aln/sala" sortKey="alunos_por_sala" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Saúde" sortKey="saude" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Criticidade" sortKey="criticidade" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Infra" sortKey="infraestrutura" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Energia" sortKey="energia" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Merenda" sortKey="merenda" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Segur." sortKey="seguranca" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Pessoal" sortKey="pessoal" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Tec." sortKey="tecnologia" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Pedag." sortKey="pedagogico" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                  <SortHeader label="Gov." sortKey="governanca" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100">
-                {payload.escolas.map((escola: SaudeOperacionalEscola) => (
-                  <tr key={escola.school_id} className="hover:bg-slate-50/80">
-                    <td className="w-16 px-3 py-3 text-center">
-                      <StatusBadge status={escola.status} />
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="max-w-80 font-medium text-slate-800">{escola.escola}</div>
-                      <div className="mt-0.5 text-[11px] text-slate-400">
-                        INEP: {escola.codigo_inep ?? "—"}
-                      </div>
-                    </td>
-                    <td className="px-3 py-3 text-slate-600">{escola.municipio}</td>
-                    <td className="px-3 py-3 text-slate-600">{escola.dre}</td>
-                    <td className="px-3 py-3 text-slate-600">{escola.zona ?? "—"}</td>
-                    <td className="px-3 py-3 text-right tabular-nums text-slate-700">{fmtInt(escola.total_alunos)}</td>
-                    <td className="px-3 py-3 text-right tabular-nums text-slate-700">{fmtDecimal(escola.alunos_por_sala)}</td>
-                    <td className="px-3 py-3"><HealthCell value={escola.saude} status={escola.status} /></td>
-                    <td className="px-3 py-3 text-right font-semibold tabular-nums text-slate-700">{fmtDecimal(escola.criticidade)}</td>
-                    <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.infraestrutura} /></td>
-                    <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.energia} /></td>
-                    <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.merenda} /></td>
-                    <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.seguranca} /></td>
-                    <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.pessoal} /></td>
-                    <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.tecnologia} /></td>
-                    <td className="px-3 py-3 text-center"><DimensionBadge value={null} /></td>
-                    <td className="px-3 py-3 text-center"><DimensionBadge value={null} /></td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      <div data-pres-slide="saude-escolas-tabela">
+        {payload.total_escolas === 0 ? (
+          <div className="rounded-2xl border border-slate-200 bg-white px-6 py-16 text-center shadow-sm">
+            <CircleHelp size={28} className="mx-auto mb-3 text-slate-300" />
+            <p className="text-sm font-medium text-slate-600">Nenhuma escola disponível.</p>
+            <p className="mt-1 text-xs text-slate-400">
+              O endpoint não retornou registros para o ano de referência.
+            </p>
           </div>
-
-          {payload.escolas.length === 0 && (
-            <div className="border-t border-slate-100 px-6 py-12 text-center">
-              <Search size={24} className="mx-auto mb-2 text-slate-300" />
-              <p className="text-sm font-medium text-slate-600">Nenhuma escola encontrada.</p>
-              <p className="mt-1 text-xs text-slate-400">Tente outro termo de busca.</p>
+        ) : (
+          <div id="sec-saude-escolas" className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <div data-pres-table-scroll="true" className="overflow-x-auto">
+              <table className="min-w-[1900px] w-full text-sm">
+                <thead style={{ background: C.primary }} className="text-white">
+                  <tr>
+                    <th scope="col" className="w-16 px-3 py-3 text-center text-[11px] font-semibold uppercase tracking-wide">
+                      Farol
+                    </th>
+                    <SortHeader label="Escola" sortKey="escola" activeKey={sortKey} direction={sortDir} onSort={handleSort} className="min-w-64" />
+                    <SortHeader label="Município" sortKey="municipio" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="DRE" sortKey="dre" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Zona" sortKey="zona" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Alunos" sortKey="total_alunos" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Aln/sala" sortKey="alunos_por_sala" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Saúde" sortKey="saude" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Criticidade" sortKey="criticidade" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Infra" sortKey="infraestrutura" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Energia" sortKey="energia" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Merenda" sortKey="merenda" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Segur." sortKey="seguranca" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Pessoal" sortKey="pessoal" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Tec." sortKey="tecnologia" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Pedag." sortKey="pedagogico" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                    <SortHeader label="Gov." sortKey="governanca" activeKey={sortKey} direction={sortDir} onSort={handleSort} />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {payload.escolas.map((escola: SaudeOperacionalEscola) => (
+                    <tr key={escola.school_id} className="hover:bg-slate-50/80">
+                      <td className="w-16 px-3 py-3 text-center">
+                        <StatusBadge status={escola.status} />
+                      </td>
+                      <td className="px-3 py-3">
+                        <div className="max-w-80 font-medium text-slate-800">{escola.escola}</div>
+                        <div className="mt-0.5 text-[11px] text-slate-400">
+                          INEP: {escola.codigo_inep ?? "—"}
+                        </div>
+                      </td>
+                      <td className="px-3 py-3 text-slate-600">{escola.municipio}</td>
+                      <td className="px-3 py-3 text-slate-600">{escola.dre}</td>
+                      <td className="px-3 py-3 text-slate-600">{escola.zona ?? "—"}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-700">{fmtInt(escola.total_alunos)}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-700">{fmtDecimal(escola.alunos_por_sala)}</td>
+                      <td className="px-3 py-3"><HealthCell value={escola.saude} status={escola.status} /></td>
+                      <td className="px-3 py-3 text-right font-semibold tabular-nums text-slate-700">{fmtDecimal(escola.criticidade)}</td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.infraestrutura} /></td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.energia} /></td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.merenda} /></td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.seguranca} /></td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.pessoal} /></td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.tecnologia} /></td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={null} /></td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={null} /></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
-          )}
 
-          <div className="flex flex-col items-center justify-between gap-3 border-t border-slate-100 px-4 py-3 sm:flex-row">
-            <div className="flex items-center gap-2 text-xs text-slate-500">
-              <span>Linhas por página:</span>
-              <div className="flex gap-1">
-                {PAGE_SIZE_OPTIONS.map((size) => (
-                  <button
-                    key={size}
-                    type="button"
-                    onClick={() => handlePageSizeChange(size)}
-                    className={`rounded px-2 py-1 font-medium transition-colors ${
-                      pageSize === size
-                        ? "text-white"
-                        : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-                    }`}
-                    style={pageSize === size ? { background: C.primary } : undefined}
-                  >
-                    {size}
-                  </button>
-                ))}
+            {payload.escolas.length === 0 && (
+              <div className="border-t border-slate-100 px-6 py-12 text-center">
+                <Search size={24} className="mx-auto mb-2 text-slate-300" />
+                <p className="text-sm font-medium text-slate-600">Nenhuma escola encontrada.</p>
+                <p className="mt-1 text-xs text-slate-400">Tente outro termo de busca.</p>
+              </div>
+            )}
+
+            <div className="flex flex-col items-center justify-between gap-3 border-t border-slate-100 px-4 py-3 sm:flex-row">
+              <div className="flex items-center gap-2 text-xs text-slate-500">
+                <span>Linhas por página:</span>
+                <div className="flex gap-1">
+                  {PAGE_SIZE_OPTIONS.map((size) => (
+                    <button
+                      key={size}
+                      type="button"
+                      onClick={() => handlePageSizeChange(size)}
+                      className={`rounded px-2 py-1 font-medium transition-colors ${
+                        pageSize === size
+                          ? "text-white"
+                          : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                      }`}
+                      style={pageSize === size ? { background: C.primary } : undefined}
+                    >
+                      {size}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex items-center gap-1 text-xs text-slate-500">
+                {pageStart > 0 && (
+                  <span className="mr-2">
+                    {pageStart.toLocaleString("pt-BR")}–{pageEnd.toLocaleString("pt-BR")} de{" "}
+                    <strong className="text-slate-700">{payload.total_filtrado.toLocaleString("pt-BR")}</strong>
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => handlePageChange(Math.max(1, payload.page - 1))}
+                  disabled={payload.page <= 1 || totalPages === 0}
+                  className="flex items-center gap-1 rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <ArrowLeft size={13} />
+                  Anterior
+                </button>
+                <span className="px-2 font-medium text-slate-700">
+                  {totalPages === 0 ? "0 de 0" : `${payload.page} / ${totalPages}`}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handlePageChange(Math.min(totalPages, payload.page + 1))}
+                  disabled={totalPages === 0 || payload.page >= totalPages}
+                  className="flex items-center gap-1 rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Próxima
+                  <ArrowRight size={13} />
+                </button>
               </div>
             </div>
-
-            <div className="flex items-center gap-1 text-xs text-slate-500">
-              {pageStart > 0 && (
-                <span className="mr-2">
-                  {pageStart.toLocaleString("pt-BR")}–{pageEnd.toLocaleString("pt-BR")} de{" "}
-                  <strong className="text-slate-700">{payload.total_filtrado.toLocaleString("pt-BR")}</strong>
-                </span>
-              )}
-              <button
-                type="button"
-                onClick={() => handlePageChange(Math.max(1, payload.page - 1))}
-                disabled={payload.page <= 1 || totalPages === 0}
-                className="flex items-center gap-1 rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <ArrowLeft size={13} />
-                Anterior
-              </button>
-              <span className="px-2 font-medium text-slate-700">
-                {totalPages === 0 ? "0 de 0" : `${payload.page} / ${totalPages}`}
-              </span>
-              <button
-                type="button"
-                onClick={() => handlePageChange(Math.min(totalPages, payload.page + 1))}
-                disabled={totalPages === 0 || payload.page >= totalPages}
-                className="flex items-center gap-1 rounded border border-slate-200 px-2 py-1 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                Próxima
-                <ArrowRight size={13} />
-              </button>
-            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
-      <div className="flex items-start gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
+      <div data-pres-hide="true" className="flex items-start gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
         <CircleHelp size={15} className="mt-0.5 shrink-0" />
         <span>
           Saúde, criticidade, status e notas dimensionais são exibidos conforme retornados pelo backend.

--- a/web/src/components/admin/AbaServicosTerceirizados.tsx
+++ b/web/src/components/admin/AbaServicosTerceirizados.tsx
@@ -181,44 +181,45 @@ export function AbaServicosTerceirizados({
   return (
     <div className="space-y-6">
       {/* Badge de fonte */}
-      <div className="flex items-center gap-2 text-xs text-emerald-700">
+      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
         <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* Banners de erro parcial */}
       {visaoErr && (sg || portaria || manip) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de visão geral indisponíveis ({visaoErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
       {sgErr && (visao || portaria || manip) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de serviços gerais indisponíveis ({sgErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
       {portariaErr && (visao || sg || manip) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de portaria indisponíveis ({portariaErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
       {manipErr && (visao || sg || portaria) && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de manipuladores de alimentos indisponíveis ({manipErr}). Exibindo apenas os demais blocos.</span>
         </div>
       )}
 
       {/* ── Visão Geral ──────────────────────────────────────────── */}
-      <div id="sec-servicos-visao" className="flex items-center gap-3 animate-fade-in-up">
+      <div id="sec-servicos-visao" data-pres-hide="true" className="flex items-center gap-3 animate-fade-in-up">
         <Layers size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Visão Geral</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="servicos-visao-resumo" className="space-y-6">
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 animate-fade-in-up [animation-delay:150ms]">
         <StatCard
           label="Áreas com Terceirização"
@@ -249,7 +250,9 @@ export function AbaServicosTerceirizados({
           sub="entre escolas que informaram agentes"
         />
       </div>
+      </div>
 
+      <div data-pres-slide="servicos-visao-cobertura" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 animate-fade-in-up [animation-delay:300ms]">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
@@ -280,14 +283,16 @@ export function AbaServicosTerceirizados({
           )}
         </div>
       </div>
+      </div>
 
       {/* ── Serviços Gerais ──────────────────────────────────────── */}
-      <div id="sec-servicos-gerais" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-servicos-gerais" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <Users size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Serviços Gerais</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="servicos-gerais-indicadores" className="space-y-6">
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard
           label="Efetivos"
@@ -318,7 +323,9 @@ export function AbaServicosTerceirizados({
           sub="média do total informado por escola"
         />
       </div>
+      </div>
 
+      <div data-pres-slide="servicos-gerais-distribuicao" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
@@ -349,14 +356,16 @@ export function AbaServicosTerceirizados({
           )}
         </div>
       </div>
+      </div>
 
       {/* ── Portaria ─────────────────────────────────────────────── */}
-      <div id="sec-servicos-portaria" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-servicos-portaria" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <ShieldCheck size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Portaria</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="servicos-portaria-indicadores" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         <StatCard
           label="Escolas com agentes de portaria"
@@ -380,7 +389,9 @@ export function AbaServicosTerceirizados({
           sub="empresas terceirizadas mais frequentes"
         />
       </div>
+      </div>
 
+      <div data-pres-slide="servicos-portaria-empresas" className="space-y-6">
       <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
         <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
           <Building size={16} style={{ color: C.primary }} />
@@ -395,18 +406,20 @@ export function AbaServicosTerceirizados({
           <NoData />
         )}
       </div>
+      </div>
 
       {/* ── Manipulador de Alimentos ────────────────────────────── */}
-      <div id="sec-servicos-manipuladores" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-servicos-manipuladores" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <ChefHat size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Manipulador de Alimentos</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
-      <p className="text-sm text-slate-500 -mt-2">
+      <p data-pres-hide="true" className="text-sm text-slate-500 -mt-2">
         Merendeiras / manipuladores vinculados ao serviço de alimentação escolar.
       </p>
 
+      <div data-pres-slide="servicos-manipuladores-indicadores" className="space-y-6">
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
         <StatCard
           label="Merendeiras estatutárias"
@@ -451,7 +464,9 @@ export function AbaServicosTerceirizados({
           sub="das escolas"
         />
       </div>
+      </div>
 
+      <div data-pres-slide="servicos-manipuladores-distribuicao" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
@@ -481,6 +496,11 @@ export function AbaServicosTerceirizados({
             <NoData />
           )}
         </div>
+      </div>
+      </div>
+
+      <div data-pres-slide="servicos-manipuladores-empresas" className="space-y-6">
+      <div className="grid grid-cols-1 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm lg:col-span-2">
           <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
             <Building size={16} style={{ color: C.primary }} />
@@ -496,14 +516,16 @@ export function AbaServicosTerceirizados({
           )}
         </div>
       </div>
+      </div>
 
       {/* ── Governança / Supervisão ──────────────────────────────── */}
-      <div id="sec-servicos-governanca" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-servicos-governanca" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <UserCheck size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Governança / Supervisão</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="servicos-governanca-aviso" className="space-y-6">
       <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm flex flex-col items-center text-center py-8">
         <div
           className="w-12 h-12 rounded-2xl flex items-center justify-center text-white shadow-sm mb-3"
@@ -515,6 +537,7 @@ export function AbaServicosTerceirizados({
           Dados de supervisão/governança dos serviços terceirizados ainda não estão disponíveis nos
           endpoints analíticos desta aba.
         </p>
+      </div>
       </div>
     </div>
   );

--- a/web/src/components/admin/AbaTecnologia.tsx
+++ b/web/src/components/admin/AbaTecnologia.tsx
@@ -182,32 +182,33 @@ export function AbaTecnologia({
   return (
     <div className="space-y-6">
       {/* Badge de fonte */}
-      <div className="flex items-center gap-2 text-xs text-emerald-700">
+      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
         <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
         <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
       </div>
 
       {/* Banners de erro parcial */}
       {infraErr && uso && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de infraestrutura tecnológica indisponíveis ({infraErr}). Exibindo apenas o uso pedagógico.</span>
         </div>
       )}
       {usoErr && infra && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+        <div data-pres-hide="true" className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
           <AlertCircle size={15} className="shrink-0 mt-0.5" />
           <span>Dados de uso pedagógico indisponíveis ({usoErr}). Exibindo apenas a infraestrutura tecnológica.</span>
         </div>
       )}
 
       {/* ── Infraestrutura Digital ───────────────────────────────── */}
-      <div id="sec-tecnologia-digital" className="flex items-center gap-3">
+      <div id="sec-tecnologia-digital" data-pres-hide="true" className="flex items-center gap-3">
         <Wifi size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Infraestrutura Digital</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="tecnologia-digital-indicadores" className="space-y-6">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <StatCard
           label="Escolas com Internet"
@@ -225,6 +226,8 @@ export function AbaTecnologia({
         />
       </div>
 
+      </div>
+      <div data-pres-slide="tecnologia-digital-conexao" className="space-y-6">
       {/* 4 colunas no lg: Disponibilidade e Provedores ocupam 1 cada (rótulos
           curtos); Qualidade ocupa 2 (rótulos longos, em barras horizontais). */}
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-5">
@@ -272,13 +275,15 @@ export function AbaTecnologia({
         </div>
       </div>
 
+      </div>
       {/* ── Parque Tecnológico ───────────────────────────────────── */}
-      <div id="sec-tecnologia-parque" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-tecnologia-parque" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <Boxes size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Parque Tecnológico</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="tecnologia-parque-indicadores" className="space-y-6">
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
         <StatCard
           label="Desktops Administrativos"
@@ -324,6 +329,8 @@ export function AbaTecnologia({
         />
       </div>
 
+      </div>
+      <div data-pres-slide="tecnologia-parque-distribuicao" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
@@ -355,6 +362,8 @@ export function AbaTecnologia({
         </div>
       </div>
 
+      </div>
+      <div data-pres-slide="tecnologia-parque-notas" className="space-y-6">
       <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm">
         <div
           className="px-6 py-4 border-b flex items-center gap-2"
@@ -373,13 +382,15 @@ export function AbaTecnologia({
         </div>
       </div>
 
+      </div>
       {/* ── Uso Pedagógico ───────────────────────────────────────── */}
-      <div id="sec-tecnologia-pedagogico" className="flex items-center gap-3 border-t border-slate-200 pt-4">
+      <div id="sec-tecnologia-pedagogico" data-pres-hide="true" className="flex items-center gap-3 border-t border-slate-200 pt-4">
         <Projector size={18} style={{ color: C.primary }} />
         <h2 className="font-semibold text-slate-800 text-base">Uso Pedagógico</h2>
         <div className="flex-1 h-px bg-slate-200" />
       </div>
 
+      <div data-pres-slide="tecnologia-pedagogico-indicadores" className="space-y-6">
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard
           label="Escolas com Projetor"
@@ -411,6 +422,8 @@ export function AbaTecnologia({
         />
       </div>
 
+      </div>
+      <div data-pres-slide="tecnologia-pedagogico-distribuicao" className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         <div className="bg-white rounded-2xl border border-slate-200 p-6 shadow-sm">
           <h3 className="font-semibold text-slate-800 text-sm mb-1 flex items-center gap-2">
@@ -455,8 +468,9 @@ export function AbaTecnologia({
           )}
         </div>
       </div>
+      </div>
 
-      <p className="text-xs text-slate-400">
+      <p data-pres-hide="true" className="text-xs text-slate-400">
         Indicadores baseados nas declarações das escolas no formulário do censo.
       </p>
     </div>

--- a/web/src/components/admin/PresentationMode.tsx
+++ b/web/src/components/admin/PresentationMode.tsx
@@ -1,53 +1,333 @@
 "use client";
 
-import React, { useEffect } from "react";
-import { MonitorPlay, X } from "lucide-react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight, MonitorPlay, X } from "lucide-react";
+
+type PresentationTab =
+  | "perfil"
+  | "pessoal"
+  | "tecnologia"
+  | "infraestrutura"
+  | "merenda"
+  | "servicos"
+  | "alunos"
+  | "saude";
+
+type PresentationSlide = {
+  id: string;
+  tabId: PresentationTab;
+  tabLabel: string;
+  sectionLabel: string;
+  slideTitle?: string;
+  contentId: string;
+};
 
 type PresentationModeProps = {
   onClose: () => void;
+  onNavigateTab: (tabId: PresentationTab) => void;
+  dark?: boolean;
 };
 
-/**
- * Shell inicial do Modo Apresentação.
- *
- * Esta é a primeira versão (PR 1): apenas o overlay base, sem slides reais,
- * âncoras, autoplay, fullscreen ou navegação. A navegação por slides e os
- * recursos avançados serão adicionados em PRs subsequentes.
- *
- * O componente é totalmente autocontido: não importa abas, não faz fetch,
- * não usa token e não toca em filtros/cache/labels.
- */
-export default function PresentationMode({ onClose }: PresentationModeProps) {
-  // Fecha com a tecla Escape.
+const RETRY_INTERVAL_MS = 150;
+const MAX_RETRY_ATTEMPTS = 8;
+
+function createSlides(
+  tabId: PresentationTab,
+  tabLabel: string,
+  sectionLabel: string,
+  entries: Array<[contentId: string, slideTitle?: string]>,
+): PresentationSlide[] {
+  return entries.map(([contentId, slideTitle]) => ({
+    id: contentId,
+    tabId,
+    tabLabel,
+    sectionLabel,
+    slideTitle,
+    contentId,
+  }));
+}
+
+const SLIDES: PresentationSlide[] = [
+  ...createSlides("perfil", "Caracterização da Rede", "Dimensão e Perfil da Rede", [
+    ["perfil-dimensao-indicadores", "Indicadores gerais"],
+    ["perfil-dimensao-distribuicao", "Distribuição das escolas"],
+    ["perfil-dimensao-matriculas", "Matrículas por porte"],
+  ]),
+  ...createSlides("perfil", "Caracterização da Rede", "Organização da Oferta e Funcionamento", [
+    ["perfil-oferta-etapas", "Etapas e modalidades"],
+    ["perfil-oferta-turnos", "Turnos de funcionamento"],
+  ]),
+  ...createSlides("perfil", "Caracterização da Rede", "Infraestrutura Educacional", [
+    ["perfil-infra-indicadores", "Indicadores de cobertura"],
+    ["perfil-infra-ambientes", "Ambientes essenciais"],
+    ["perfil-infra-media", "Média por porte"],
+  ]),
+  ...createSlides("perfil", "Caracterização da Rede", "Detalhamento por DRE", [
+    ["perfil-dre-tabela", "Tabela consolidada"],
+  ]),
+
+  ...createSlides("pessoal", "Pessoal e Gestão Escolar", "Estrutura de Gestão Escolar", [
+    ["pessoal-estrutura-resumo", "Indicadores gerais"],
+    ["pessoal-estrutura-composicao", "Composição da gestão"],
+  ]),
+  ...createSlides("pessoal", "Pessoal e Gestão Escolar", "Coordenação Pedagógica", [
+    ["pessoal-coordenacao", "Cobertura e composição"],
+  ]),
+  ...createSlides("pessoal", "Pessoal e Gestão Escolar", "Quadro de Pessoal", [
+    ["pessoal-quadro-indicadores", "Indicadores gerais"],
+    ["pessoal-quadro-distribuicao", "Distribuição por vínculo"],
+    ["pessoal-quadro-dre", "Detalhamento por DRE"],
+  ]),
+
+  ...createSlides("tecnologia", "Tecnologia e Equipamentos", "Infraestrutura Digital", [
+    ["tecnologia-digital-indicadores", "Indicadores gerais"],
+    ["tecnologia-digital-conexao", "Disponibilidade e qualidade da conexão"],
+  ]),
+  ...createSlides("tecnologia", "Tecnologia e Equipamentos", "Parque Tecnológico", [
+    ["tecnologia-parque-indicadores", "Inventário de equipamentos"],
+    ["tecnologia-parque-distribuicao", "Distribuição do parque"],
+    ["tecnologia-parque-notas", "Notas por equipamento"],
+  ]),
+  ...createSlides("tecnologia", "Tecnologia e Equipamentos", "Uso Pedagógico", [
+    ["tecnologia-pedagogico-indicadores", "Indicadores gerais"],
+    ["tecnologia-pedagogico-distribuicao", "Recursos e uso pedagógico"],
+  ]),
+
+  ...createSlides("infraestrutura", "Infraestrutura e Segurança", "Condições Estruturais e Ambientes", [
+    ["infra-condicoes-resumo", "Indicadores gerais"],
+    ["infra-condicoes-situacao", "Situação dos prédios"],
+    ["infra-condicoes-ambientes", "Ambientes escolares"],
+  ]),
+  ...createSlides("infraestrutura", "Infraestrutura e Segurança", "Energia, Climatização e Capacidade Elétrica", [
+    ["infra-energia-distribuicao", "Energia e climatização"],
+    ["infra-energia-tabela", "Salas climatizadas"],
+  ]),
+  ...createSlides("infraestrutura", "Infraestrutura e Segurança", "Segurança Física e Patrimonial", [
+    ["infra-seguranca-indicadores", "Indicadores gerais"],
+    ["infra-seguranca-acesso", "Controle de acesso"],
+    ["infra-seguranca-iluminacao", "Iluminação e monitoramento"],
+    ["infra-seguranca-perimetro", "Proteção perimetral"],
+  ]),
+
+  ...createSlides("merenda", "Merenda Escolar", "Oferta e Adequação da Merenda", [
+    ["merenda-oferta-resumo", "Indicadores gerais"],
+    ["merenda-oferta-graficos", "Regularidade da oferta"],
+    ["merenda-oferta-necessidades", "Qualidade e atendimento"],
+  ]),
+  ...createSlides("merenda", "Merenda Escolar", "Estrutura Física da Cozinha", [
+    ["merenda-estrutura-cozinha", "Condições da cozinha e refeitório"],
+    ["merenda-estrutura-refeitorio", "Tamanho e adequação"],
+  ]),
+  ...createSlides("merenda", "Merenda Escolar", "Equipamentos da Merenda", [
+    ["merenda-equipamentos-cards", "Inventário geral"],
+    ["merenda-equipamentos-cobertura", "Cobertura por tipo"],
+    ["merenda-equipamentos-criticidade", "Médias e criticidade"],
+    ["merenda-equipamentos-conservacao", "Estado de conservação"],
+    ["merenda-equipamentos-tabela", "Distribuição dos estados"],
+  ]),
+  ...createSlides("merenda", "Merenda Escolar", "Condições Sanitárias e Segurança", [
+    ["merenda-sanitarias-armazenamento", "Armazenamento dos alimentos"],
+    ["merenda-sanitarias-itens", "Presença de itens básicos"],
+    ["merenda-sanitarias-seguranca", "EPIs e extintores"],
+  ]),
+
+  ...createSlides("servicos", "Serviços Terceirizados", "Visão Geral", [
+    ["servicos-visao-resumo", "Indicadores gerais"],
+    ["servicos-visao-cobertura", "Cobertura por área"],
+  ]),
+  ...createSlides("servicos", "Serviços Terceirizados", "Serviços Gerais", [
+    ["servicos-gerais-indicadores", "Quadro geral"],
+    ["servicos-gerais-distribuicao", "Vínculos e empresas"],
+  ]),
+  ...createSlides("servicos", "Serviços Terceirizados", "Portaria", [
+    ["servicos-portaria-indicadores", "Indicadores gerais"],
+    ["servicos-portaria-empresas", "Empresas prestadoras"],
+  ]),
+  ...createSlides("servicos", "Serviços Terceirizados", "Manipuladores de Alimentos", [
+    ["servicos-manipuladores-indicadores", "Quadro geral"],
+    ["servicos-manipuladores-distribuicao", "Vínculos e atendimento"],
+    ["servicos-manipuladores-empresas", "Empresas prestadoras"],
+  ]),
+  ...createSlides("servicos", "Serviços Terceirizados", "Governança e Supervisão", [
+    ["servicos-governanca-aviso", "Disponibilidade dos indicadores"],
+  ]),
+
+  ...createSlides("alunos", "Perfil dos Alunos e Resultados", "Visão Geral dos Alunos", [
+    ["alunos-visao-indicadores", "Indicadores gerais"],
+  ]),
+  ...createSlides("alunos", "Perfil dos Alunos e Resultados", "Distribuição por Faixa", [
+    ["alunos-faixas-distribuicao", "Beneficiários e abandono"],
+  ]),
+  ...createSlides("alunos", "Perfil dos Alunos e Resultados", "Abandono e Risco", [
+    ["alunos-abandono-risco", "DREs com maior taxa de abandono"],
+  ]),
+
+  ...createSlides("saude", "Saúde Operacional", "Resumo da Saúde Operacional", [
+    ["saude-resumo-indicadores", "Indicadores gerais"],
+  ]),
+  ...createSlides("saude", "Saúde Operacional", "Escolas por Índice de Saúde", [
+    ["saude-escolas-tabela", "Tabela por escola"],
+  ]),
+];
+
+function removeActiveSlideState() {
+  document.querySelectorAll<HTMLElement>("[data-pres-slide]").forEach((element) => {
+    element.classList.remove("ca-pres-slide-active");
+    element.removeAttribute("aria-current");
+  });
+}
+
+export default function PresentationMode({ onClose, onNavigateTab, dark }: PresentationModeProps) {
+  const [slideIndex, setSlideIndex] = useState(0);
+  const [slideStatus, setSlideStatus] = useState<"idle" | "found" | "missing">("idle");
+  const slideIndexRef = useRef(0);
+  const retryTimerRef = useRef<number | null>(null);
+  const navigationTokenRef = useRef(0);
+  const onNavigateTabRef = useRef(onNavigateTab);
+
+  const total = SLIDES.length;
+  const slide = SLIDES[slideIndex];
+
   useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+    onNavigateTabRef.current = onNavigateTab;
+  }, [onNavigateTab]);
+
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      window.clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const activateSlideWithRetry = useCallback((target: PresentationSlide, navigationToken: number) => {
+    let attempts = 0;
+
+    const tryActivate = () => {
+      if (navigationToken !== navigationTokenRef.current) return;
+
+      attempts += 1;
+      removeActiveSlideState();
+
+      const element = document.querySelector<HTMLElement>(
+        `[data-pres-slide="${target.contentId}"]`,
+      );
+
+      if (element) {
+        element.classList.add("ca-pres-slide-active");
+        element.setAttribute("aria-current", "true");
+        retryTimerRef.current = null;
+        setSlideStatus("found");
+        return;
+      }
+
+      if (attempts < MAX_RETRY_ATTEMPTS) {
+        retryTimerRef.current = window.setTimeout(tryActivate, RETRY_INTERVAL_MS);
+        return;
+      }
+
+      retryTimerRef.current = null;
+      setSlideStatus("missing");
     };
+
+    retryTimerRef.current = window.setTimeout(tryActivate, RETRY_INTERVAL_MS);
+  }, []);
+
+  const goToSlide = useCallback((nextIndex: number) => {
+    const normalized = ((nextIndex % total) + total) % total;
+    const target = SLIDES[normalized];
+    const navigationToken = navigationTokenRef.current + 1;
+
+    navigationTokenRef.current = navigationToken;
+    slideIndexRef.current = normalized;
+    clearRetryTimer();
+    removeActiveSlideState();
+    setSlideIndex(normalized);
+    setSlideStatus("idle");
+    onNavigateTabRef.current(target.tabId);
+    activateSlideWithRetry(target, navigationToken);
+  }, [activateSlideWithRetry, clearRetryTimer, total]);
+
+  const goNext = useCallback(
+    () => goToSlide(slideIndexRef.current + 1),
+    [goToSlide],
+  );
+  const goPrev = useCallback(
+    () => goToSlide(slideIndexRef.current - 1),
+    [goToSlide],
+  );
+
+  useEffect(() => {
+    const initialTimer = window.setTimeout(() => goToSlide(0), 0);
+    return () => window.clearTimeout(initialTimer);
+  }, [goToSlide]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        goNext();
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        goPrev();
+      }
+    };
+
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
+  }, [goNext, goPrev, onClose]);
 
-  // Trava o scroll do body enquanto o overlay estiver aberto e restaura ao desmontar.
   useEffect(() => {
-    const prevOverflow = document.body.style.overflow;
+    const previousBodyOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
+
     return () => {
-      document.body.style.overflow = prevOverflow;
+      navigationTokenRef.current += 1;
+      clearRetryTimer();
+      removeActiveSlideState();
+      document.body.style.overflow = previousBodyOverflow;
     };
-  }, []);
+  }, [clearRetryTimer]);
 
   return (
     <div className="ca-pres-shell" role="dialog" aria-modal="true" aria-label="Modo Apresentação">
-      <div className="ca-pres-backdrop" onClick={onClose} />
-      <div className="ca-pres-panel">
-        <header className="ca-pres-header">
-          <div className="ca-pres-title">
-            <MonitorPlay size={18} />
-            <div>
-              <strong>Modo Apresentação</strong>
-              <span>Visualização em tela cheia do painel SEDUC</span>
-            </div>
-          </div>
+      <header className="ca-pres-top">
+        <div className="ca-pres-heading">
+          <span className="ca-pres-kicker">
+            <MonitorPlay size={15} />
+            {slide.tabLabel}
+          </span>
+          <span className="ca-pres-title">{slide.sectionLabel}</span>
+          {slide.slideTitle && <span className="ca-pres-subtitle">{slide.slideTitle}</span>}
+          {slideStatus === "missing" && (
+            <span className="ca-pres-missing">Slide não encontrado após o carregamento da aba.</span>
+          )}
+        </div>
+
+        <div className="ca-pres-controls">
+          <span className="ca-pres-counter">
+            {slideIndex + 1} / {total}
+          </span>
+          <button
+            type="button"
+            className="ca-pres-nav-btn"
+            title="Slide anterior"
+            aria-label="Slide anterior"
+            onClick={goPrev}
+          >
+            <ChevronLeft size={18} />
+          </button>
+          <button
+            type="button"
+            className="ca-pres-nav-btn"
+            title="Próximo slide"
+            aria-label="Próximo slide"
+            onClick={goNext}
+          >
+            <ChevronRight size={18} />
+          </button>
           <button
             type="button"
             className="ca-pres-close"
@@ -55,23 +335,19 @@ export default function PresentationMode({ onClose }: PresentationModeProps) {
             aria-label="Fechar apresentação"
             onClick={onClose}
           >
-            <X size={18} />
-          </button>
-        </header>
-
-        <div className="ca-pres-body">
-          <div className="ca-pres-card">
-            <h2>Estrutura inicial do modo apresentação.</h2>
-            <p>A navegação por slides será implementada nos próximos PRs.</p>
-          </div>
-        </div>
-
-        <div className="ca-pres-actions">
-          <button type="button" className="ca-pres-launch-btn" onClick={onClose}>
-            Fechar apresentação
+            <X size={16} />
+            <span>Fechar</span>
           </button>
         </div>
-      </div>
+      </header>
+
+      <footer className="ca-pres-footer">
+        <img
+          className="ca-pres-footer-logo"
+          src={dark ? "/logo-horizontal-letter-white.png" : "/parceiros.png"}
+          alt="FADEP · Secretaria de Educação · Governo do Pará"
+        />
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
Evolui o Modo Apresentação para um deck de slides no dashboard admin.

A apresentação passa a ocultar sidebar, topbar, filtros e rodapé normal, exibindo header próprio, footer institucional e apenas um slide ativo por vez.

Adiciona marcações data-pres-slide nas abas analíticas, permitindo dividir submenus extensos em telas menores, com navegação manual por botões e teclado.

Implementa ativação exclusiva de slides por ca-pres-slide-active, retry para carregamento assíncrono, cleanup de timers e classes ativas, além de tratamento seguro para slides não encontrados.

Adiciona rolagem interna controlada para tabelas extensas no modo apresentação, sem transformar a página inteira em scroll.

Mantém o PresentationMode desacoplado das abas: não importa nem renderiza componentes Aba*, não faz fetch, não usa token, não altera filtros, cache, labels, cálculos, payloads ou endpoints.

Não implementa autoplay, fullscreen nativo, progress bar, painel lateral ou modo compacto avançado.