### PR TITLE
feat(api): ativar governanca no indice de saude

### DIFF
--- a/api/cmd/api/analytics_saude_operacional.go
+++ b/api/cmd/api/analytics_saude_operacional.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	saudeOperacionalNome            = "Índice de Saúde Operacional por escola"
-	saudeOperacionalVersao          = "1.0.0"
+	saudeOperacionalVersao          = "1.1.0"
 	saudeOperacionalPageSizeDefault = 10
 )
 
@@ -31,6 +31,7 @@ var saudeOperacionalDimensoesHabilitadas = []string{
 	"seguranca",
 	"pessoal",
 	"tecnologia",
+	"governanca",
 }
 
 var saudeOperacionalPageSizes = map[int]bool{
@@ -422,13 +423,15 @@ func calculateSecurity(data map[string]any) *float64 {
 	)
 }
 
+// calculatePeople mede a suficiência de pessoal operacional/de apoio (merenda,
+// serviços gerais e portaria). As funções de gestão escolar (direção,
+// coordenação pedagógica, etc.) migraram para a dimensão Governança a partir do
+// Saúde-01B, evitando dupla contagem entre Pessoal/RH e Governança.
 func calculatePeople(data map[string]any) *float64 {
 	return meanValid(
 		scoreCategorical(data["qtd_atende_necessidade_merenda"], simNaoScores),
 		scoreCategorical(data["qtd_atende_necessidade_sg"], simNaoScores),
 		scoreCategorical(data["qtd_atende_necessidade_portaria"], simNaoScores),
-		scoreCategorical(data["possui_direcao"], simNaoScores),
-		scoreCategorical(data["possui_coord_pedagogico"], simNaoScores),
 	)
 }
 
@@ -455,6 +458,79 @@ func calculateTechnology(data map[string]any) *float64 {
 	)
 }
 
