### PR TITLE
fix(api): normalizar filtros globais prodep

### DIFF
--- a/api/cmd/api/analytics_financeiro_governanca.go
+++ b/api/cmd/api/analytics_financeiro_governanca.go
@@ -77,16 +77,51 @@ func (f prodepFilters) args() []any {
 	}
 }
 
+// Mapeamento de caracteres acentuados → ASCII usado por translate() para
+// normalizar acentos do português SEM depender da extensão `unaccent` (que pode
+// não estar habilitada no Railway). Os dois lados precisam ter o mesmo número de
+// caracteres, como exige translate().
+const (
+	prodepAccentFrom = `ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇáàâãäéèêëíìîïóòôõöúùûüç`
+	prodepAccentTo   = `AAAAAEEEEIIIIOOOOOUUUUCaaaaaeeeeiiiiooooouuuuc`
+)
+
+// sqlNormalizeProdep devolve uma expressão SQL que normaliza `expr` para uma
+// comparação tolerante entre os valores do filtro global (UI) e os valores
+// gravados no PRODEP. A normalização: (1) remove o prefixo opcional quando
+// presente — "DRE " em dre_prodep, "RI " em ri_prodep — via regexp_replace
+// case-insensitive; (2) remove acentos comuns via translate(); (3) aplica
+// UPPER+TRIM. prefix vazio significa "não remover prefixo" (caso de município).
+//
+// É aplicada aos DOIS lados (coluna do PRODEP e parâmetro), de modo que:
+//   dre=ABAETETUBA  case com dre_prodep="DRE ABAETETUBA"
+//   ri=XINGU        case com ri_prodep="RI Xingu"
+//   municipio=ACARA case tanto com "ACARA" quanto com "Acará"
+//
+// `expr` é sempre uma expressão controlada pelo servidor (nome de coluna ou
+// placeholder posicional) — nunca entrada do usuário —, então a interpolação
+// aqui não introduz injeção; os valores da UI continuam chegando por $3/$4/$5.
+func sqlNormalizeProdep(expr, prefix string) string {
+	inner := expr
+	if prefix != "" {
+		inner = fmt.Sprintf(`regexp_replace(%s, '^\s*%s\s+', '', 'i')`, expr, prefix)
+	}
+	return fmt.Sprintf(`UPPER(TRIM(translate(%s, '%s', '%s')))`, inner, prodepAccentFrom, prodepAccentTo)
+}
+
 // prodepWhereSQL é a cláusula WHERE comum a todas as agregações. Sempre restringe
 // a usar_na_carga = true e aplica os filtros opcionais de forma parametrizada.
+// DRE, município e RI usam comparação normalizada (ver sqlNormalizeProdep) para
+// aceitar os valores do filtro global, que chegam sem prefixo "DRE "/"RI " e sem
+// acentos. Os nomes dos query params e o restante da lógica não mudam.
 // $1=ano $2=categoria $3=dre $4=municipio $5=ri $6=match_status $7=status_pc.
-const prodepWhereSQL = `
+var prodepWhereSQL = `
 	WHERE usar_na_carga = true
 	  AND ($1 = 0  OR ano = $1)
 	  AND ($2 = '' OR categoria = $2)
