### PR TITLE
chore: ignorar artefatos locais de trabalho

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ key.json
 src/dev/
 
 .claude
+
+# Bases e artefatos locais de trabalho
+_local/


### PR DESCRIPTION
## Resumo

Adiciona `_local/` ao `.gitignore` versionado para impedir que bases brutas, artefatos locais de auditoria e saídas temporárias sejam adicionados ao repositório.

## Contexto

A frente IDEB 2023 utiliza `_local/ideb/` para armazenar planilha bruta, scripts exploratórios e saídas locais de auditoria. Esses arquivos não devem ser versionados.

Antes, `_local/` estava ignorado apenas via `.git/info/exclude`, o que funciona localmente, mas não protege outros clones do repositório.

## Alterações

- adiciona `_local/` ao `.gitignore`;
- garante newline final no arquivo.

## Fora do escopo

- não adiciona arquivos de `_local/`;
- não adiciona planilha IDEB;
- não cria migration;
- não altera backend;
- não altera frontend;
- não altera documentação metodológica.

## Validação

- `git check-ignore` confirma que `_local/` é ignorado via `.gitignore`;
- `git ls-files _local` retorna vazio;
- working tree limpo após commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)