### PR TITLE
feat(api): ativar pedagogico no indice de saude

### DIFF
--- a/api/cmd/api/analytics_saude_operacional.go
+++ b/api/cmd/api/analytics_saude_operacional.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -20,7 +21,7 @@ import (
 
 const (
 	saudeOperacionalNome            = "Índice de Saúde Operacional por escola"
-	saudeOperacionalVersao          = "1.1.0"
+	saudeOperacionalVersao          = "1.2.0"
 	saudeOperacionalPageSizeDefault = 10
 )
 
@@ -31,6 +32,7 @@ var saudeOperacionalDimensoesHabilitadas = []string{
 	"seguranca",
 	"pessoal",
 	"tecnologia",
+	"pedagogico",
 	"governanca",
 }
 
@@ -531,7 +533,93 @@ func calculateGovernance(data map[string]any) *float64 {
 	return ptrFloat(score)
 }
 
-func calculateSchoolHealth(data map[string]any) saudeOperacionalCalculation {
+// idebPedagogicoAggregate reúne os agregados brutos de IDEB de uma escola usados
+// para derivar a dimensão Pedagógico. Mantém os dados crus (soma ponderada, peso
+// total e média simples) para que a regra de fallback seja calculável por função
+// pura, testável sem banco.
+type idebPedagogicoAggregate struct {
+	// SomaPonderada = SUM(ideb * total_avaliado) com ideb não nulo e total_avaliado > 0.
+	SomaPonderada float64
+	// TotalPeso = SUM(total_avaliado) sob a mesma condição da soma ponderada.
+	TotalPeso float64
+	// MediaSimples = AVG(ideb) com ideb não nulo; nil quando não há IDEB válido.
+	MediaSimples *float64
+}
+
+// calculatePedagogicoFromIdeb converte os agregados de IDEB de uma escola na nota
+// Pedagógico em escala 0–100 (ideb * 10):
+//   - média ponderada por total_avaliado quando há peso válido (> 0);
+//   - fallback para média simples quando há IDEB válido mas nenhum total_avaliado > 0;
+//   - nil quando não há IDEB válido — ausência de IDEB NUNCA vira zero.
+func calculatePedagogicoFromIdeb(agg idebPedagogicoAggregate) *float64 {
+	if agg.TotalPeso > 0 {
+		return ptrFloat((agg.SomaPonderada / agg.TotalPeso) * 10)
+	}
+	if agg.MediaSimples != nil {
+		return ptrFloat(*agg.MediaSimples * 10)
+	}
+	return nil
+}
+
+// saudeOperacionalPedagogicoSQL agrega ideb_resultados do ÚLTIMO ano disponível
+// (MAX(ano)) por school_id. Considera apenas registros com vínculo cadastral
+// (school_id IS NOT NULL); registros sem match em schools não contribuem para
+// nenhuma escola. A regra de conversão/fallback fica em Go
+// (calculatePedagogicoFromIdeb), por isso a query devolve os agregados crus.
+const saudeOperacionalPedagogicoSQL = `
+	WITH ultimo_ano AS (
+		SELECT MAX(ano) AS ano FROM ideb_resultados
+	)
+	SELECT
+		i.school_id,
+		COALESCE(SUM(i.ideb * i.total_avaliado) FILTER (
+			WHERE i.ideb IS NOT NULL AND i.total_avaliado > 0), 0) AS soma_ponderada,
+		COALESCE(SUM(i.total_avaliado) FILTER (
+			WHERE i.ideb IS NOT NULL AND i.total_avaliado > 0), 0) AS total_peso,
+		AVG(i.ideb) FILTER (WHERE i.ideb IS NOT NULL) AS media_simples
+	FROM ideb_resultados i
+	JOIN ultimo_ano u ON u.ano = i.ano
+	WHERE i.school_id IS NOT NULL
+	GROUP BY i.school_id
+`
+
+// loadPedagogicoPorEscola devolve a nota Pedagógico (0–100) já calculada por
+// school_id, a partir do IDEB oficial do último ano em ideb_resultados. Escolas
+// sem IDEB válido não entram no mapa — o lookup de uma chave ausente devolve nil
+// naturalmente, preservando o padrão "sem dados" da dimensão.
+func (app *application) loadPedagogicoPorEscola(ctx context.Context) (map[int]*float64, error) {
+	rows, err := app.models.Schools.DB.QueryContext(ctx, saudeOperacionalPedagogicoSQL)
+	if err != nil {
+		return nil, fmt.Errorf("consultar pedagógico/IDEB por escola: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[int]*float64)
+	for rows.Next() {
+		var (
+			schoolID      int
+			somaPonderada float64
+			totalPeso     float64
+			mediaSimples  sql.NullFloat64
+		)
+		if err := rows.Scan(&schoolID, &somaPonderada, &totalPeso, &mediaSimples); err != nil {
+			return nil, fmt.Errorf("ler pedagógico/IDEB por escola: %w", err)
+		}
+		agg := idebPedagogicoAggregate{
+			SomaPonderada: somaPonderada,
+			TotalPeso:     totalPeso,
+		}
+		if mediaSimples.Valid {
+			agg.MediaSimples = ptrFloat(mediaSimples.Float64)
+		}
+		if pedagogico := calculatePedagogicoFromIdeb(agg); pedagogico != nil {
+			out[schoolID] = pedagogico
+		}
+	}
+	return out, rows.Err()
+}
+
+func calculateSchoolHealth(data map[string]any, pedagogico *float64) saudeOperacionalCalculation {
 	pesos := saudeOperacionalPesosMetodologia()
 	infraestrutura := calculateInfrastructure(data)
 	energia := calculateEnergy(data)
@@ -548,6 +636,7 @@ func calculateSchoolHealth(data map[string]any) saudeOperacionalCalculation {
 		weightedHealthValue{Value: seguranca, Weight: pesos.Seguranca},
 		weightedHealthValue{Value: pessoal, Weight: pesos.Pessoal},
 		weightedHealthValue{Value: tecnologia, Weight: pesos.Tecnologia},
+		weightedHealthValue{Value: pedagogico, Weight: pesos.Pedagogico},
 		weightedHealthValue{Value: governanca, Weight: pesos.Governanca},
 	)
 	saude := roundOptional1(saudeRaw)
@@ -578,7 +667,7 @@ func calculateSchoolHealth(data map[string]any) saudeOperacionalCalculation {
 			Seguranca:      roundOptional1(seguranca),
 			Pessoal:        roundOptional1(pessoal),
 			Tecnologia:     roundOptional1(tecnologia),
-			Pedagogico:     nil,
+			Pedagogico:     roundOptional1(pedagogico),
 			Governanca:     roundOptional1(governanca),
 		},
 	}
@@ -609,7 +698,11 @@ func nullableTrimmedString(value sql.NullString) *string {
 	return ptrString(trimmed)
 }
 
-func buildSaudeOperacionalEscola(row saudeOperacionalDBRow) (SaudeOperacionalEscola, error) {
+// buildSaudeOperacionalEscola monta a escola do payload. O parâmetro pedagogico
+// é a nota Pedagógico (0–100) derivada do IDEB para a escola; só é aplicado
+// quando há censo concluído (a escola é, de fato, pontuada). Escolas sem censo
+// permanecem "sem_dados" com todas as dimensões nulas, mesmo que possuam IDEB.
+func buildSaudeOperacionalEscola(row saudeOperacionalDBRow, pedagogico *float64) (SaudeOperacionalEscola, error) {
 	out := SaudeOperacionalEscola{
 		SchoolID:   row.SchoolID,
 		CensusID:   nil,
@@ -633,7 +726,7 @@ func buildSaudeOperacionalEscola(row saudeOperacionalDBRow) (SaudeOperacionalEsc
 	if err != nil {
 		return SaudeOperacionalEscola{}, fmt.Errorf("decodificar JSONB do censo %d: %w", censusID, err)
 	}
-	calculation := calculateSchoolHealth(data)
+	calculation := calculateSchoolHealth(data, pedagogico)
 	out.TotalAlunos = calculation.TotalAlunos
 	out.SalasAula = calculation.SalasAula
 	out.AlunosPorSala = calculation.AlunosPorSala
@@ -1008,6 +1101,15 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 	filters := parseSaudeOperacionalFilters(q)
 	query, args := buildSaudeOperacionalQuery(year, filters)
 
+	// Nota Pedagógico (IDEB) por escola, do último ano disponível em
+	// ideb_resultados. Independe do ano do censo: é o resultado oficial mais
+	// recente aplicado a cada escola pontuada.
+	pedagogicoPorEscola, err := app.loadPedagogicoPorEscola(r.Context())
+	if err != nil {
+		app.errorJSON(w, err, http.StatusInternalServerError)
+		return
+	}
+
 	dbRows, err := app.models.Schools.DB.QueryContext(r.Context(), query, args...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("consultar saúde operacional das escolas: %v", err), http.StatusInternalServerError)
@@ -1031,7 +1133,7 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 			app.errorJSON(w, fmt.Errorf("ler escola da saúde operacional: %v", err), http.StatusInternalServerError)
 			return
 		}
-		escola, err := buildSaudeOperacionalEscola(row)
+		escola, err := buildSaudeOperacionalEscola(row, pedagogicoPorEscola[row.SchoolID])
 		if err != nil {
 			app.errorJSON(w, err, http.StatusInternalServerError)
 			return

--- a/api/cmd/api/analytics_saude_operacional_test.go
+++ b/api/cmd/api/analytics_saude_operacional_test.go
@@ -192,9 +192,9 @@ func TestSaudeOperacionalWeights(t *testing.T) {
 	}
 
 	enabled := pesos.Infraestrutura + pesos.Energia + pesos.Merenda +
-		pesos.Seguranca + pesos.Pessoal + pesos.Tecnologia + pesos.Governanca
-	if math.Abs(enabled-0.92) > 1e-12 {
-		t.Fatalf("enabled weights = %v; want 0.92", enabled)
+		pesos.Seguranca + pesos.Pessoal + pesos.Tecnologia + pesos.Pedagogico + pesos.Governanca
+	if math.Abs(enabled-1) > 1e-12 {
+		t.Fatalf("enabled weights = %v; want 1.00", enabled)
 	}
 }
 
@@ -203,8 +203,8 @@ func TestSaudeOperacionalMethodologyMetadata(t *testing.T) {
 	if got.Nome != "Índice de Saúde Operacional por escola" {
 		t.Fatalf("nome = %q", got.Nome)
 	}
-	if got.Versao != "1.1.0" {
-		t.Fatalf("versao = %q; want 1.1.0", got.Versao)
+	if got.Versao != "1.2.0" {
+		t.Fatalf("versao = %q; want 1.2.0", got.Versao)
 	}
 
 	want := []string{
@@ -214,6 +214,7 @@ func TestSaudeOperacionalMethodologyMetadata(t *testing.T) {
 		"seguranca",
 		"pessoal",
 		"tecnologia",
+		"pedagogico",
 		"governanca",
 	}
 	if len(got.DimensoesHabilitadas) != len(want) {
@@ -309,7 +310,8 @@ func TestSaudeOperacionalCalculateSchoolHealth(t *testing.T) {
 		"qtd_salas_aula":                  json.Number("12"),
 	}
 
-	got := calculateSchoolHealth(data)
+	// Com Pedagógico 100 e todas as demais dimensões 100, a Saúde permanece 100.
+	got := calculateSchoolHealth(data, floatPointerForTest(100))
 	assertOptionalFloat(t, got.Saude, floatPointerForTest(100))
 	assertOptionalFloat(t, got.Criticidade, floatPointerForTest(0))
 	assertOptionalFloat(t, got.AlunosPorSala, floatPointerForTest(25))
@@ -322,10 +324,52 @@ func TestSaudeOperacionalCalculateSchoolHealth(t *testing.T) {
 	if got.SalasAula == nil || *got.SalasAula != 12 {
 		t.Fatalf("salas_aula = %v; want 12", got.SalasAula)
 	}
-	if got.Dimensoes.Pedagogico != nil {
-		t.Fatalf("pedagogico = %v; want nil", *got.Dimensoes.Pedagogico)
-	}
+	assertOptionalFloat(t, got.Dimensoes.Pedagogico, floatPointerForTest(100))
 	assertOptionalFloat(t, got.Dimensoes.Governanca, floatPointerForTest(100))
+
+	// Sem IDEB (pedagogico nil), a dimensão fica nula e não derruba a Saúde:
+	// renormaliza pelos pesos das demais dimensões, mantendo 100.
+	semIdeb := calculateSchoolHealth(data, nil)
+	assertOptionalFloat(t, semIdeb.Saude, floatPointerForTest(100))
+	if semIdeb.Dimensoes.Pedagogico != nil {
+		t.Fatalf("pedagogico = %v; want nil", *semIdeb.Dimensoes.Pedagogico)
+	}
+}
+
+func TestCalculatePedagogicoFromIdeb(t *testing.T) {
+	tests := []struct {
+		name string
+		agg  idebPedagogicoAggregate
+		want *float64
+	}{
+		{
+			name: "uma etapa: IDEB 4.8 vira 48.0",
+			agg:  idebPedagogicoAggregate{SomaPonderada: 4.8 * 50, TotalPeso: 50, MediaSimples: floatPointerForTest(4.8)},
+			want: floatPointerForTest(48),
+		},
+		{
+			name: "multiplas etapas usam media ponderada por total_avaliado",
+			// IDEB 5.0 (peso 100) e 6.0 (peso 300): (5*100 + 6*300)/400 = 5.75 -> 57.5
+			agg:  idebPedagogicoAggregate{SomaPonderada: 5.0*100 + 6.0*300, TotalPeso: 400, MediaSimples: floatPointerForTest(5.5)},
+			want: floatPointerForTest(57.5),
+		},
+		{
+			name: "fallback para media simples quando nao ha total_avaliado > 0",
+			agg:  idebPedagogicoAggregate{SomaPonderada: 0, TotalPeso: 0, MediaSimples: floatPointerForTest(5.0)},
+			want: floatPointerForTest(50),
+		},
+		{
+			name: "sem IDEB valido retorna nil (nunca zero)",
+			agg:  idebPedagogicoAggregate{SomaPonderada: 0, TotalPeso: 0, MediaSimples: nil},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertOptionalFloat(t, calculatePedagogicoFromIdeb(tt.agg), tt.want)
+		})
+	}
 }
 
 func TestCalculateGovernance(t *testing.T) {
@@ -434,7 +478,7 @@ func TestCalculatePeopleExcludesGestao(t *testing.T) {
 func TestSaudeOperacionalZeroAndCriticality(t *testing.T) {
 	got := calculateSchoolHealth(map[string]any{
 		"rede_eletrica_atende": "Não",
-	})
+	}, nil)
 
 	assertOptionalFloat(t, got.Dimensoes.Energia, floatPointerForTest(0))
 	assertOptionalFloat(t, got.Saude, floatPointerForTest(0))
@@ -480,7 +524,7 @@ func TestSaudeOperacionalMetricParsing(t *testing.T) {
 	got := calculateSchoolHealth(map[string]any{
 		"total_alunos":   10,
 		"qtd_salas_aula": 0,
-	})
+	}, nil)
 	if got.AlunosPorSala != nil {
 		t.Fatalf("alunos_por_sala with zero rooms = %v; want nil", *got.AlunosPorSala)
 	}
@@ -488,13 +532,15 @@ func TestSaudeOperacionalMetricParsing(t *testing.T) {
 	got = calculateSchoolHealth(map[string]any{
 		"total_alunos":   10.5,
 		"qtd_salas_aula": 2,
-	})
+	}, nil)
 	if got.TotalAlunos != nil || got.AlunosPorSala != nil {
 		t.Fatalf("fractional student count should remain invalid: total=%v ratio=%v", got.TotalAlunos, got.AlunosPorSala)
 	}
 }
 
 func TestSaudeOperacionalSchoolWithoutCensus(t *testing.T) {
+	// Mesmo recebendo uma nota Pedagógico (IDEB existe), escola sem censo concluído
+	// permanece sem_dados com todas as dimensões nulas.
 	escola, err := buildSaudeOperacionalEscola(saudeOperacionalDBRow{
 		SchoolID:   10,
 		CodigoINEP: sql.NullString{String: "12345678", Valid: true},
@@ -503,7 +549,7 @@ func TestSaudeOperacionalSchoolWithoutCensus(t *testing.T) {
 		DRE:        "DRE 1",
 		Zona:       sql.NullString{},
 		CensusID:   sql.NullInt64{},
-	})
+	}, floatPointerForTest(75))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +577,7 @@ func TestSaudeOperacionalPayloadSerializesNull(t *testing.T) {
 		SchoolID: 1,
 		Escola:   "Escola",
 		CensusID: sql.NullInt64{},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Resumo

Ativa a dimensão **Pedagógico** no backend do Índice de Saúde Operacional das escolas, usando a base oficial do IDEB já carregada em `ideb_resultados`.

## Regra metodológica

- Converte IDEB para escala 0–100 usando `IDEB * 10`.
- Para escolas com múltiplas etapas, usa média ponderada por `total_avaliado`.
- Quando não há peso válido, aplica fallback para média simples das etapas com IDEB.
- Quando não há IDEB válido, mantém `pedagogico = nil`, sem transformar ausência de dado oficial em zero.
- Usa o último ano disponível em `ideb_resultados` via `MAX(ano)`.

## Alterações

- Atualiza a versão metodológica do Índice de Saúde Operacional para `1.2.0`.
- Adiciona `pedagogico` às dimensões habilitadas.
- Eleva a soma dos pesos habilitados para `1.00`.
- Agrega IDEB por `school_id` em query auxiliar executada uma única vez.
- Injeta a nota pedagógica no cálculo de `calculateSchoolHealth`.
- Mantém Governança intacta.
- Mantém escolas sem censo concluído como `sem_dados`.

## Validação

- `go test -count=1 ./...` executado com sucesso.
- `go vet ./...` executado sem apontamentos.
- `go build ./cmd/api/...` executado com sucesso.

## Testes

Inclui cobertura para:

- uma etapa com IDEB válido;
- múltiplas etapas com média ponderada;
- fallback para média simples;
- ausência de IDEB retornando `nil`;
- escola sem censo concluído permanecendo `sem_dados`.

## Fora do escopo

- Não altera frontend.
- Não altera migrations.
- Não altera importador IDEB.
- Não altera dados.
- Não altera `schools`.
- Não altera arquivos `_local`.

## Pendência posterior

O frontend ainda precisa ser ajustado na frente Saúde-02C para a coluna **Pedag.** ler `escola.dimensoes.pedagogico`.