+// normalizeGovText extrai uma string do JSONB e a normaliza para comparação
+// tolerante (trim, minúsculas, sem acentos), reaproveitando normalizeSaudeSearch.
+// O segundo retorno indica se há, de fato, um valor preenchido para o campo:
+// valores ausentes, não-string ou vazios contam como "não informado".
+func normalizeGovText(value any) (string, bool) {
+	text, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", false
+	}
+	return normalizeSaudeSearch(text), true
+}
+
+// calculateGovernance pontua a dimensão Governança (0–100): equipe gestora
+// (direção, secretário, coordenação pedagógica e, por regra OU, algum
+// vice-diretor), regularização institucional junto ao CEE/PA e conselho escolar
+// constituído/ativo. A comparação é case/acento-insensível.
+//
+// Se NENHUM campo candidato estiver presente no JSON, retorna nil para preservar
+// o padrão "sem dados". Se ao menos um campo existir, retorna número: respostas
+// "Não"/equivalentes/ausentes pontuam 0, mas não anulam a dimensão.
+func calculateGovernance(data map[string]any) *float64 {
+	var score float64
+	present := false
+
+	addSim := func(key string, points float64) {
+		norm, ok := normalizeGovText(data[key])
+		if !ok {
+			return
+		}
+		present = true
+		if norm == "sim" {
+			score += points
+		}
+	}
+
+	addSim("possui_direcao", 20)
+	addSim("possui_secretario", 10)
+	addSim("possui_coord_pedagogico", 10)
+
+	// Bloco de vice-diretor por regra OU: pontua se houver vice pedagógico OU
+	// administrativo. Considera-se presente se qualquer um dos campos existir.
+	vicePed, okPed := normalizeGovText(data["possui_vice_pedagogico"])
+	viceAdm, okAdm := normalizeGovText(data["possui_vice_administrativo"])
+	if okPed || okAdm {
+		present = true
+		if vicePed == "sim" || viceAdm == "sim" {
+			score += 10
+		}
+	}
+
+	addSim("regularizada_cee", 15)
+	addSim("conselho_escolar", 15)
+
+	// Conselho ativo: Sim=20, Parcialmente=10, demais (Não/vazio)=0.
+	if norm, ok := normalizeGovText(data["conselho_ativo"]); ok {
+		present = true
+		switch norm {
+		case "sim":
+			score += 20
+		case "parcialmente":
+			score += 10
+		}
+	}
+
+	if !present {
+		return nil
+	}
+	return ptrFloat(score)
+}
+
 func calculateSchoolHealth(data map[string]any) saudeOperacionalCalculation {
 	pesos := saudeOperacionalPesosMetodologia()
 	infraestrutura := calculateInfrastructure(data)
@@ -463,6 +539,7 @@ func calculateSchoolHealth(data map[string]any) saudeOperacionalCalculation {
 	seguranca := calculateSecurity(data)
 	pessoal := calculatePeople(data)
 	tecnologia := calculateTechnology(data)
+	governanca := calculateGovernance(data)
 
 	saudeRaw := weightedMeanValid(
 		weightedHealthValue{Value: infraestrutura, Weight: pesos.Infraestrutura},
@@ -471,6 +548,7 @@ func calculateSchoolHealth(data map[string]any) saudeOperacionalCalculation {
 		weightedHealthValue{Value: seguranca, Weight: pesos.Seguranca},
 		weightedHealthValue{Value: pessoal, Weight: pesos.Pessoal},
 		weightedHealthValue{Value: tecnologia, Weight: pesos.Tecnologia},
+		weightedHealthValue{Value: governanca, Weight: pesos.Governanca},
 	)
 	saude := roundOptional1(saudeRaw)
 
@@ -501,7 +579,7 @@ func calculateSchoolHealth(data map[string]any) saudeOperacionalCalculation {
 			Pessoal:        roundOptional1(pessoal),
 			Tecnologia:     roundOptional1(tecnologia),
 			Pedagogico:     nil,
-			Governanca:     nil,
+			Governanca:     roundOptional1(governanca),
 		},
 	}
 }

--- a/api/cmd/api/analytics_saude_operacional_test.go
+++ b/api/cmd/api/analytics_saude_operacional_test.go
@@ -192,9 +192,9 @@ func TestSaudeOperacionalWeights(t *testing.T) {
 	}
 
 	enabled := pesos.Infraestrutura + pesos.Energia + pesos.Merenda +
-		pesos.Seguranca + pesos.Pessoal + pesos.Tecnologia
-	if math.Abs(enabled-0.84) > 1e-12 {
-		t.Fatalf("enabled weights = %v; want 0.84", enabled)
+		pesos.Seguranca + pesos.Pessoal + pesos.Tecnologia + pesos.Governanca
+	if math.Abs(enabled-0.92) > 1e-12 {
+		t.Fatalf("enabled weights = %v; want 0.92", enabled)
 	}
 }
 
@@ -203,8 +203,8 @@ func TestSaudeOperacionalMethodologyMetadata(t *testing.T) {
 	if got.Nome != "Índice de Saúde Operacional por escola" {
 		t.Fatalf("nome = %q", got.Nome)
 	}
-	if got.Versao != "1.0.0" {
-		t.Fatalf("versao = %q; want 1.0.0", got.Versao)
+	if got.Versao != "1.1.0" {
+		t.Fatalf("versao = %q; want 1.1.0", got.Versao)
 	}
 
 	want := []string{
@@ -214,6 +214,7 @@ func TestSaudeOperacionalMethodologyMetadata(t *testing.T) {
 		"seguranca",
 		"pessoal",
 		"tecnologia",
+		"governanca",
 	}
 	if len(got.DimensoesHabilitadas) != len(want) {
 		t.Fatalf("dimensoes_habilitadas = %v; want %v", got.DimensoesHabilitadas, want)
@@ -293,7 +294,13 @@ func TestSaudeOperacionalCalculateSchoolHealth(t *testing.T) {
 		"qtd_atende_necessidade_portaria": "Sim",
 		"qtd_atende_necessidade_sg":       "Sim",
 		"possui_direcao":                  "Sim",
+		"possui_secretario":               "Sim",
 		"possui_coord_pedagogico":         "Sim",
+		"possui_vice_pedagogico":          "Sim",
+		"possui_vice_administrativo":      "Sim",
+		"regularizada_cee":                "Sim",
+		"conselho_escolar":                "Sim",
+		"conselho_ativo":                  "Sim",
 		"internet_disponivel":             "Sim",
 		"qualidade_internet":              "A internet é estável e atende plenamente às necessidades da escola",
 		"computadores_atendem":            "Sim",
@@ -318,9 +325,110 @@ func TestSaudeOperacionalCalculateSchoolHealth(t *testing.T) {
 	if got.Dimensoes.Pedagogico != nil {
 		t.Fatalf("pedagogico = %v; want nil", *got.Dimensoes.Pedagogico)
 	}
-	if got.Dimensoes.Governanca != nil {
-		t.Fatalf("governanca = %v; want nil", *got.Dimensoes.Governanca)
+	assertOptionalFloat(t, got.Dimensoes.Governanca, floatPointerForTest(100))
+}
+
+func TestCalculateGovernance(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		want *float64
+	}{
+		{
+			name: "governanca completa",
+			data: map[string]any{
+				"possui_direcao":          "Sim",
+				"possui_secretario":       "Sim",
+				"possui_coord_pedagogico": "Sim",
+				"possui_vice_pedagogico":  "Sim",
+				"regularizada_cee":        "Sim",
+				"conselho_escolar":        "Sim",
+				"conselho_ativo":          "Sim",
+			},
+			want: floatPointerForTest(100),
+		},
+		{
+			name: "conselho parcialmente ativo",
+			data: map[string]any{
+				"possui_direcao":             "Sim",
+				"possui_secretario":          "Sim",
+				"possui_coord_pedagogico":    "Sim",
+				"possui_vice_administrativo": "Sim",
+				"regularizada_cee":           "Sim",
+				"conselho_escolar":           "Sim",
+				"conselho_ativo":             "Parcialmente",
+			},
+			want: floatPointerForTest(90),
+		},
+		{
+			name: "apenas direcao e cee",
+			data: map[string]any{
+				"possui_direcao":          "Sim",
+				"possui_secretario":       "Não",
+				"possui_coord_pedagogico": "Não",
+				"regularizada_cee":        "Sim",
+				"conselho_escolar":        "Não",
+			},
+			want: floatPointerForTest(35),
+		},
+		{
+			name: "vice por regra OU usa administrativo",
+			data: map[string]any{
+				"possui_vice_pedagogico":     "Não",
+				"possui_vice_administrativo": "Sim",
+			},
+			want: floatPointerForTest(10),
+		},
+		{
+			name: "tudo nao com variacoes de caixa e acento",
+			data: map[string]any{
+				"possui_direcao":             "nao",
+				"possui_secretario":          "NÃO",
+				"possui_coord_pedagogico":    " não ",
+				"possui_vice_pedagogico":     "Nao",
+				"possui_vice_administrativo": "não",
+				"regularizada_cee":           "Não",
+				"conselho_escolar":           "nÃo",
+				"conselho_ativo":             "Não",
+			},
+			want: floatPointerForTest(0),
+		},
+		{
+			name: "todos ausentes retorna nil",
+			data: map[string]any{
+				"situacao_estrutura": "Não necessita de reforma.",
+			},
+			want: nil,
+		},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertOptionalFloat(t, calculateGovernance(tt.data), tt.want)
+		})
+	}
+}
+
+// TestCalculatePeopleExcludesGestao garante que, após o Saúde-01B, as funções de
+// gestão (direção e coordenação pedagógica) não influenciam mais Pessoal/RH, que
+// passa a medir apenas suficiência de pessoal operacional/de apoio.
+func TestCalculatePeopleExcludesGestao(t *testing.T) {
+	base := map[string]any{
+		"qtd_atende_necessidade_merenda":  "Sim",
+		"qtd_atende_necessidade_sg":       "Sim",
+		"qtd_atende_necessidade_portaria": "Sim",
+	}
+	withGestao := map[string]any{
+		"qtd_atende_necessidade_merenda":  "Sim",
+		"qtd_atende_necessidade_sg":       "Sim",
+		"qtd_atende_necessidade_portaria": "Sim",
+		"possui_direcao":                  "Não",
+		"possui_coord_pedagogico":         "Não",
+	}
+
+	assertOptionalFloat(t, calculatePeople(base), floatPointerForTest(100))
+	// "Não" em direção/coordenação não pode derrubar Pessoal/RH.
+	assertOptionalFloat(t, calculatePeople(withGestao), floatPointerForTest(100))
 }
 
 func TestSaudeOperacionalZeroAndCriticality(t *testing.T) {


### PR DESCRIPTION
Ativa a dimensão Governança no Índice de Saúde Operacional das escolas.

A dimensão passa a medir capacidade real de gestão escolar, institucionalidade e participação, combinando direção escolar, secretário escolar, coordenação pedagógica, presença de vice-direção, regularização junto ao CEE/PA, Conselho Escolar constituído e funcionamento do conselho.

Move possui_direcao e possui_coord_pedagogico da dimensão Pessoal/RH para Governança, evitando dupla contagem e deixando Pessoal/RH focada em suficiência operacional e de apoio.

Mantém Pedagógico como dimensão nula nesta etapa.

Inclui Governança nas dimensões habilitadas do cálculo ponderado, preservando a renormalização por pesos disponíveis. A soma dos pesos habilitados passa de 0.84 para 0.92.

Atualiza a versão metodológica do Índice de Saúde Operacional para 1.1.0.

Adiciona testes para a nova regra de Governança, para a exclusão dos campos de gestão em Pessoal/RH, para a lista de dimensões habilitadas e para o payload metodológico.