### PR TITLE
feat(admin): iniciar relatorios gerenciais em xlsx

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -380,6 +380,10 @@ func (app *application) routes() http.Handler {
 
 			// Filtros globais do dashboard.
 			protected.Get("/admin/analytics/filtros/opcoes", app.AdminAnalyticsFiltrosOpcoes)
+
+			// Relatórios gerenciais por aba (XLSX). Camada extensível; o
+			// report_id é resolvido contra reportsCatalog.
+			protected.Get("/admin/reports/{report_id}", app.AdminGetReport)
 		})
 	})
 

--- a/api/cmd/api/reports.go
+++ b/api/cmd/api/reports.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// =====================================================================
+// Relatórios gerenciais — handler HTTP e relatório piloto
+// =====================================================================
+// Rota: GET /v1/admin/reports/{report_id} (protegida por requireAdminAuth).
+// Respostas:
+//   - 401: token ausente/inválido (tratado pelo middleware).
+//   - 404: report_id não consta no catálogo.
+//   - 400: format diferente de xlsx.
+//   - 500: erro interno (consulta/geração).
+//   - 200: arquivo XLSX como anexo.
+//
+// Esta camada é independente dos endpoints analíticos: não altera
+// consultas, views nem cálculos existentes. Reaproveita apenas o padrão
+// de filtros globais (year, dre, municipio, zona, regiao_integracao).
+// =====================================================================
+
+// reportFormatXLSX é o único formato suportado nesta fase.
+const reportFormatXLSX = "xlsx"
+
+// reportFilters reúne os filtros globais aplicáveis ao relatório. Difere
+// de AnalyticsFilters num ponto importante: year ausente/ inválido
+// significa "todos os anos" (Year = 0), e não o ano corrente — um
+// relatório de acompanhamento deve poder consolidar o histórico.
+type reportFilters struct {
+	Year             int // 0 = todos os anos
+	DRE              string
+	Municipio        string
+	Zona             string
+	RegiaoIntegracao string
+}
+
+// parseReportFilters lê os filtros da query string, removendo espaços. Um
+// year ausente, em branco, não numérico, zero ou negativo desativa o
+// filtro de ano (Year = 0).
+func parseReportFilters(q url.Values) reportFilters {
+	f := reportFilters{
+		DRE:              strings.TrimSpace(q.Get("dre")),
+		Municipio:        strings.TrimSpace(q.Get("municipio")),
+		Zona:             strings.TrimSpace(q.Get("zona")),
+		RegiaoIntegracao: strings.TrimSpace(q.Get("regiao_integracao")),
+	}
+	if y, err := strconv.Atoi(strings.TrimSpace(q.Get("year"))); err == nil && y > 0 {
+		f.Year = y
+	}
+	return f
+}
+
+// args devolve os argumentos posicionais na ordem usada pelas consultas de
+// relatório: $1=year (0 = sem filtro), $2=dre, $3=municipio, $4=zona,
+// $5=regiao_integracao.
+func (f reportFilters) args() []any {
+	return []any{f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao}
+}
+
+// describe monta a linha 2 do XLSX ("Filtros aplicados — ..."). Sempre
+// informa o recorte de ano; filtros territoriais só aparecem quando ativos.
+func (f reportFilters) describe() string {
+	parts := make([]string, 0, 5)
+	if f.Year > 0 {
+		parts = append(parts, "Ano: "+strconv.Itoa(f.Year))
+	} else {
+		parts = append(parts, "Ano: todos")
+	}
+	if f.RegiaoIntegracao != "" {
+		parts = append(parts, "Região de Integração: "+f.RegiaoIntegracao)
+	}
+	if f.DRE != "" {
+		parts = append(parts, "DRE: "+f.DRE)
+	}
+	if f.Municipio != "" {
+		parts = append(parts, "Município: "+f.Municipio)
+	}
+	if f.Zona != "" {
+		parts = append(parts, "Zona: "+f.Zona)
+	}
+	return "Filtros aplicados — " + strings.Join(parts, " | ")
+}
+
+// normalizeReportFormat aplica o default xlsx quando o parâmetro está
+// ausente e normaliza caixa/espaços para a validação.
+func normalizeReportFormat(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return reportFormatXLSX
+	}
+	return raw
+}
+
+// censoStatusLabel classifica o status gerencial de uma escola a partir do
+// status técnico do censo (hasCensus=false quando não há resposta) e do
+// estado de sincronização com a planilha. Espelha a tabela documentada na
+// especificação:
+//
+//	sem resposta                                   -> Pendente
+//	draft                                          -> Rascunho
+//	completed + sheet_synced_at IS NULL            -> Pendente de Sincronização
+//	completed + sheet_synced_at IS NOT NULL        -> Concluído
+//	qualquer outro                                 -> Verificar
+func censoStatusLabel(status string, hasCensus, synced bool) string {
+	if !hasCensus {
+		return "Pendente"
+	}
+	switch status {
+	case "draft":
+		return "Rascunho"
+	case "completed":
+		if synced {
+			return "Concluído"
+		}
+		return "Pendente de Sincronização"
+	default:
+		return "Verificar"
+	}
+}
+
+// situacaoOperacional é a coluna complementar "Situação Operacional".
+// Inicialmente deriva do status gerencial, traduzindo-o para uma frase de
+// leitura operacional pelas DREs (documentado em código, conforme a spec).
+func situacaoOperacional(statusLabel string) string {
+	switch statusLabel {
+	case "Pendente":
+		return "Aguardando preenchimento"
+	case "Rascunho":
+		return "Preenchimento em andamento"
+	case "Pendente de Sincronização":
+		return "Concluído, aguardando sincronização"
+	case "Concluído":
+		return "Concluído e sincronizado"
+	default:
+		return "Verificar manualmente"
+	}
+}
+
+// AdminGetReport é o handler da rota GET /v1/admin/reports/{report_id}.
+func (app *application) AdminGetReport(w http.ResponseWriter, r *http.Request) {
+	reportID := strings.TrimSpace(chi.URLParam(r, "report_id"))
+
+	def, ok := lookupReport(reportID)
+	if !ok {
+		app.errorJSON(w, fmt.Errorf("relatório %q não encontrado", reportID), http.StatusNotFound)
+		return
+	}
+
+	format := normalizeReportFormat(r.URL.Query().Get("format"))
+	if format != reportFormatXLSX {
+		app.errorJSON(w, fmt.Errorf("formato %q não suportado; use format=xlsx", format), http.StatusBadRequest)
+		return
+	}
+
+	filters := parseReportFilters(r.URL.Query())
+
+	var (
+		rd  reportData
+		err error
+	)
+	switch def.ID {
+	case reportCensoPreenchimentoID:
+		rd, err = app.buildCensoPreenchimentoReportData(r.Context(), def, filters)
+	default:
+		// Catálogo e dispatch desalinhados: defensivo.
+		app.errorJSON(w, fmt.Errorf("relatório %q sem implementação", def.ID), http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		app.logger.Printf("AdminGetReport %s: %v", def.ID, err)
+		app.errorJSON(w, fmt.Errorf("erro ao gerar relatório"), http.StatusInternalServerError)
+		return
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		app.logger.Printf("AdminGetReport %s: gerar xlsx: %v", def.ID, err)
+		app.errorJSON(w, fmt.Errorf("erro ao gerar arquivo"), http.StatusInternalServerError)
+		return
+	}
+
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		app.logger.Printf("AdminGetReport %s: serializar xlsx: %v", def.ID, err)
+		app.errorJSON(w, fmt.Errorf("erro ao gerar arquivo"), http.StatusInternalServerError)
+		return
+	}
+
+	filename := buildReportFileName(def.FileBase, filters)
+	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		app.logger.Printf("AdminGetReport %s: escrever resposta: %v", def.ID, err)
+	}
+}
+
+// censoPreenchimentoReportColumns são os cabeçalhos do relatório piloto, na
+// ordem exigida pela especificação (colunas territoriais comuns seguidas
+// dos campos de acompanhamento).
+var censoPreenchimentoReportColumns = []string{
+	"Região de Integração",
+	"DRE",
+	"Município",
+	"Zona",
+	"Código INEP",
+	"Escola",
+	"Status do Censo",
+	"Ano",
+	"Última Atualização",
+	"Sincronizado com Planilha",
+	"Data de Sincronização",
+	"Situação Operacional",
+}
+
+// censoPreenchimentoSelectSQL parte de schools s com LEFT JOIN na resposta
+// de censo mais recente (CTE latest_census) para que escolas sem resposta
+// permaneçam no recorte e apareçam como pendentes. A Região de Integração
+// vem de um LEFT JOIN em reg_integracao (mesma grafia por município usada
+// nos demais endpoints). NÃO reutiliza censusListSelectSQL/AnalyticsFilters,
+// que fazem JOIN obrigatório com census_responses e excluiriam pendentes.
+//
+// Ano: $1 = 0 considera todas as respostas (pega a mais recente por escola);
+// $1 > 0 restringe à resposta daquele ano. Demais filtros incidem sobre
+// schools s com UPPER(TRIM(...)) para tolerar caixa e espaços.
+//
+// A ordenação segue a prioridade gerencial (Pendente, Rascunho, Pendente de
+// Sincronização, Concluído, Verificar) e depois DRE, Município, Escola, INEP.
+const censoPreenchimentoSelectSQL = `
+	WITH latest_census AS (
+		SELECT DISTINCT ON (school_id)
+			school_id, status, year, updated_at, sheet_synced_at
+		FROM census_responses
+		WHERE ($1 = 0 OR year = $1)
+		ORDER BY school_id, updated_at DESC, id DESC
+	)
+	SELECT
+		COALESCE(ri.regiao_de_integracao, '') AS regiao_integracao,
+		COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre,
+		COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio,
+		COALESCE(NULLIF(TRIM(s.zona), ''), '') AS zona,
+		COALESCE(s.codigo_inep, '') AS codigo_inep,
+		COALESCE(NULLIF(TRIM(s.nome_escola), ''), 'Sem nome') AS nome_escola,
+		cr.status,
+		cr.year,
+		cr.updated_at,
+		(cr.sheet_synced_at IS NOT NULL) AS synced,
+		cr.sheet_synced_at
+	FROM schools s
+	LEFT JOIN latest_census cr ON cr.school_id = s.id
+	LEFT JOIN reg_integracao ri ON UPPER(TRIM(ri.municipio)) = UPPER(TRIM(s.municipio))
+	WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))
+	ORDER BY
+		CASE
+			WHEN cr.status IS NULL THEN 1
+			WHEN cr.status = 'draft' THEN 2
+			WHEN cr.status = 'completed' AND cr.sheet_synced_at IS NULL THEN 3
+			WHEN cr.status = 'completed' AND cr.sheet_synced_at IS NOT NULL THEN 4
+			ELSE 5
+		END,
+		UPPER(TRIM(s.dre)),
+		UPPER(TRIM(s.municipio)),
+		UPPER(TRIM(s.nome_escola)),
+		s.codigo_inep
+`
+
+// reportDateLayout é o formato pt-BR usado para datas no XLSX.
+const reportDateLayout = "02/01/2006 15:04"
+
+// buildCensoPreenchimentoReportData executa a consulta do relatório piloto
+// e monta o reportData (sem paginar). Datas chegam formatadas em pt-BR; o
+// ano vem como inteiro quando há resposta, ou célula vazia quando pendente.
+func (app *application) buildCensoPreenchimentoReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
+	rows, err := app.models.Schools.DB.QueryContext(ctx, censoPreenchimentoSelectSQL, f.args()...)
+	if err != nil {
+		return reportData{}, fmt.Errorf("consultar preenchimento: %w", err)
+	}
+	defer rows.Close()
+
+	data := make([][]any, 0)
+	for rows.Next() {
+		var (
+			regiao, dre, municipio, zona, inep, escola string
+			status                                     sql.NullString
+			year                                       sql.NullInt64
+			updatedAt, syncedAt                        sql.NullTime
+			synced                                     bool
+		)
+		if err := rows.Scan(&regiao, &dre, &municipio, &zona, &inep, &escola,
+			&status, &year, &updatedAt, &synced, &syncedAt); err != nil {
+			return reportData{}, fmt.Errorf("ler linha: %w", err)
+		}
+
+		label := censoStatusLabel(status.String, status.Valid, synced)
+
+		anoCell := any("")
+		if year.Valid {
+			anoCell = int(year.Int64)
+		}
+		updatedCell := ""
+		if updatedAt.Valid {
+			updatedCell = updatedAt.Time.Format(reportDateLayout)
+		}
+		syncedCell := "Não"
+		if synced {
+			syncedCell = "Sim"
+		}
+		syncDateCell := ""
+		if syncedAt.Valid {
+			syncDateCell = syncedAt.Time.Format(reportDateLayout)
+		}
+
+		data = append(data, []any{
+			regiao,
+			dre,
+			municipio,
+			zona,
+			inep,
+			escola,
+			label,
+			anoCell,
+			updatedCell,
+			syncedCell,
+			syncDateCell,
+			situacaoOperacional(label),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return reportData{}, fmt.Errorf("iterar linhas: %w", err)
+	}
+
+	return reportData{
+		Title:       def.Title,
+		SheetName:   def.SheetName,
+		FiltersLine: f.describe(),
+		Headers:     censoPreenchimentoReportColumns,
+		Rows:        data,
+	}, nil
+}

--- a/api/cmd/api/reports_catalog.go
+++ b/api/cmd/api/reports_catalog.go
@@ -1,0 +1,52 @@
+package main
+
+// =====================================================================
+// Catálogo de relatórios gerenciais por aba
+// =====================================================================
+// Camada extensível: cada relatório exportável é descrito por uma
+// ReportDefinition e registrado em reportsCatalog. A rota
+// GET /v1/admin/reports/{report_id} resolve o report_id contra este
+// catálogo (404 quando não existe) e o handler dispara o builder
+// específico do relatório.
+//
+// Nesta primeira fase só existe o relatório piloto
+// "censo-preenchimento-escolas". Novos relatórios (saúde operacional,
+// infraestrutura, merenda, tecnologia, ...) devem ser adicionados aqui
+// com seu próprio builder no handler, sem alterar a rota nem o gerador
+// XLSX genérico.
+// =====================================================================
+
+// reportCensoPreenchimentoID é o identificador do relatório piloto de
+// acompanhamento do preenchimento do censo.
+const reportCensoPreenchimentoID = "censo-preenchimento-escolas"
+
+// ReportDefinition descreve os metadados de um relatório gerencial. Os
+// campos são suficientes para montar o cabeçalho do XLSX (Title), nomear
+// a aba (SheetName) e derivar o nome do arquivo (FileBase). A consulta e
+// a montagem das linhas ficam no builder específico de cada relatório,
+// mantendo o catálogo livre de dependências de banco e de excelize.
+type ReportDefinition struct {
+	ID          string
+	Title       string
+	Description string
+	SheetName   string
+	FileBase    string
+}
+
+// reportsCatalog é o registro de relatórios disponíveis, indexado por ID.
+var reportsCatalog = map[string]ReportDefinition{
+	reportCensoPreenchimentoID: {
+		ID:          reportCensoPreenchimentoID,
+		Title:       "Relatório de Acompanhamento do Preenchimento do Censo",
+		Description: "Acompanhamento nominal do preenchimento do censo por escola, incluindo escolas ainda pendentes.",
+		SheetName:   "Preenchimento Censo",
+		FileBase:    "relatorio_censo_preenchimento_escolas",
+	},
+}
+
+// lookupReport devolve a definição do relatório e um booleano indicando
+// se ela existe no catálogo.
+func lookupReport(id string) (ReportDefinition, bool) {
+	def, ok := reportsCatalog[id]
+	return def, ok
+}

--- a/api/cmd/api/reports_test.go
+++ b/api/cmd/api/reports_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestReportsCatalogRecognizesPiloto garante que o relatório piloto está
+// registrado e expõe os metadados esperados.
+func TestReportsCatalogRecognizesPiloto(t *testing.T) {
+	def, ok := lookupReport(reportCensoPreenchimentoID)
+	if !ok {
+		t.Fatalf("lookupReport(%q) = not found; esperado encontrado", reportCensoPreenchimentoID)
+	}
+	if def.ID != reportCensoPreenchimentoID {
+		t.Fatalf("ID = %q; want %q", def.ID, reportCensoPreenchimentoID)
+	}
+	if def.SheetName != "Preenchimento Censo" {
+		t.Fatalf("SheetName = %q; want %q", def.SheetName, "Preenchimento Censo")
+	}
+	if def.FileBase != "relatorio_censo_preenchimento_escolas" {
+		t.Fatalf("FileBase = %q; inesperado", def.FileBase)
+	}
+	if strings.TrimSpace(def.Title) == "" {
+		t.Fatalf("Title vazio")
+	}
+}
+
+// TestReportsCatalogUnknownNotFound garante que um report_id inexistente
+// não é resolvido.
+func TestReportsCatalogUnknownNotFound(t *testing.T) {
+	if _, ok := lookupReport("relatorio-que-nao-existe"); ok {
+		t.Fatalf("lookupReport de id inexistente retornou ok=true")
+	}
+	if _, ok := lookupReport(""); ok {
+		t.Fatalf("lookupReport(\"\") retornou ok=true")
+	}
+}
+
+// TestNormalizeReportFormat cobre o default xlsx e a normalização de caixa.
+func TestNormalizeReportFormat(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", "xlsx"},
+		{"   ", "xlsx"},
+		{"xlsx", "xlsx"},
+		{"XLSX", "xlsx"},
+		{" Xlsx ", "xlsx"},
+		{"pdf", "pdf"},
+		{"csv", "csv"},
+	}
+	for _, tt := range tests {
+		if got := normalizeReportFormat(tt.in); got != tt.want {
+			t.Fatalf("normalizeReportFormat(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestParseReportFiltersYear garante que year ausente/inválido vira 0
+// (todos os anos) — diferente de parseAnalyticsFilters.
+func TestParseReportFiltersYear(t *testing.T) {
+	for _, invalid := range []string{"", "abc", "0", "-3", "  "} {
+		got := parseReportFilters(url.Values{"year": {invalid}})
+		if got.Year != 0 {
+			t.Fatalf("year %q = %d; want 0 (todos os anos)", invalid, got.Year)
+		}
+	}
+	got := parseReportFilters(url.Values{"year": {" 2026 "}})
+	if got.Year != 2026 {
+		t.Fatalf("year válido = %d; want 2026", got.Year)
+	}
+}
+
+// TestParseReportFiltersStringsAndArgs cobre a leitura dos filtros textuais
+// e a ordem posicional dos argumentos.
+func TestParseReportFiltersStringsAndArgs(t *testing.T) {
+	q := url.Values{
+		"year":              {"2026"},
+		"dre":               {"  BELEM  "},
+		"municipio":         {"Belém"},
+		"zona":              {"Urbana"},
+		"regiao_integracao": {"GUAJARA"},
+	}
+	f := parseReportFilters(q)
+	if f.DRE != "BELEM" || f.Municipio != "Belém" || f.Zona != "Urbana" || f.RegiaoIntegracao != "GUAJARA" {
+		t.Fatalf("filtros = %+v; leitura incorreta", f)
+	}
+	args := f.args()
+	want := []any{2026, "BELEM", "Belém", "Urbana", "GUAJARA"}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v; want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args[%d] = %v; want %v", i, args[i], want[i])
+		}
+	}
+}
+
+// TestCensoStatusLabel cobre a tabela de classificação gerencial.
+func TestCensoStatusLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    string
+		hasCensus bool
+		synced    bool
+		want      string
+	}{
+		{"sem resposta", "", false, false, "Pendente"},
+		{"rascunho", "draft", true, false, "Rascunho"},
+		{"completed nao sincronizado", "completed", true, false, "Pendente de Sincronização"},
+		{"completed sincronizado", "completed", true, true, "Concluído"},
+		{"status inesperado", "qualquer", true, false, "Verificar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := censoStatusLabel(tt.status, tt.hasCensus, tt.synced); got != tt.want {
+				t.Fatalf("censoStatusLabel(%q,%v,%v) = %q; want %q",
+					tt.status, tt.hasCensus, tt.synced, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSituacaoOperacional garante que cada status gerencial mapeia para uma
+// frase operacional distinta.
+func TestSituacaoOperacional(t *testing.T) {
+	labels := []string{"Pendente", "Rascunho", "Pendente de Sincronização", "Concluído", "Verificar"}
+	seen := map[string]bool{}
+	for _, l := range labels {
+		s := situacaoOperacional(l)
+		if strings.TrimSpace(s) == "" {
+			t.Fatalf("situacaoOperacional(%q) vazia", l)
+		}
+		if seen[s] {
+			t.Fatalf("situacaoOperacional(%q) = %q duplicada", l, s)
+		}
+		seen[s] = true
+	}
+}
+
+// TestSanitizeFileNamePart garante nomes seguros (minúsculas, sem acentos,
+// sem espaços, sem caracteres especiais).
+func TestSanitizeFileNamePart(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"DRE Belém", "dre_belem"},
+		{"  São Félix  ", "sao_felix"},
+		{"Conceição/Araguaia", "conceicao_araguaia"},
+		{"GUAJARÁ", "guajara"},
+		{"a..b__c", "a_b_c"},
+		{"!@#$", ""},
+		{"Já é 2026!", "ja_e_2026"},
+	}
+	for _, tt := range tests {
+		if got := sanitizeFileNamePart(tt.in); got != tt.want {
+			t.Fatalf("sanitizeFileNamePart(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestBuildReportFileName cobre os exemplos da especificação.
+func TestBuildReportFileName(t *testing.T) {
+	base := "relatorio_censo_preenchimento_escolas"
+
+	tests := []struct {
+		name    string
+		filters reportFilters
+		want    string
+	}{
+		{
+			name:    "ano especifico",
+			filters: reportFilters{Year: 2026},
+			want:    "relatorio_censo_preenchimento_escolas_2026.xlsx",
+		},
+		{
+			name:    "todos os anos",
+			filters: reportFilters{Year: 0},
+			want:    "relatorio_censo_preenchimento_escolas_todos_anos.xlsx",
+		},
+		{
+			name:    "ano e dre",
+			filters: reportFilters{Year: 2026, DRE: "Belém"},
+			want:    "relatorio_censo_preenchimento_escolas_2026_dre_belem.xlsx",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildReportFileName(base, tt.filters)
+			if got != tt.want {
+				t.Fatalf("buildReportFileName = %q; want %q", got, tt.want)
+			}
+			if strings.ContainsAny(got, " /\\") {
+				t.Fatalf("filename %q contém caractere inseguro", got)
+			}
+		})
+	}
+}
+
+// TestWriteReportXLSXNonEmpty garante que a geração produz um arquivo XLSX
+// não vazio com o título e os cabeçalhos esperados.
+func TestWriteReportXLSXNonEmpty(t *testing.T) {
+	rd := reportData{
+		Title:       "Relatório de Teste",
+		SheetName:   "Preenchimento Censo",
+		FiltersLine: "Filtros aplicados — Ano: 2026",
+		Headers:     censoPreenchimentoReportColumns,
+		Rows: [][]any{
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "12345678", "Escola X",
+				"Pendente", "", "", "Não", "", "Aguardando preenchimento"},
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "87654321", "Escola Y",
+				"Concluído", 2026, "01/06/2026 10:00", "Sim", "02/06/2026 11:00", "Concluído e sincronizado"},
+		},
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		t.Fatalf("writeReportXLSX erro: %v", err)
+	}
+
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer erro: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("arquivo XLSX vazio")
+	}
+
+	// A aba deve existir com o nome amigável.
+	if idx, err := f.GetSheetIndex("Preenchimento Censo"); err != nil || idx < 0 {
+		t.Fatalf("aba 'Preenchimento Censo' não encontrada (idx=%d, err=%v)", idx, err)
+	}
+
+	// Título na A1.
+	if v, err := f.GetCellValue("Preenchimento Censo", "A1"); err != nil || v != "Relatório de Teste" {
+		t.Fatalf("A1 = %q (err=%v); want título", v, err)
+	}
+
+	// Primeiro cabeçalho na linha 4.
+	if v, err := f.GetCellValue("Preenchimento Censo", "A4"); err != nil || v != "Região de Integração" {
+		t.Fatalf("A4 = %q (err=%v); want primeiro cabeçalho", v, err)
+	}
+
+	// Primeira linha de dados na linha 5.
+	if v, err := f.GetCellValue("Preenchimento Censo", "G5"); err != nil || v != "Pendente" {
+		t.Fatalf("G5 = %q (err=%v); want 'Pendente'", v, err)
+	}
+}
+
+// TestCensoPreenchimentoQueryShape valida o formato da consulta do piloto:
+// parte de schools s, usa LEFT JOIN (inclui escolas pendentes), filtro de
+// ano opcional ($1 = 0 OR year = $1), filtros globais por AND e ordenação
+// por prioridade gerencial. Não pode exigir status='completed' no WHERE.
+func TestCensoPreenchimentoQueryShape(t *testing.T) {
+	q := censoPreenchimentoSelectSQL
+
+	mustContain := []string{
+		"FROM schools s",
+		"LEFT JOIN latest_census cr",
+		"LEFT JOIN reg_integracao ri",
+		"DISTINCT ON (school_id)",
+		"($1 = 0 OR year = $1)",
+		"($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))",
+		"($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))",
+		"($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))",
+		"FROM reg_integracao",
+		"UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))",
+		"WHEN cr.status IS NULL THEN 1",
+		"WHEN cr.status = 'draft' THEN 2",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(q, frag) {
+			t.Fatalf("query não contém %q", frag)
+		}
+	}
+
+	if strings.Contains(q, "INNER JOIN") {
+		t.Fatalf("query usa INNER JOIN; o LEFT JOIN deve incluir escolas pendentes")
+	}
+	if strings.Contains(q, "AND status = 'completed'") || strings.Contains(q, "s.status = 'completed'") {
+		t.Fatalf("query exige status='completed' no WHERE geral; pendentes/rascunhos seriam excluídos")
+	}
+}

--- a/api/cmd/api/reports_xlsx.go
+++ b/api/cmd/api/reports_xlsx.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/xuri/excelize/v2"
+)
+
+// =====================================================================
+// Gerador XLSX genérico de relatórios
+// =====================================================================
+// Recebe um reportData (título, filtros, cabeçalhos e linhas já prontos
+// pelo builder do relatório) e produz um *excelize.File com o layout
+// padrão da primeira fase:
+//
+//   Linha 1: título do relatório (negrito, mesclado sobre as colunas)
+//   Linha 2: filtros aplicados
+//   Linha 3: em branco
+//   Linha 4: cabeçalhos (negrito, painel congelado abaixo)
+//   Linha 5+: dados
+//
+// Sem design avançado: negrito no cabeçalho, freeze pane, largura básica
+// das colunas e nome de aba amigável. Reaproveita a dependência já
+// existente github.com/xuri/excelize/v2 (nenhuma dependência nova).
+// =====================================================================
+
+// reportData é o contrato neutro entre os builders de relatório e o
+// gerador XLSX. As células de Rows podem ser string, int, float64 ou
+// já-formatadas (datas chegam como string no padrão pt-BR).
+type reportData struct {
+	Title       string
+	SheetName   string
+	FiltersLine string
+	Headers     []string
+	Rows        [][]any
+}
+
+// dataInicialRow é a primeira linha de dados (linha 5; cabeçalho na 4).
+const (
+	reportHeaderRow = 4
+	reportDataRow   = 5
+)
+
+// writeReportXLSX monta o arquivo XLSX a partir do reportData. Nunca
+// pagina: escreve todas as linhas recebidas.
+func writeReportXLSX(rd reportData) (*excelize.File, error) {
+	f := excelize.NewFile()
+
+	sheet := strings.TrimSpace(rd.SheetName)
+	if sheet == "" {
+		sheet = "Relatório"
+	}
+	// excelize cria "Sheet1" por padrão; renomeia para o nome amigável.
+	if err := f.SetSheetName("Sheet1", sheet); err != nil {
+		return nil, fmt.Errorf("nomear aba: %w", err)
+	}
+
+	numCols := len(rd.Headers)
+	if numCols == 0 {
+		numCols = 1
+	}
+	lastColName, err := excelize.ColumnNumberToName(numCols)
+	if err != nil {
+		return nil, fmt.Errorf("calcular última coluna: %w", err)
+	}
+
+	// Título (linha 1) e filtros (linha 2).
+	if err := f.SetCellValue(sheet, "A1", rd.Title); err != nil {
+		return nil, err
+	}
+	if err := f.SetCellValue(sheet, "A2", rd.FiltersLine); err != nil {
+		return nil, err
+	}
+	// Mescla o título sobre as colunas do relatório para ficar legível.
+	if numCols > 1 {
+		if err := f.MergeCell(sheet, "A1", lastColName+"1"); err != nil {
+			return nil, err
+		}
+	}
+
+	// Estilos: título em negrito maior, cabeçalho em negrito.
+	titleStyle, err := f.NewStyle(&excelize.Style{
+		Font: &excelize.Font{Bold: true, Size: 14},
+	})
+	if err != nil {
+		return nil, err
+	}
+	headerStyle, err := f.NewStyle(&excelize.Style{
+		Font: &excelize.Font{Bold: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := f.SetCellStyle(sheet, "A1", "A1", titleStyle); err != nil {
+		return nil, err
+	}
+
+	// Cabeçalhos (linha 4).
+	for i, h := range rd.Headers {
+		cell, err := excelize.CoordinatesToCellName(i+1, reportHeaderRow)
+		if err != nil {
+			return nil, err
+		}
+		if err := f.SetCellValue(sheet, cell, h); err != nil {
+			return nil, err
+		}
+	}
+	if len(rd.Headers) > 0 {
+		headerLast, _ := excelize.CoordinatesToCellName(numCols, reportHeaderRow)
+		if err := f.SetCellStyle(sheet, "A4", headerLast, headerStyle); err != nil {
+			return nil, err
+		}
+	}
+
+	// Dados (linha 5 em diante).
+	for r, row := range rd.Rows {
+		for c, val := range row {
+			cell, err := excelize.CoordinatesToCellName(c+1, reportDataRow+r)
+			if err != nil {
+				return nil, err
+			}
+			if err := f.SetCellValue(sheet, cell, val); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Largura básica das colunas; nada sofisticado.
+	if err := f.SetColWidth(sheet, "A", lastColName, 20); err != nil {
+		return nil, err
+	}
+
+	// Congela o painel abaixo do cabeçalho, mantendo-o visível na rolagem.
+	if err := f.SetPanes(sheet, &excelize.Panes{
+		Freeze:      true,
+		YSplit:      reportHeaderRow,
+		TopLeftCell: "A" + fmt.Sprint(reportDataRow),
+		ActivePane:  "bottomLeft",
+	}); err != nil {
+		return nil, err
+	}
+
+	if idx, err := f.GetSheetIndex(sheet); err == nil {
+		f.SetActiveSheet(idx)
+	}
+
+	return f, nil
+}
+
+// buildReportFileName deriva um nome de arquivo seguro (sem acentos, sem
+// espaços) a partir do FileBase do relatório e dos filtros aplicados.
+// Sempre inclui o recorte de ano (ano específico ou "todos_anos") e, em
+// seguida, os filtros territoriais presentes. Exemplos:
+//
+//	relatorio_censo_preenchimento_escolas_2026.xlsx
+//	relatorio_censo_preenchimento_escolas_todos_anos.xlsx
+//	relatorio_censo_preenchimento_escolas_2026_dre_belem.xlsx
+func buildReportFileName(fileBase string, f reportFilters) string {
+	parts := []string{sanitizeFileNamePart(fileBase)}
+
+	if f.Year > 0 {
+		parts = append(parts, fmt.Sprintf("%d", f.Year))
+	} else {
+		parts = append(parts, "todos_anos")
+	}
+
+	if f.RegiaoIntegracao != "" {
+		parts = append(parts, "regiao", sanitizeFileNamePart(f.RegiaoIntegracao))
+	}
+	if f.DRE != "" {
+		parts = append(parts, "dre", sanitizeFileNamePart(f.DRE))
+	}
+	if f.Municipio != "" {
+		parts = append(parts, "municipio", sanitizeFileNamePart(f.Municipio))
+	}
+	if f.Zona != "" {
+		parts = append(parts, "zona", sanitizeFileNamePart(f.Zona))
+	}
+
+	name := strings.Join(parts, "_")
+	name = strings.Trim(name, "_")
+	if name == "" {
+		name = "relatorio"
+	}
+	return name + ".xlsx"
+}
+
+// accentReplacer mapeia os caracteres acentuados comuns do português para
+// seus equivalentes ASCII, evitando depender de golang.org/x/text só para
+// normalizar nomes de arquivo.
+var accentReplacer = strings.NewReplacer(
+	"á", "a", "à", "a", "â", "a", "ã", "a", "ä", "a",
+	"é", "e", "è", "e", "ê", "e", "ë", "e",
+	"í", "i", "ì", "i", "î", "i", "ï", "i",
+	"ó", "o", "ò", "o", "ô", "o", "õ", "o", "ö", "o",
+	"ú", "u", "ù", "u", "û", "u", "ü", "u",
+	"ç", "c", "ñ", "n",
+	"Á", "A", "À", "A", "Â", "A", "Ã", "A", "Ä", "A",
+	"É", "E", "È", "E", "Ê", "E", "Ë", "E",
+	"Í", "I", "Ì", "I", "Î", "I", "Ï", "I",
+	"Ó", "O", "Ò", "O", "Ô", "O", "Õ", "O", "Ö", "O",
+	"Ú", "U", "Ù", "U", "Û", "U", "Ü", "U",
+	"Ç", "C", "Ñ", "N",
+)
+
+// sanitizeFileNamePart normaliza um trecho para uso em nome de arquivo:
+// minúsculas, sem acentos, e qualquer caractere não alfanumérico vira um
+// único underscore. Garante um nome seguro para o header Content-Disposition.
+func sanitizeFileNamePart(s string) string {
+	s = accentReplacer.Replace(strings.TrimSpace(s))
+	s = strings.ToLower(s)
+
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastUnderscore = false
+		default:
+			if !lastUnderscore {
+				b.WriteByte('_')
+				lastUnderscore = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}


### PR DESCRIPTION
Implementa a infraestrutura inicial de relatorios gerenciais no backend, com geracao de XLSX protegida por autenticacao administrativa, e o relatorio piloto censo-preenchimento-escolas.

- Cria rota GET /v1/admin/reports/{report_id} (grupo admin protegido).
- Adiciona catalogo extensivel de relatorios (reports_catalog.go).
- Gerador XLSX generico com titulo, filtros, cabecalho e freeze pane.
- Relatorio piloto parte de schools s com LEFT JOIN census_responses, incluindo escolas pendentes; respeita filtros globais; sem paginacao.
- format invalido -> 400; report_id inexistente -> 404; token -> 401.