-	  AND ($3 = '' OR UPPER(TRIM(dre_prodep)) = UPPER(TRIM($3)))
-	  AND ($4 = '' OR UPPER(TRIM(municipio_resolvido)) = UPPER(TRIM($4)))
-	  AND ($5 = '' OR UPPER(TRIM(ri_prodep)) = UPPER(TRIM($5)))
+	  AND ($3 = '' OR ` + sqlNormalizeProdep("COALESCE(dre_prodep, '')", "DRE") + ` = ` + sqlNormalizeProdep("$3::text", "DRE") + `)
+	  AND ($4 = '' OR ` + sqlNormalizeProdep("COALESCE(municipio_resolvido, '')", "") + ` = ` + sqlNormalizeProdep("$4::text", "") + `)
+	  AND ($5 = '' OR ` + sqlNormalizeProdep("COALESCE(ri_prodep, '')", "RI") + ` = ` + sqlNormalizeProdep("$5::text", "RI") + `)
 	  AND ($6 = '' OR match_status = $6)
 	  AND ($7 = '' OR COALESCE(status_prestacao_contas, '') = $7)
 `

--- a/api/cmd/api/analytics_financeiro_governanca_test.go
+++ b/api/cmd/api/analytics_financeiro_governanca_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -59,6 +60,49 @@ func TestParseProdepFilters_InvalidValuesRejected(t *testing.T) {
 		if _, err := parseProdepFilters(q); err == nil {
 			t.Fatalf("%s: esperava erro de validação, obtive nil", name)
 		}
+	}
+}
+
+func TestProdepAccentMapsSameLength(t *testing.T) {
+	// translate() exige que os dois lados tenham o mesmo número de caracteres.
+	from := []rune(prodepAccentFrom)
+	to := []rune(prodepAccentTo)
+	if len(from) != len(to) {
+		t.Fatalf("mapas de acento com tamanhos diferentes: from=%d to=%d", len(from), len(to))
+	}
+}
+
+func TestSQLNormalizeProdep_WithPrefix(t *testing.T) {
+	got := sqlNormalizeProdep("$3::text", "DRE")
+	for _, want := range []string{"regexp_replace(", "$3::text", "DRE", "translate(", "UPPER(TRIM("} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expressão normalizada não contém %q: %s", want, got)
+		}
+	}
+}
+
+func TestSQLNormalizeProdep_NoPrefix(t *testing.T) {
+	got := sqlNormalizeProdep("COALESCE(municipio_resolvido, '')", "")
+	if strings.Contains(got, "regexp_replace(") {
+		t.Fatalf("prefixo vazio não deveria gerar regexp_replace: %s", got)
+	}
+	for _, want := range []string{"translate(", "UPPER(TRIM(", "municipio_resolvido"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expressão normalizada não contém %q: %s", want, got)
+		}
+	}
+}
+
+func TestProdepWhereSQLNormalizesGeoFilters(t *testing.T) {
+	// O WHERE montado deve aplicar a normalização aos filtros geográficos e
+	// preservar os filtros enumerados sem alteração.
+	for _, want := range []string{"dre_prodep", "municipio_resolvido", "ri_prodep", "translate(", "regexp_replace("} {
+		if !strings.Contains(prodepWhereSQL, want) {
+			t.Fatalf("prodepWhereSQL não contém %q", want)
+		}
+	}
+	if !strings.Contains(prodepWhereSQL, "usar_na_carga = true") {
+		t.Fatalf("prodepWhereSQL deve manter o filtro usar_na_carga = true")
 	}
 }
 

--- a/web/src/components/admin/AbaGestaoFinanceiraGovernanca.tsx
+++ b/web/src/components/admin/AbaGestaoFinanceiraGovernanca.tsx
@@ -381,6 +381,7 @@ export function AbaGestaoFinanceiraGovernanca({
           base_dige e registros PRODEP-only validados. Esses registros não alimentam
           automaticamente o Índice de Saúde Operacional escola-a-escola enquanto não
           houver vínculo confirmado com <code className="font-mono">schools</code>.
+          {" "}O filtro <strong className="font-medium">Zona</strong> não se aplica aos dados PRODEP.
         </div>
       </div>
 


### PR DESCRIPTION
Corrige a compatibilidade entre os filtros globais do dashboard e os valores armazenados na base PRODEP.

O endpoint financeiro passa a normalizar DRE, Região de Integração e município antes da comparação, removendo prefixos DRE/RI, desconsiderando acentos comuns do português e aplicando trim/uppercase.

Com isso, valores enviados pela interface como dre=ABAETETUBA, ri=XINGU e municipio=ACARA passam a localizar corretamente registros armazenados como DRE ABAETETUBA, RI Xingu e Acará.

Mantém os valores da interface parametrizados no SQL, sem interpolação de input do usuário, e preserva as regras existentes de ano, categoria, match_status, status_prestacao_contas e usar_na_carga.

Adiciona testes unitários para a normalização SQL e mantém os testes preexistentes do endpoint PRODEP.

Inclui nota discreta na aba Gestão Financeira informando que o filtro Zona não se aplica aos dados PRODEP.

Não altera migrations, importador PRODEP, dados, schools, payload do endpoint, rankings, cálculos financeiros ou demais abas.