### PR TITLE
fix(admin): exibir governanca na saude operacional

### DIFF
--- a/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
+++ b/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
@@ -557,7 +557,7 @@ export function AbaSaudeOperacionalEscolas({
                       <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.pessoal} /></td>
                       <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.tecnologia} /></td>
                       <td className="px-3 py-3 text-center"><DimensionBadge value={null} /></td>
-                      <td className="px-3 py-3 text-center"><DimensionBadge value={null} /></td>
+                      <td className="px-3 py-3 text-center"><DimensionBadge value={escola.dimensoes.governanca} /></td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Resumo

Corrige a coluna **Gov.** da tela **Saúde Operacional das Escolas** para exibir o valor retornado pelo backend em `escola.dimensoes.governanca`.

## Contexto

O PR #110 ativou o cálculo da dimensão Governança no backend, mas a tabela do frontend ainda renderizava a coluna Gov. com `value={null}` fixo. Por isso a coluna continuava aparecendo como `—`, mesmo com a API já preparada.

## Alteração

- Troca `value={null}` por `value={escola.dimensoes.governanca}` na coluna Gov.
- Mantém a coluna **Pedag.** como `null`, pois a dimensão Pedagógico ainda não foi implementada no backend.

## Validação

- `npm run build` executado com sucesso.
- `web/next-env.d.ts` foi restaurado após o build.
- Apenas `web/src/components/admin/AbaSaudeOperacionalEscolas.tsx` foi alterado.

## Fora do escopo

- Não altera backend.
- Não altera cálculo do índice.
- Não altera migrations.
- Não altera testes.
- Não altera dados.
- Não altera outras abas.
