### PR TITLE
feat(admin): adicionar governanca institucional

### DIFF
--- a/api/cmd/api/analytics_governanca_institucional.go
+++ b/api/cmd/api/analytics_governanca_institucional.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// =========================================================================
+// Gestão Financeira e Governança — Governança Institucional (PR 1)
+//
+// Endpoint analítico que lê a view vw_censo_governanca_institucional
+// (migration 0016) e devolve o resumo da dimensão Governança Institucional
+// para a aba "Gestão Financeira e Governança":
+//   GET /v1/admin/analytics/financeiro-governanca/institucional
+//
+// Fonte: respostas CONCLUÍDAS do Censo (a view já filtra status = 'completed').
+// Por isso o filtro `ano` NÃO se aplica aqui — diferentemente do bloco PRODEP,
+// que tem seus próprios filtros. Os filtros globais aplicáveis são: dre,
+// municipio, zona. A nota/metadados deixa explícito que se trata do Censo atual.
+//
+// Regra metodológica (docs/dashboard/governanca-institucional-financeira.md):
+//   * "Não informado"/vazio NUNCA vira "Não" — fica fora do numerador (a view
+//     o mantém como NULL e o FILTER (WHERE bool) só conta TRUE).
+//   * Denominador de "Conselho ativo" e "Conselho parcialmente ativo" é o total
+//     de escolas com Conselho Escolar constituído (conselho_escolar = 'Sim'),
+//     não o total de respostas concluídas.
+// =========================================================================
+
+// governancaInstitucionalFilters reúne os filtros globais aplicáveis. String
+// vazia significa "filtro desativado".
+type governancaInstitucionalFilters struct {
+	DRE       string
+	Municipio string
+	Zona      string
+}
+
+// args devolve os argumentos posicionais na ordem esperada por
+// governancaInstitucionalWhereSQL ($1=dre $2=municipio $3=zona).
+func (f governancaInstitucionalFilters) args() []any {
+	return []any{f.DRE, f.Municipio, f.Zona}
+}
+
+// parseGovernancaInstitucionalFilters lê os filtros opcionais da query string.
+// Não há valores enumerados a validar (são textos livres comparados de forma
+// case-insensitive no SQL), portanto nunca falha. `ano`, `ri` e demais filtros
+// PRODEP são intencionalmente ignorados.
+func parseGovernancaInstitucionalFilters(q url.Values) governancaInstitucionalFilters {
+	get := func(key string) string { return strings.TrimSpace(q.Get(key)) }
+	return governancaInstitucionalFilters{
+		DRE:       get("dre"),
+		Municipio: get("municipio"),
+		Zona:      get("zona"),
+	}
+}
+
+// governancaInstitucionalWhereSQL é a cláusula WHERE parametrizada aplicada
+// sobre a view (que já restringe a status = 'completed'). Comparações
+// case-insensitive com TRIM. $1=dre $2=municipio $3=zona.
+const governancaInstitucionalWhereSQL = `
+	WHERE ($1 = '' OR UPPER(TRIM(dre)) = UPPER(TRIM($1)))
+	  AND ($2 = '' OR UPPER(TRIM(municipio)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(zona)) = UPPER(TRIM($3)))
+`
+
+// GovernancaIndicador é a tripla total/denominador/percentual de cada card.
+type GovernancaIndicador struct {
+	Total       int64   `json:"total"`
+	Denominador int64   `json:"denominador"`
+	Percentual  float64 `json:"percentual"`
+}
+
+// novoGovernancaIndicador monta o indicador já com o percentual calculado.
+func novoGovernancaIndicador(total, denominador int64) GovernancaIndicador {
+	return GovernancaIndicador{
+		Total:       total,
+		Denominador: denominador,
+		Percentual:  pctGovernanca(total, denominador),
+	}
+}
+
+// pctGovernanca = total / denominador * 100, arredondado a 2 casas. Devolve 0
+// quando o denominador é zero (nunca erro/divisão por zero).
+func pctGovernanca(total, denominador int64) float64 {
+	if denominador == 0 {
+		return 0
+	}
+	return round2(float64(total) / float64(denominador) * 100)
+}
+
+type GovernancaInstitucionalResumo struct {
+	TotalEscolas              int64               `json:"totalEscolas"`
+	RegularizadasCEE          GovernancaIndicador `json:"regularizadasCEE"`
+	ConselhoConstituido       GovernancaIndicador `json:"conselhoConstituido"`
+	ConselhoAtivo             GovernancaIndicador `json:"conselhoAtivo"`
+	ConselhoParcialmenteAtivo GovernancaIndicador `json:"conselhoParcialmenteAtivo"`
+	GovernancaCompleta        GovernancaIndicador `json:"governancaCompleta"`
+	GovernancaCritica         GovernancaIndicador `json:"governancaCritica"`
+}
+
+type GovernancaInstitucionalMetadados struct {
+	Fonte           string `json:"fonte"`
+	StatusRespostas string `json:"statusRespostas"`
+	Observacao      string `json:"observacao"`
+}
+
+type GovernancaInstitucionalPayload struct {
+	Resumo    GovernancaInstitucionalResumo    `json:"resumo"`
+	Metadados GovernancaInstitucionalMetadados `json:"metadados"`
+}
+
+const governancaInstitucionalObservacao = "Indicadores calculados a partir de respostas concluídas do Censo. " +
+	"Não informado não é tratado como Não. O denominador de \"Conselho ativo\" e \"Conselho parcialmente ativo\" " +
+	"é o total de escolas com Conselho Escolar constituído."
+
+// AdminAnalyticsFinanceiroGovernancaInstitucional responde GET
+// /v1/admin/analytics/financeiro-governanca/institucional.
+//
+// Filtros opcionais: dre, municipio, zona. Sem respostas no recorte devolve
+// estrutura válida com zeros (percentuais = 0), nunca erro.
+func (app *application) AdminAnalyticsFinanceiroGovernancaInstitucional(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	db := app.models.Schools.DB
+
+	filters := parseGovernancaInstitucionalFilters(r.URL.Query())
+	args := filters.args()
+
+	var (
+		totalEscolas        int64
+		regularizadas       int64
+		conselhoConstituido int64
+		conselhoAtivo       int64
+		conselhoParcial     int64
+		governancaCompleta  int64
+		governancaCritica   int64
+	)
+
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*)::bigint,
+			COUNT(*) FILTER (WHERE is_regularizada_cee)::bigint,
+			COUNT(*) FILTER (WHERE has_conselho_escolar)::bigint,
+			COUNT(*) FILTER (WHERE is_conselho_ativo)::bigint,
+			COUNT(*) FILTER (WHERE is_conselho_parcialmente_ativo)::bigint,
+			COUNT(*) FILTER (WHERE is_governanca_completa)::bigint,
+			COUNT(*) FILTER (WHERE is_governanca_critica)::bigint
+		FROM vw_censo_governanca_institucional`+governancaInstitucionalWhereSQL,
+		args...,
+	).Scan(
+		&totalEscolas,
+		&regularizadas,
+		&conselhoConstituido,
+		&conselhoAtivo,
+		&conselhoParcial,
+		&governancaCompleta,
+		&governancaCritica,
+	); err != nil {
+		app.errorJSON(w, fmt.Errorf("resumo governanca institucional: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	out := GovernancaInstitucionalPayload{
+		Resumo: GovernancaInstitucionalResumo{
+			TotalEscolas:              totalEscolas,
+			RegularizadasCEE:          novoGovernancaIndicador(regularizadas, totalEscolas),
+			ConselhoConstituido:       novoGovernancaIndicador(conselhoConstituido, totalEscolas),
+			ConselhoAtivo:             novoGovernancaIndicador(conselhoAtivo, conselhoConstituido),
+			ConselhoParcialmenteAtivo: novoGovernancaIndicador(conselhoParcial, conselhoConstituido),
+			GovernancaCompleta:        novoGovernancaIndicador(governancaCompleta, totalEscolas),
+			GovernancaCritica:         novoGovernancaIndicador(governancaCritica, totalEscolas),
+		},
+		Metadados: GovernancaInstitucionalMetadados{
+			Fonte:           "Censo Operacional",
+			StatusRespostas: "completed",
+			Observacao:      governancaInstitucionalObservacao,
+		},
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: out})
+}

--- a/api/cmd/api/analytics_governanca_institucional_test.go
+++ b/api/cmd/api/analytics_governanca_institucional_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestPctGovernanca(t *testing.T) {
+	cases := []struct {
+		total, denominador int64
+		want               float64
+	}{
+		{0, 0, 0},      // denominador zero → 0 (não erro)
+		{10, 0, 0},     // denominador zero → 0 mesmo com numerador
+		{0, 822, 0},    // numerador zero → 0
+		{411, 822, 50}, // 50%
+		{1, 3, 33.33},  // arredonda a 2 casas
+		{624, 822, 75.91},
+		{822, 822, 100},
+	}
+	for _, c := range cases {
+		if got := pctGovernanca(c.total, c.denominador); got != c.want {
+			t.Fatalf("pctGovernanca(%d, %d) = %v, esperava %v", c.total, c.denominador, got, c.want)
+		}
+	}
+}
+
+func TestNovoGovernancaIndicador(t *testing.T) {
+	ind := novoGovernancaIndicador(624, 822)
+	if ind.Total != 624 {
+		t.Fatalf("total: esperava 624, obtive %d", ind.Total)
+	}
+	if ind.Denominador != 822 {
+		t.Fatalf("denominador: esperava 822, obtive %d", ind.Denominador)
+	}
+	if ind.Percentual != 75.91 {
+		t.Fatalf("percentual: esperava 75.91, obtive %v", ind.Percentual)
+	}
+
+	// Denominador zero não deve quebrar e o percentual deve ser 0.
+	vazio := novoGovernancaIndicador(0, 0)
+	if vazio.Percentual != 0 {
+		t.Fatalf("denominador zero: esperava percentual 0, obtive %v", vazio.Percentual)
+	}
+}
+
+func TestParseGovernancaInstitucionalFilters_Defaults(t *testing.T) {
+	f := parseGovernancaInstitucionalFilters(url.Values{})
+	if f.DRE != "" || f.Municipio != "" || f.Zona != "" {
+		t.Fatalf("esperava todos os filtros vazios, obtive %+v", f)
+	}
+}
+
+func TestParseGovernancaInstitucionalFilters_TrimEIgnoraOutros(t *testing.T) {
+	q := url.Values{
+		"dre":       {"  DRE Abaetetuba  "},
+		"municipio": {" Acará "},
+		"zona":      {" Rural "},
+		// Filtros que NÃO se aplicam a Governança Institucional devem ser ignorados.
+		"ano": {"2025"},
+		"ri":  {"RI Xingu"},
+	}
+	f := parseGovernancaInstitucionalFilters(q)
+	if f.DRE != "DRE Abaetetuba" {
+		t.Fatalf("dre: esperava \"DRE Abaetetuba\" (trim), obtive %q", f.DRE)
+	}
+	if f.Municipio != "Acará" {
+		t.Fatalf("municipio: esperava \"Acará\" (trim), obtive %q", f.Municipio)
+	}
+	if f.Zona != "Rural" {
+		t.Fatalf("zona: esperava \"Rural\" (trim), obtive %q", f.Zona)
+	}
+}
+
+func TestGovernancaInstitucionalFiltersArgsOrder(t *testing.T) {
+	f := governancaInstitucionalFilters{DRE: "d", Municipio: "m", Zona: "z"}
+	args := f.args()
+	if len(args) != 3 {
+		t.Fatalf("esperava 3 args ($1=dre $2=municipio $3=zona), obtive %d", len(args))
+	}
+	if args[0] != "d" || args[1] != "m" || args[2] != "z" {
+		t.Fatalf("ordem dos args incorreta: %+v", args)
+	}
+}
+
+func TestGovernancaInstitucionalWhereSQLParametrizado(t *testing.T) {
+	// O WHERE deve usar placeholders posicionais e comparações case-insensitive,
+	// nunca interpolar valores da UI.
+	for _, want := range []string{"$1", "$2", "$3", "UPPER(TRIM(dre))", "UPPER(TRIM(municipio))", "UPPER(TRIM(zona))"} {
+		if !strings.Contains(governancaInstitucionalWhereSQL, want) {
+			t.Fatalf("governancaInstitucionalWhereSQL não contém %q", want)
+		}
+	}
+}

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -369,6 +369,9 @@ func (app *application) routes() http.Handler {
 			// Gestão Financeira e Governança — repasses PRODEP (PR técnico 2).
 			protected.Get("/admin/analytics/financeiro-governanca/prodep", app.AdminAnalyticsFinanceiroGovernancaProdep)
 
+			// Gestão Financeira e Governança — Governança Institucional (Censo, PR 1).
+			protected.Get("/admin/analytics/financeiro-governanca/institucional", app.AdminAnalyticsFinanceiroGovernancaInstitucional)
+
 			// Andamento do preenchimento do censo por DRE.
 			protected.Get("/admin/analytics/preenchimento/dre", app.AdminAnalyticsPreenchimentoDre)
 

--- a/api/cmd/api/migrations/0016_vw_censo_governanca_institucional.sql
+++ b/api/cmd/api/migrations/0016_vw_censo_governanca_institucional.sql
@@ -1,0 +1,68 @@
+-- =====================================================================
+-- Migration 0016 — vw_censo_governanca_institucional
+-- =====================================================================
+-- Governança Institucional (aba "Gestão Financeira e Governança", PR 1).
+-- Fonte: census_responses.data (JSONB) + schools, somente respostas
+-- concluídas (status = 'completed').
+--
+-- Campos do Censo (etapa "Gestão, Participação e Política"):
+--   regularizada_cee  → 'Sim' / 'Não'
+--   conselho_escolar  → 'Sim' / 'Não'
+--   conselho_ativo    → 'Sim' / 'Parcialmente' / 'Não'  (condicional:
+--                       só preenchido quando conselho_escolar = 'Sim')
+--
+-- Regra metodológica (docs/dashboard/governanca-institucional-financeira.md):
+--   "Não informado"/vazio NUNCA vira "Não" — permanece NULL. Por isso os
+--   campos textuais usam NULLIF(...,'') e os booleanos comparam contra 'Sim'
+--   / 'Não' / 'Parcialmente'; quando o valor é NULL, o booleano resultante é
+--   NULL (ausência de informação), nunca FALSE.
+--
+-- Aplicação idempotente: CREATE OR REPLACE VIEW. Replicada em
+-- infra/init.sql e na cópia api/cmd/api/migrations/0016_*.sql (idênticas).
+-- =====================================================================
+
+CREATE OR REPLACE VIEW vw_censo_governanca_institucional AS
+WITH base AS (
+    SELECT
+        cr.id                                       AS census_id,
+        s.id                                        AS school_id,
+        s.codigo_inep,
+        s.nome_escola                               AS escola,
+        s.dre,
+        s.municipio,
+        s.zona,
+        NULLIF(cr.data->>'regularizada_cee', '')    AS regularizada_cee,
+        NULLIF(cr.data->>'conselho_escolar', '')    AS conselho_escolar,
+        NULLIF(cr.data->>'conselho_ativo', '')      AS conselho_ativo
+    FROM census_responses cr
+    JOIN schools s ON s.id = cr.school_id
+    WHERE cr.status = 'completed'
+)
+SELECT
+    census_id,
+    school_id,
+    codigo_inep,
+    escola,
+    dre,
+    municipio,
+    zona,
+    regularizada_cee,
+    conselho_escolar,
+    conselho_ativo,
+    -- Booleanos: NULL quando o campo é "Não informado" (não vira FALSE).
+    (regularizada_cee = 'Sim')        AS is_regularizada_cee,
+    (conselho_escolar = 'Sim')        AS has_conselho_escolar,
+    (conselho_ativo = 'Sim')          AS is_conselho_ativo,
+    (conselho_ativo = 'Parcialmente') AS is_conselho_parcialmente_ativo,
+    -- Governança completa: os três quesitos = 'Sim'. NULL em qualquer campo
+    -- propaga NULL (não conta como completa nem como crítica).
+    (regularizada_cee = 'Sim'
+     AND conselho_escolar = 'Sim'
+     AND conselho_ativo = 'Sim')      AS is_governanca_completa,
+    -- Governança crítica: pelo menos um quesito = 'Não'. Como o OR com TRUE
+    -- curto-circuita, basta um 'Não' para resultar TRUE; valores NULL não
+    -- forçam crítica (Não informado não vira Não).
+    (regularizada_cee = 'Não'
+     OR conselho_escolar = 'Não'
+     OR conselho_ativo = 'Não')       AS is_governanca_critica
+FROM base;

--- a/infra/init.sql
+++ b/infra/init.sql
@@ -519,3 +519,52 @@ CREATE INDEX IF NOT EXISTS idx_prodep_repasses_school_id    ON prodep_repasses (
 CREATE INDEX IF NOT EXISTS idx_prodep_repasses_match_status ON prodep_repasses (match_status);
 CREATE INDEX IF NOT EXISTS idx_prodep_repasses_inep         ON prodep_repasses (codigo_inep_prodep);
 CREATE INDEX IF NOT EXISTS idx_prodep_repasses_batch        ON prodep_repasses (import_batch_id);
+
+-- =====================================================================
+-- vw_censo_governanca_institucional (espelho de
+-- infra/migrations/0016_vw_censo_governanca_institucional.sql)
+-- =====================================================================
+-- Governança Institucional (aba "Gestão Financeira e Governança", PR 1).
+-- Somente respostas concluídas. "Não informado"/vazio permanece NULL e
+-- nunca é convertido em "Não".
+-- =====================================================================
+
+CREATE OR REPLACE VIEW vw_censo_governanca_institucional AS
+WITH base AS (
+    SELECT
+        cr.id                                       AS census_id,
+        s.id                                        AS school_id,
+        s.codigo_inep,
+        s.nome_escola                               AS escola,
+        s.dre,
+        s.municipio,
+        s.zona,
+        NULLIF(cr.data->>'regularizada_cee', '')    AS regularizada_cee,
+        NULLIF(cr.data->>'conselho_escolar', '')    AS conselho_escolar,
+        NULLIF(cr.data->>'conselho_ativo', '')      AS conselho_ativo
+    FROM census_responses cr
+    JOIN schools s ON s.id = cr.school_id
+    WHERE cr.status = 'completed'
+)
+SELECT
+    census_id,
+    school_id,
+    codigo_inep,
+    escola,
+    dre,
+    municipio,
+    zona,
+    regularizada_cee,
+    conselho_escolar,
+    conselho_ativo,
+    (regularizada_cee = 'Sim')        AS is_regularizada_cee,
+    (conselho_escolar = 'Sim')        AS has_conselho_escolar,
+    (conselho_ativo = 'Sim')          AS is_conselho_ativo,
+    (conselho_ativo = 'Parcialmente') AS is_conselho_parcialmente_ativo,
+    (regularizada_cee = 'Sim'
+     AND conselho_escolar = 'Sim'
+     AND conselho_ativo = 'Sim')      AS is_governanca_completa,
+    (regularizada_cee = 'Não'
+     OR conselho_escolar = 'Não'
+     OR conselho_ativo = 'Não')       AS is_governanca_critica
+FROM base;

--- a/infra/migrations/0016_vw_censo_governanca_institucional.sql
+++ b/infra/migrations/0016_vw_censo_governanca_institucional.sql
@@ -1,0 +1,68 @@
+-- =====================================================================
+-- Migration 0016 — vw_censo_governanca_institucional
+-- =====================================================================
+-- Governança Institucional (aba "Gestão Financeira e Governança", PR 1).
+-- Fonte: census_responses.data (JSONB) + schools, somente respostas
+-- concluídas (status = 'completed').
+--
+-- Campos do Censo (etapa "Gestão, Participação e Política"):
+--   regularizada_cee  → 'Sim' / 'Não'
+--   conselho_escolar  → 'Sim' / 'Não'
+--   conselho_ativo    → 'Sim' / 'Parcialmente' / 'Não'  (condicional:
+--                       só preenchido quando conselho_escolar = 'Sim')
+--
+-- Regra metodológica (docs/dashboard/governanca-institucional-financeira.md):
+--   "Não informado"/vazio NUNCA vira "Não" — permanece NULL. Por isso os
+--   campos textuais usam NULLIF(...,'') e os booleanos comparam contra 'Sim'
+--   / 'Não' / 'Parcialmente'; quando o valor é NULL, o booleano resultante é
+--   NULL (ausência de informação), nunca FALSE.
+--
+-- Aplicação idempotente: CREATE OR REPLACE VIEW. Replicada em
+-- infra/init.sql e na cópia api/cmd/api/migrations/0016_*.sql (idênticas).
+-- =====================================================================
+
+CREATE OR REPLACE VIEW vw_censo_governanca_institucional AS
+WITH base AS (
+    SELECT
+        cr.id                                       AS census_id,
+        s.id                                        AS school_id,
+        s.codigo_inep,
+        s.nome_escola                               AS escola,
+        s.dre,
+        s.municipio,
+        s.zona,
+        NULLIF(cr.data->>'regularizada_cee', '')    AS regularizada_cee,
+        NULLIF(cr.data->>'conselho_escolar', '')    AS conselho_escolar,
+        NULLIF(cr.data->>'conselho_ativo', '')      AS conselho_ativo
+    FROM census_responses cr
+    JOIN schools s ON s.id = cr.school_id
+    WHERE cr.status = 'completed'
+)
+SELECT
+    census_id,
+    school_id,
+    codigo_inep,
+    escola,
+    dre,
+    municipio,
+    zona,
+    regularizada_cee,
+    conselho_escolar,
+    conselho_ativo,
+    -- Booleanos: NULL quando o campo é "Não informado" (não vira FALSE).
+    (regularizada_cee = 'Sim')        AS is_regularizada_cee,
+    (conselho_escolar = 'Sim')        AS has_conselho_escolar,
+    (conselho_ativo = 'Sim')          AS is_conselho_ativo,
+    (conselho_ativo = 'Parcialmente') AS is_conselho_parcialmente_ativo,
+    -- Governança completa: os três quesitos = 'Sim'. NULL em qualquer campo
+    -- propaga NULL (não conta como completa nem como crítica).
+    (regularizada_cee = 'Sim'
+     AND conselho_escolar = 'Sim'
+     AND conselho_ativo = 'Sim')      AS is_governanca_completa,
+    -- Governança crítica: pelo menos um quesito = 'Não'. Como o OR com TRUE
+    -- curto-circuita, basta um 'Não' para resultar TRUE; valores NULL não
+    -- forçam crítica (Não informado não vira Não).
+    (regularizada_cee = 'Não'
+     OR conselho_escolar = 'Não'
+     OR conselho_ativo = 'Não')       AS is_governanca_critica
+FROM base;

--- a/web/src/components/admin/AbaGestaoFinanceiraGovernanca.tsx
+++ b/web/src/components/admin/AbaGestaoFinanceiraGovernanca.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import {
   Landmark, AlertCircle, Loader2, Wallet, RefreshCcw, Percent,
   Building2, Link2, Unlink, CalendarRange, FileCheck2, Network, Trophy,
+  ShieldCheck, Users, UserCheck, AlertTriangle, Award,
 } from "lucide-react";
 import { apiFetch } from "./shared/api";
 import { C } from "./shared/constants";
@@ -89,6 +90,33 @@ type ProdepFinanceiroPayload = {
   };
 };
 
+// ── Governança Institucional (Censo, PR 1) ──────────────────────────────────
+// Payload de GET /v1/admin/analytics/financeiro-governanca/institucional.
+// Fonte: respostas concluídas do Censo (não usa `ano` nem dados PRODEP).
+
+type GovernancaIndicador = {
+  total: number;
+  denominador: number;
+  percentual: number;
+};
+
+type GovernancaInstitucionalPayload = {
+  resumo: {
+    totalEscolas: number;
+    regularizadasCEE: GovernancaIndicador;
+    conselhoConstituido: GovernancaIndicador;
+    conselhoAtivo: GovernancaIndicador;
+    conselhoParcialmenteAtivo: GovernancaIndicador;
+    governancaCompleta: GovernancaIndicador;
+    governancaCritica: GovernancaIndicador;
+  };
+  metadados: {
+    fonte: string;
+    statusRespostas: string;
+    observacao: string;
+  };
+};
+
 type AbaGestaoFinanceiraGovernancaProps = {
   token: string;
   onUnauth: () => void;
@@ -108,6 +136,18 @@ function buildFinanceiroParams(filters?: DashboardFilters): string {
   if (filters?.dre) p.set("dre", filters.dre);
   if (filters?.municipio) p.set("municipio", filters.municipio);
   if (filters?.regiao_integracao) p.set("ri", filters.regiao_integracao);
+  const s = p.toString();
+  return s ? `?${s}` : "";
+}
+
+// Governança Institucional usa APENAS os filtros globais aplicáveis ao Censo:
+// dre, municipio, zona. NÃO envia `ano` (o bloco usa as respostas concluídas do
+// Censo atual) nem `ri`/filtros PRODEP — mantido separado de buildFinanceiroParams.
+function buildGovernancaInstitucionalParams(filters?: DashboardFilters): string {
+  const p = new URLSearchParams();
+  if (filters?.dre) p.set("dre", filters.dre);
+  if (filters?.municipio) p.set("municipio", filters.municipio);
+  if (filters?.zona) p.set("zona", filters.zona);
   const s = p.toString();
   return s ? `?${s}` : "";
 }
@@ -241,7 +281,11 @@ function RankingTable({ rows }: { rows: ProdepRankingEscola[] }) {
   );
 }
 
-export function AbaGestaoFinanceiraGovernanca({
+// ProdepFinanceiroBlock — bloco financeiro PRODEP (conteúdo original da aba).
+// Mantido idêntico; apenas extraído para um componente interno para que a
+// Governança Institucional (Censo) seja renderizada de forma independente,
+// sem ser ocultada pelos estados de loading/erro/vazio do PRODEP.
+function ProdepFinanceiroBlock({
   token, onUnauth, filters, onLoadComplete,
 }: AbaGestaoFinanceiraGovernancaProps) {
   const [data, setData] = useState<ProdepFinanceiroPayload | null>(null);
@@ -550,6 +594,140 @@ export function AbaGestaoFinanceiraGovernanca({
       <p data-pres-hide="true" className="text-xs text-slate-400">
         {data.metadados.observacao}
       </p>
+    </div>
+  );
+}
+
+// ── Governança Institucional (Censo, PR 1) ──────────────────────────────────
+// Bloco autônomo, com fetch/loading/erro próprios, para que apareça
+// independentemente do estado dos dados PRODEP. Fonte: respostas concluídas do
+// Censo. Filtros aplicáveis: dre, municipio, zona (nunca `ano`).
+function GovernancaInstitucionalBlock({
+  token, onUnauth, filters,
+}: {
+  token: string;
+  onUnauth: () => void;
+  filters?: DashboardFilters;
+}) {
+  const [data, setData] = useState<GovernancaInstitucionalPayload | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setData(null);
+    setError("");
+
+    const qs = buildGovernancaInstitucionalParams(filters);
+
+    apiFetch<GovernancaInstitucionalPayload>(
+      `/v1/admin/analytics/financeiro-governanca/institucional${qs}`, token,
+    )
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch((e: unknown) => {
+        const msg = (e as Error).message;
+        if (msg === "UNAUTHORIZED") { if (!cancelled) onUnauth(); return; }
+        if (!cancelled) setError(msg);
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [token, onUnauth, filters]);
+
+  return (
+    <div className="space-y-4">
+      <SectionHeader id="sec-governanca-institucional" Icon={Landmark} title="Governança Institucional" />
+
+      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-sky-700">
+        <span className="inline-block w-2 h-2 rounded-full bg-sky-500" />
+        <span>Fonte: Censo Operacional · respostas concluídas</span>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-slate-400">
+          <Loader2 className="animate-spin mr-2" size={20} style={{ color: C.primary }} />
+          Carregando indicadores de governança…
+        </div>
+      ) : error ? (
+        <div className="flex items-start gap-2 bg-rose-50 border border-rose-200 text-rose-700 rounded-xl px-4 py-3 text-sm">
+          <AlertCircle size={16} className="shrink-0 mt-0.5" />
+          Não foi possível carregar a governança institucional: {error}
+        </div>
+      ) : !data ? (
+        <NoData />
+      ) : (
+        <div data-pres-slide="governanca-institucional-cards" className="space-y-4">
+          <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+            <StatCard
+              label="Regularizadas no CEE/PA"
+              value={fmtInt(data.resumo.regularizadasCEE.total)}
+              Icon={ShieldCheck}
+              tone="green"
+              sub={`${fmtPct(data.resumo.regularizadasCEE.percentual)} de respostas concluídas`}
+            />
+            <StatCard
+              label="Conselho Escolar constituído"
+              value={fmtInt(data.resumo.conselhoConstituido.total)}
+              Icon={Users}
+              tone="blue"
+              sub={`${fmtPct(data.resumo.conselhoConstituido.percentual)} de respostas concluídas`}
+            />
+            <StatCard
+              label="Conselhos em funcionamento ativo"
+              value={fmtInt(data.resumo.conselhoAtivo.total)}
+              Icon={UserCheck}
+              tone="green"
+              sub={`${fmtPct(data.resumo.conselhoAtivo.percentual)} das escolas com conselho`}
+            />
+            <StatCard
+              label="Conselhos parcialmente ativos"
+              value={fmtInt(data.resumo.conselhoParcialmenteAtivo.total)}
+              Icon={AlertTriangle}
+              tone="amber"
+              sub={`${fmtPct(data.resumo.conselhoParcialmenteAtivo.percentual)} das escolas com conselho`}
+            />
+            <StatCard
+              label="Governança institucional completa"
+              value={fmtInt(data.resumo.governancaCompleta.total)}
+              Icon={Award}
+              tone="green"
+              sub={`${fmtPct(data.resumo.governancaCompleta.percentual)} de respostas concluídas`}
+            />
+            <StatCard
+              label="Governança incompleta/crítica"
+              value={fmtInt(data.resumo.governancaCritica.total)}
+              Icon={AlertTriangle}
+              tone="orange"
+              sub={`${fmtPct(data.resumo.governancaCritica.percentual)} com algum item = Não`}
+            />
+          </div>
+
+          {/* Nota metodológica do bloco */}
+          <div className="bg-slate-50 border border-slate-200 rounded-xl px-4 py-3 text-xs text-slate-500 leading-relaxed">
+            Indicadores calculados a partir das respostas concluídas do Censo. O campo
+            {" "}<strong className="font-medium">&quot;Conselho ativo&quot;</strong> usa como denominador
+            apenas escolas com Conselho Escolar constituído.
+            {" "}<strong className="font-medium">Não informado</strong> não é tratado como Não.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// AbaGestaoFinanceiraGovernanca — composição da aba: Governança Institucional
+// (Censo) no topo, seguida do bloco financeiro PRODEP. Cada bloco gerencia seu
+// próprio fetch e estados, com filtros globais distintos.
+export function AbaGestaoFinanceiraGovernanca(props: AbaGestaoFinanceiraGovernancaProps) {
+  return (
+    <div className="space-y-8">
+      <GovernancaInstitucionalBlock
+        token={props.token}
+        onUnauth={props.onUnauth}
+        filters={props.filters}
+      />
+      <ProdepFinanceiroBlock {...props} />
     </div>
   );
 }


### PR DESCRIPTION
Adiciona a primeira implementação funcional do bloco Governança Institucional na aba Gestão Financeira e Governança.

Cria a view vw_censo_governanca_institucional sobre respostas concluídas do Censo, cruzando census_responses com schools e preservando valores não informados como NULL.

Adiciona endpoint administrativo GET /v1/admin/analytics/financeiro-governanca/institucional, protegido por autenticação admin, com filtros por DRE, município e zona.

O endpoint retorna cards de regularização CEE/PA, Conselho Escolar constituído, Conselho ativo, Conselho parcialmente ativo, Governança institucional completa e Governança incompleta/crítica, respeitando os denominadores definidos na metodologia.

Inclui testes backend para cálculo percentual, filtros, argumentos e parametrização SQL.

Adiciona o bloco Governança Institucional no frontend, com loading e erro próprios, sem interferir no bloco financeiro PRODEP existente.

Mantém fora do escopo o cruzamento com PRODEP, a situação financeira consolidada por escola e a ativação da dimensão Governança no Índice de Saúde Operacional.

Não altera dados, formulário, importador PRODEP, endpoint PRODEP, Saúde Operacional, packages ou arquivos locais.

Ressalvas conhecidas:
- O lint passou de 8 para 9 erros react-hooks/set-state-in-effect. O novo erro segue o mesmo padrão técnico já existente nas demais abas administrativas e não quebra o build.
- Smoke visual manual em /admin ainda deve ser feito antes do merge.