### PR TITLE
fix(admin): corrigir fechamento jsx do modo apresentacao

### DIFF
--- a/web/src/components/admin/PresentationMode.tsx
+++ b/web/src/components/admin/PresentationMode.tsx
@@ -520,8 +520,7 @@ export default function PresentationMode({ onClose, onNavigateTab }: Presentatio
             <span>Fechar</span>
           </button>
         </div>
-
-
+      </header>
     </div>
   );
 }


### PR DESCRIPTION
Corrige o fechamento da tag header no componente PresentationMode.

O merge anterior deixou o JSX do Modo Apresentação com a tag header aberta, causando erro de parsing no build local em PresentationMode.tsx.

Ajusta apenas o fechamento estrutural do JSX, sem alterar slides, navegação, autoplay, observers, retry, cleanup, aba Gestão Financeira, page.tsx, backend ou qualquer outro arquivo.

O build do web passa após a correção. O lint segue falhando apenas por erros preexistentes de react-hooks/set-state-in-effect em outras abas.