### PR TITLE
feat(admin): adicionar relatorio de saude operacional

### DIFF
--- a/api/cmd/api/analytics_saude_operacional.go
+++ b/api/cmd/api/analytics_saude_operacional.go
@@ -1108,6 +1108,102 @@ func buildSaudeOperacionalQuery(year int, f saudeOperacionalFilters) (string, []
 	}
 }
 
+// saudeOperacionalDatasetTimings carrega a medição por etapa do carregamento
+// base da Saúde Operacional (pedagógico, query e iteração/cálculo). Permite que
+// o handler analítico preserve o log de performance existente mesmo após a
+// extração de buildSaudeOperacionalDataset.
+type saudeOperacionalDatasetTimings struct {
+	PedagogicoMs  int64
+	QueryMs       int64
+	IterateCalcMs int64
+	CalcMs        int64
+}
+
+// buildSaudeOperacionalDataset concentra o carregamento e o cálculo base de
+// TODAS as escolas do recorte (filtros globais) para um dado ano de censo,
+// devolvendo as escolas já pontuadas (saúde, criticidade, status e dimensões) e
+// a medição por etapa. NÃO filtra por busca, não ordena e não pagina — essas
+// responsabilidades permanecem em quem consome o dataset:
+//   - o endpoint analítico aplica busca/ordenação/paginação para a tela;
+//   - o relatório gerencial exporta todas as escolas do recorte.
+//
+// Mantém a instrumentação de erro por etapa (saude_operacional_perf_error) e a
+// regra de cálculo das dimensões intacta — a lógica de pontuação não é
+// duplicada em nenhum dos consumidores.
+func (app *application) buildSaudeOperacionalDataset(
+	ctx context.Context,
+	year int,
+	filters saudeOperacionalFilters,
+) ([]SaudeOperacionalEscola, saudeOperacionalDatasetTimings, error) {
+	var timings saudeOperacionalDatasetTimings
+
+	// Nota Pedagógico (IDEB) por escola, do último ano disponível em
+	// ideb_resultados. Independe do ano do censo: é o resultado oficial mais
+	// recente aplicado a cada escola pontuada.
+	pedStart := time.Now()
+	pedagogicoPorEscola, err := app.loadPedagogicoPorEscola(ctx)
+	if err != nil {
+		app.logger.Printf("saude_operacional_perf_error: stage=load_pedagogico elapsed_ms=%d error=%q",
+			time.Since(pedStart).Milliseconds(), err.Error())
+		return nil, timings, err
+	}
+	timings.PedagogicoMs = time.Since(pedStart).Milliseconds()
+
+	query, args := buildSaudeOperacionalQuery(year, filters)
+
+	queryStart := time.Now()
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		app.logger.Printf("saude_operacional_perf_error: stage=query elapsed_ms=%d error=%q",
+			time.Since(queryStart).Milliseconds(), err.Error())
+		return nil, timings, fmt.Errorf("consultar saúde operacional das escolas: %v", err)
+	}
+	defer dbRows.Close()
+	timings.QueryMs = time.Since(queryStart).Milliseconds()
+
+	// iterateStart cobre todo o loop (scan + build). calcDuration acumula apenas o
+	// tempo de buildSaudeOperacionalEscola (decode JSONB + cálculo das dimensões),
+	// permitindo separar "iteração das linhas" de "decode/cálculo".
+	iterateStart := time.Now()
+	var calcDuration time.Duration
+	allEscolas := make([]SaudeOperacionalEscola, 0)
+	for dbRows.Next() {
+		var row saudeOperacionalDBRow
+		if err := dbRows.Scan(
+			&row.SchoolID,
+			&row.CodigoINEP,
+			&row.Escola,
+			&row.Municipio,
+			&row.DRE,
+			&row.Zona,
+			&row.CensusID,
+			&row.Data,
+		); err != nil {
+			app.logger.Printf("saude_operacional_perf_error: stage=scan elapsed_ms=%d error=%q",
+				time.Since(iterateStart).Milliseconds(), err.Error())
+			return nil, timings, fmt.Errorf("ler escola da saúde operacional: %v", err)
+		}
+		calcStart := time.Now()
+		escola, err := buildSaudeOperacionalEscola(row, pedagogicoPorEscola[row.SchoolID])
+		calcDuration += time.Since(calcStart)
+		if err != nil {
+			app.logger.Printf("saude_operacional_perf_error: stage=build_escola elapsed_ms=%d error=%q",
+				time.Since(iterateStart).Milliseconds(), err.Error())
+			return nil, timings, err
+		}
+		allEscolas = append(allEscolas, escola)
+	}
+	if err := dbRows.Err(); err != nil {
+		app.logger.Printf("saude_operacional_perf_error: stage=rows_err elapsed_ms=%d error=%q",
+			time.Since(iterateStart).Milliseconds(), err.Error())
+		return nil, timings, fmt.Errorf("iterar escolas da saúde operacional: %v", err)
+	}
+	timings.IterateCalcMs = time.Since(iterateStart).Milliseconds()
+	timings.CalcMs = calcDuration.Milliseconds()
+
+	return allEscolas, timings, nil
+}
+
 // AdminAnalyticsSaudeOperacionalEscolas retorna escolas com índice de saúde operacional.
 // Parâmetros opcionais: year, page, page_size, search, sort, direction.
 // Filtros globais opcionais: dre, municipio, zona, regiao_integracao.
@@ -1160,11 +1256,10 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 	}
 
 	filters := parseSaudeOperacionalFilters(q)
-	query, args := buildSaudeOperacionalQuery(year, filters)
 
-	// parseMs cobre todo o parse/validação dos parâmetros e a montagem da query
-	// (etapas acima). has_* registram apenas presença/ausência dos filtros — nunca
-	// os valores em si, para não vazar termos de busca/dados nos logs.
+	// parseMs cobre todo o parse/validação dos parâmetros (etapas acima). has_*
+	// registram apenas presença/ausência dos filtros — nunca os valores em si,
+	// para não vazar termos de busca/dados nos logs.
 	parseMs := time.Since(routeStart).Milliseconds()
 	hasSearch := strings.TrimSpace(searchQuery) != ""
 	hasDRE := filters.DRE != ""
@@ -1172,72 +1267,18 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 	hasZona := filters.Zona != ""
 	hasRegiao := filters.RegiaoIntegracao != ""
 
-	// Nota Pedagógico (IDEB) por escola, do último ano disponível em
-	// ideb_resultados. Independe do ano do censo: é o resultado oficial mais
-	// recente aplicado a cada escola pontuada.
-	pedStart := time.Now()
-	pedagogicoPorEscola, err := app.loadPedagogicoPorEscola(r.Context())
+	// Carregamento e cálculo base de todas as escolas do recorte. A função
+	// reaproveitável também alimenta o relatório gerencial de Saúde Operacional;
+	// o handler segue responsável por busca, ordenação e paginação.
+	allEscolas, timings, err := app.buildSaudeOperacionalDataset(r.Context(), year, filters)
 	if err != nil {
-		app.logger.Printf("saude_operacional_perf_error: stage=load_pedagogico elapsed_ms=%d error=%q",
-			time.Since(pedStart).Milliseconds(), err.Error())
 		app.errorJSON(w, err, http.StatusInternalServerError)
 		return
 	}
-	pedagogicoMs := time.Since(pedStart).Milliseconds()
-
-	queryStart := time.Now()
-	dbRows, err := app.models.Schools.DB.QueryContext(r.Context(), query, args...)
-	if err != nil {
-		app.logger.Printf("saude_operacional_perf_error: stage=query elapsed_ms=%d error=%q",
-			time.Since(queryStart).Milliseconds(), err.Error())
-		app.errorJSON(w, fmt.Errorf("consultar saúde operacional das escolas: %v", err), http.StatusInternalServerError)
-		return
-	}
-	defer dbRows.Close()
-	queryMs := time.Since(queryStart).Milliseconds()
-
-	// iterateStart cobre todo o loop (scan + build). calcDuration acumula apenas o
-	// tempo de buildSaudeOperacionalEscola (decode JSONB + cálculo das dimensões),
-	// permitindo separar "iteração das linhas" de "decode/cálculo".
-	iterateStart := time.Now()
-	var calcDuration time.Duration
-	allEscolas := make([]SaudeOperacionalEscola, 0)
-	for dbRows.Next() {
-		var row saudeOperacionalDBRow
-		if err := dbRows.Scan(
-			&row.SchoolID,
-			&row.CodigoINEP,
-			&row.Escola,
-			&row.Municipio,
-			&row.DRE,
-			&row.Zona,
-			&row.CensusID,
-			&row.Data,
-		); err != nil {
-			app.logger.Printf("saude_operacional_perf_error: stage=scan elapsed_ms=%d error=%q",
-				time.Since(iterateStart).Milliseconds(), err.Error())
-			app.errorJSON(w, fmt.Errorf("ler escola da saúde operacional: %v", err), http.StatusInternalServerError)
-			return
-		}
-		calcStart := time.Now()
-		escola, err := buildSaudeOperacionalEscola(row, pedagogicoPorEscola[row.SchoolID])
-		calcDuration += time.Since(calcStart)
-		if err != nil {
-			app.logger.Printf("saude_operacional_perf_error: stage=build_escola elapsed_ms=%d error=%q",
-				time.Since(iterateStart).Milliseconds(), err.Error())
-			app.errorJSON(w, err, http.StatusInternalServerError)
-			return
-		}
-		allEscolas = append(allEscolas, escola)
-	}
-	if err := dbRows.Err(); err != nil {
-		app.logger.Printf("saude_operacional_perf_error: stage=rows_err elapsed_ms=%d error=%q",
-			time.Since(iterateStart).Milliseconds(), err.Error())
-		app.errorJSON(w, fmt.Errorf("iterar escolas da saúde operacional: %v", err), http.StatusInternalServerError)
-		return
-	}
-	iterateCalcMs := time.Since(iterateStart).Milliseconds()
-	calcMs := calcDuration.Milliseconds()
+	pedagogicoMs := timings.PedagogicoMs
+	queryMs := timings.QueryMs
+	iterateCalcMs := timings.IterateCalcMs
+	calcMs := timings.CalcMs
 
 	paginateStart := time.Now()
 	pageSlice, resumo, totalFiltrado, totalPages, page := buildSaudeOperacionalPage(

--- a/api/cmd/api/reports.go
+++ b/api/cmd/api/reports.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -170,6 +171,12 @@ func (app *application) AdminGetReport(w http.ResponseWriter, r *http.Request) {
 	switch def.ID {
 	case reportCensoPreenchimentoID:
 		rd, err = app.buildCensoPreenchimentoReportData(r.Context(), def, filters)
+	case reportSaudeOperacionalID:
+		// Saúde Operacional depende de um ano de censo específico. Resolve o ano
+		// antes de gerar dados e nome do arquivo, para que ambos reflitam o ano
+		// efetivamente usado (e não "todos os anos").
+		filters.Year = resolveSaudeOperacionalReportYear(filters, time.Now())
+		rd, err = app.buildSaudeOperacionalReportData(r.Context(), def, filters)
 	default:
 		// Catálogo e dispatch desalinhados: defensivo.
 		app.errorJSON(w, fmt.Errorf("relatório %q sem implementação", def.ID), http.StatusNotFound)

--- a/api/cmd/api/reports_catalog.go
+++ b/api/cmd/api/reports_catalog.go
@@ -20,6 +20,12 @@ package main
 // acompanhamento do preenchimento do censo.
 const reportCensoPreenchimentoID = "censo-preenchimento-escolas"
 
+// reportSaudeOperacionalID é o identificador do relatório de Índice de Saúde
+// Operacional por escola, que exporta todas as escolas do recorte com índice,
+// criticidade, status e notas por dimensão, reaproveitando a metodologia da
+// aba "Saúde Operacional".
+const reportSaudeOperacionalID = "saude-operacional-escolas"
+
 // ReportDefinition descreve os metadados de um relatório gerencial. Os
 // campos são suficientes para montar o cabeçalho do XLSX (Title), nomear
 // a aba (SheetName) e derivar o nome do arquivo (FileBase). A consulta e
@@ -41,6 +47,13 @@ var reportsCatalog = map[string]ReportDefinition{
 		Description: "Acompanhamento nominal do preenchimento do censo por escola, incluindo escolas ainda pendentes.",
 		SheetName:   "Preenchimento Censo",
 		FileBase:    "relatorio_censo_preenchimento_escolas",
+	},
+	reportSaudeOperacionalID: {
+		ID:          reportSaudeOperacionalID,
+		Title:       "Relatório de Índice de Saúde Operacional por Escola",
+		Description: "Índice de Saúde Operacional por escola, com criticidade, status e notas por dimensão, para todas as escolas do recorte.",
+		SheetName:   "Saude Operacional",
+		FileBase:    "relatorio_saude_operacional_escolas",
 	},
 }
 

--- a/api/cmd/api/reports_saude_operacional.go
+++ b/api/cmd/api/reports_saude_operacional.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// =====================================================================
+// Relatório gerencial — Índice de Saúde Operacional por escola
+// =====================================================================
+// Exporta, sem paginação, todas as escolas do recorte com o Índice de
+// Saúde Operacional, criticidade, status e notas por dimensão. Reaproveita
+// integralmente a metodologia da aba "Saúde Operacional" via
+// buildSaudeOperacionalDataset — a regra de cálculo das dimensões NÃO é
+// duplicada aqui.
+//
+// Diferenças em relação ao relatório piloto (censo-preenchimento):
+//   - depende de um ano de censo específico (não existe "todos os anos");
+//   - a ordenação padrão é por criticidade decrescente (mais críticas
+//     primeiro), mantendo as escolas "sem_dados" ao final.
+// =====================================================================
+
+// saudeOperacionalReportColumns são os cabeçalhos do relatório, na ordem
+// exigida pela especificação: colunas territoriais, identificação, métricas
+// operacionais, índice/criticidade/status e, por fim, as notas por dimensão.
+var saudeOperacionalReportColumns = []string{
+	"Região de Integração",
+	"DRE",
+	"Município",
+	"Zona",
+	"Código INEP",
+	"Escola",
+	"Alunos",
+	"Salas",
+	"Alunos por sala",
+	"Índice de Saúde",
+	"Criticidade",
+	"Status",
+	"Infraestrutura",
+	"Energia",
+	"Merenda",
+	"Segurança",
+	"Pessoal",
+	"Tecnologia",
+	"Pedagógico",
+	"Governança",
+}
+
+// resolveSaudeOperacionalReportYear decide o ano de censo do relatório. Ao
+// contrário do relatório de preenchimento (Year = 0 ⇒ todos os anos), a Saúde
+// Operacional depende de um ano específico: quando o filtro de ano está ausente
+// ou inválido (Year = 0), usa o ano padrão do endpoint analítico (ano corrente),
+// preservando o comportamento da aba "Saúde Operacional".
+func resolveSaudeOperacionalReportYear(f reportFilters, now time.Time) int {
+	if f.Year > 0 {
+		return f.Year
+	}
+	return now.Year()
+}
+
+// saudeOperacionalStatusLabel traduz o status técnico do payload analítico
+// ("saudavel", "atencao", "critica", "sem_dados") para um rótulo legível na
+// coluna Status do XLSX. Não altera o payload público — é apresentação.
+func saudeOperacionalStatusLabel(status string) string {
+	switch status {
+	case "saudavel":
+		return "Saudável"
+	case "atencao":
+		return "Atenção"
+	case "critica":
+		return "Crítica"
+	default:
+		return "Sem dados"
+	}
+}
+
+// reportRegiaoSQL carrega o mapa município → Região de Integração a partir de
+// reg_integracao. A chave usa UPPER(TRIM(municipio)) para casar com schools.
+// municipio do mesmo jeito que os demais endpoints (sem unaccent nesta etapa).
+const reportRegiaoSQL = `
+	SELECT UPPER(TRIM(municipio)) AS municipio, COALESCE(regiao_de_integracao, '') AS regiao
+	FROM reg_integracao
+`
+
+// loadRegiaoPorMunicipio devolve o mapa município (normalizado) → Região de
+// Integração, usado para preencher a coluna territorial do relatório sem alterar
+// o payload da Saúde Operacional (que não expõe a região).
+func (app *application) loadRegiaoPorMunicipio(ctx context.Context) (map[string]string, error) {
+	rows, err := app.models.Schools.DB.QueryContext(ctx, reportRegiaoSQL)
+	if err != nil {
+		return nil, fmt.Errorf("consultar regiões de integração: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]string)
+	for rows.Next() {
+		var municipio, regiao string
+		if err := rows.Scan(&municipio, &regiao); err != nil {
+			return nil, fmt.Errorf("ler região de integração: %w", err)
+		}
+		if _, ok := out[municipio]; !ok {
+			out[municipio] = regiao
+		}
+	}
+	return out, rows.Err()
+}
+
+// normalizeReportMunicipio normaliza o município para casar com a chave de
+// reportRegiaoSQL (UPPER(TRIM(...))).
+func normalizeReportMunicipio(municipio string) string {
+	return strings.ToUpper(strings.TrimSpace(municipio))
+}
+
+// reportCriticidadeValue extrai a criticidade comparável de uma escola. Escolas
+// pontuadas sempre possuem criticidade; o valor sentinela negativo só protege
+// contra um nil inesperado, jogando-o para o fim do grupo de pontuadas.
+func reportCriticidadeValue(e SaudeOperacionalEscola) float64 {
+	if e.Criticidade == nil {
+		return -1
+	}
+	return *e.Criticidade
+}
+
+// reportINEPValue devolve o código INEP da escola (vazio quando ausente), usado
+// como critério final e estável de desempate.
+func reportINEPValue(e SaudeOperacionalEscola) string {
+	if e.CodigoINEP == nil {
+		return ""
+	}
+	return *e.CodigoINEP
+}
+
+// lessSaudeOperacionalReport ordena as escolas do relatório: escolas "sem_dados"
+// vão para o final; entre as pontuadas, criticidade decrescente (mais críticas
+// primeiro); empates por DRE, Município, Escola e Código INEP (texto case/acento
+// insensível). A ordenação é determinística.
+func lessSaudeOperacionalReport(a, b SaudeOperacionalEscola) bool {
+	aSemDados := a.Status == "sem_dados"
+	bSemDados := b.Status == "sem_dados"
+	if aSemDados != bSemDados {
+		// não-sem_dados vem antes.
+		return !aSemDados
+	}
+
+	if !aSemDados {
+		ac := reportCriticidadeValue(a)
+		bc := reportCriticidadeValue(b)
+		if ac != bc {
+			return ac > bc
+		}
+	}
+
+	if c := strings.Compare(normalizeSaudeSearch(a.DRE), normalizeSaudeSearch(b.DRE)); c != 0 {
+		return c < 0
+	}
+	if c := strings.Compare(normalizeSaudeSearch(a.Municipio), normalizeSaudeSearch(b.Municipio)); c != 0 {
+		return c < 0
+	}
+	if c := strings.Compare(normalizeSaudeSearch(a.Escola), normalizeSaudeSearch(b.Escola)); c != 0 {
+		return c < 0
+	}
+	return reportINEPValue(a) < reportINEPValue(b)
+}
+
+// sortSaudeOperacionalReport ordena uma cópia das escolas pela ordem do
+// relatório (ver lessSaudeOperacionalReport), sem alterar o slice de origem.
+func sortSaudeOperacionalReport(escolas []SaudeOperacionalEscola) []SaudeOperacionalEscola {
+	sorted := append([]SaudeOperacionalEscola(nil), escolas...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return lessSaudeOperacionalReport(sorted[i], sorted[j])
+	})
+	return sorted
+}
+
+// optFloatCell devolve a célula de um número opcional: célula vazia quando nil,
+// caso contrário o próprio valor (já arredondado pela metodologia).
+func optFloatCell(v *float64) any {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// optIntCell devolve a célula de um inteiro opcional: vazia quando nil.
+func optIntCell(v *int) any {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// optStringCell devolve a célula de uma string opcional: vazia quando nil.
+func optStringCell(v *string) any {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// buildSaudeOperacionalReportData monta o reportData do relatório de Saúde
+// Operacional: carrega o dataset base (todas as escolas do recorte, no ano
+// resolvido), resolve a Região de Integração por município, ordena por
+// criticidade decrescente e projeta as colunas do XLSX. Não pagina.
+func (app *application) buildSaudeOperacionalReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
+	soFilters := saudeOperacionalFilters{
+		DRE:              f.DRE,
+		Municipio:        f.Municipio,
+		Zona:             f.Zona,
+		RegiaoIntegracao: f.RegiaoIntegracao,
+	}
+
+	escolas, _, err := app.buildSaudeOperacionalDataset(ctx, f.Year, soFilters)
+	if err != nil {
+		return reportData{}, err
+	}
+
+	regiaoPorMunicipio, err := app.loadRegiaoPorMunicipio(ctx)
+	if err != nil {
+		return reportData{}, err
+	}
+
+	sorted := sortSaudeOperacionalReport(escolas)
+
+	rows := make([][]any, 0, len(sorted))
+	for _, e := range sorted {
+		regiao := regiaoPorMunicipio[normalizeReportMunicipio(e.Municipio)]
+		rows = append(rows, []any{
+			regiao,
+			e.DRE,
+			e.Municipio,
+			optStringCell(e.Zona),
+			optStringCell(e.CodigoINEP),
+			e.Escola,
+			optIntCell(e.TotalAlunos),
+			optIntCell(e.SalasAula),
+			optFloatCell(e.AlunosPorSala),
+			optFloatCell(e.Saude),
+			optFloatCell(e.Criticidade),
+			saudeOperacionalStatusLabel(e.Status),
+			optFloatCell(e.Dimensoes.Infraestrutura),
+			optFloatCell(e.Dimensoes.Energia),
+			optFloatCell(e.Dimensoes.Merenda),
+			optFloatCell(e.Dimensoes.Seguranca),
+			optFloatCell(e.Dimensoes.Pessoal),
+			optFloatCell(e.Dimensoes.Tecnologia),
+			optFloatCell(e.Dimensoes.Pedagogico),
+			optFloatCell(e.Dimensoes.Governanca),
+		})
+	}
+
+	return reportData{
+		Title:       def.Title,
+		SheetName:   def.SheetName,
+		FiltersLine: f.describe(),
+		Headers:     saudeOperacionalReportColumns,
+		Rows:        rows,
+	}, nil
+}

--- a/api/cmd/api/reports_saude_operacional_test.go
+++ b/api/cmd/api/reports_saude_operacional_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReportsCatalogRecognizesSaudeOperacional garante que o relatório de Saúde
+// Operacional está registrado com os metadados esperados.
+func TestReportsCatalogRecognizesSaudeOperacional(t *testing.T) {
+	def, ok := lookupReport(reportSaudeOperacionalID)
+	if !ok {
+		t.Fatalf("lookupReport(%q) = not found; esperado encontrado", reportSaudeOperacionalID)
+	}
+	if def.ID != reportSaudeOperacionalID {
+		t.Fatalf("ID = %q; want %q", def.ID, reportSaudeOperacionalID)
+	}
+	if def.SheetName != "Saude Operacional" {
+		t.Fatalf("SheetName = %q; want %q", def.SheetName, "Saude Operacional")
+	}
+	if def.FileBase != "relatorio_saude_operacional_escolas" {
+		t.Fatalf("FileBase = %q; want %q", def.FileBase, "relatorio_saude_operacional_escolas")
+	}
+	if def.Title != "Relatório de Índice de Saúde Operacional por Escola" {
+		t.Fatalf("Title = %q; inesperado", def.Title)
+	}
+}
+
+// TestResolveSaudeOperacionalReportYear cobre o ano específico e o fallback para
+// o ano corrente quando o filtro está ausente/inválido (Year = 0).
+func TestResolveSaudeOperacionalReportYear(t *testing.T) {
+	now := time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC)
+
+	if got := resolveSaudeOperacionalReportYear(reportFilters{Year: 2025}, now); got != 2025 {
+		t.Fatalf("ano específico = %d; want 2025", got)
+	}
+	if got := resolveSaudeOperacionalReportYear(reportFilters{Year: 0}, now); got != 2026 {
+		t.Fatalf("ano ausente = %d; want 2026 (ano corrente)", got)
+	}
+}
+
+// TestSaudeOperacionalStatusLabel garante a tradução dos status técnicos para
+// rótulos legíveis na coluna Status.
+func TestSaudeOperacionalStatusLabel(t *testing.T) {
+	tests := map[string]string{
+		"saudavel":   "Saudável",
+		"atencao":    "Atenção",
+		"critica":    "Crítica",
+		"sem_dados":  "Sem dados",
+		"inesperado": "Sem dados",
+	}
+	for in, want := range tests {
+		if got := saudeOperacionalStatusLabel(in); got != want {
+			t.Fatalf("saudeOperacionalStatusLabel(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+// TestSaudeOperacionalReportColumns garante a presença e ordem das colunas
+// exigidas, incluindo Pedagógico e Governança ao final.
+func TestSaudeOperacionalReportColumns(t *testing.T) {
+	want := []string{
+		"Região de Integração", "DRE", "Município", "Zona", "Código INEP", "Escola",
+		"Alunos", "Salas", "Alunos por sala", "Índice de Saúde", "Criticidade", "Status",
+		"Infraestrutura", "Energia", "Merenda", "Segurança", "Pessoal", "Tecnologia",
+		"Pedagógico", "Governança",
+	}
+	if len(saudeOperacionalReportColumns) != len(want) {
+		t.Fatalf("len(colunas) = %d; want %d", len(saudeOperacionalReportColumns), len(want))
+	}
+	for i := range want {
+		if saudeOperacionalReportColumns[i] != want[i] {
+			t.Fatalf("coluna[%d] = %q; want %q", i, saudeOperacionalReportColumns[i], want[i])
+		}
+	}
+}
+
+// TestSortSaudeOperacionalReport valida a ordenação: criticidade decrescente,
+// sem_dados ao final e desempate por DRE/Município/Escola/INEP.
+func TestSortSaudeOperacionalReport(t *testing.T) {
+	escola := func(nome, dre, mun, inep, status string, criticidade *float64) SaudeOperacionalEscola {
+		var inepPtr *string
+		if inep != "" {
+			inepPtr = ptrString(inep)
+		}
+		return SaudeOperacionalEscola{
+			Escola:      nome,
+			DRE:         dre,
+			Municipio:   mun,
+			CodigoINEP:  inepPtr,
+			Status:      status,
+			Criticidade: criticidade,
+		}
+	}
+
+	semDados := escola("Z Escola Sem Dados", "DRE A", "Mun A", "11111111", "sem_dados", nil)
+	critica := escola("Escola Critica", "DRE B", "Mun B", "22222222", "critica", ptrFloat(80))
+	atencao := escola("Escola Atencao", "DRE C", "Mun C", "33333333", "atencao", ptrFloat(40))
+	// Duas escolas com mesma criticidade para testar desempate por DRE.
+	empateZ := escola("Escola Empate", "DRE Z", "Mun Z", "44444444", "critica", ptrFloat(60))
+	empateA := escola("Escola Empate", "DRE A", "Mun A", "55555555", "critica", ptrFloat(60))
+
+	in := []SaudeOperacionalEscola{semDados, atencao, empateZ, critica, empateA}
+	got := sortSaudeOperacionalReport(in)
+
+	// Ordem esperada: critica(80), empateA(60, DRE A), empateZ(60, DRE Z), atencao(40), semDados.
+	wantINEP := []string{"22222222", "55555555", "44444444", "33333333", "11111111"}
+	if len(got) != len(wantINEP) {
+		t.Fatalf("len = %d; want %d", len(got), len(wantINEP))
+	}
+	for i, inep := range wantINEP {
+		if reportINEPValue(got[i]) != inep {
+			t.Fatalf("posição %d INEP = %q; want %q", i, reportINEPValue(got[i]), inep)
+		}
+	}
+
+	// O slice de origem não deve ser alterado.
+	if reportINEPValue(in[0]) != "11111111" {
+		t.Fatalf("slice de origem foi alterado: in[0] INEP = %q", reportINEPValue(in[0]))
+	}
+}
+
+// TestOptCellHelpers cobre as células opcionais (vazias quando nil).
+func TestOptCellHelpers(t *testing.T) {
+	if optFloatCell(nil) != "" {
+		t.Fatalf("optFloatCell(nil) != vazio")
+	}
+	if optFloatCell(ptrFloat(72.5)) != 72.5 {
+		t.Fatalf("optFloatCell(72.5) = %v; want 72.5", optFloatCell(ptrFloat(72.5)))
+	}
+	if optIntCell(nil) != "" {
+		t.Fatalf("optIntCell(nil) != vazio")
+	}
+	if optIntCell(ptrInt(120)) != 120 {
+		t.Fatalf("optIntCell(120) = %v; want 120", optIntCell(ptrInt(120)))
+	}
+	if optStringCell(nil) != "" {
+		t.Fatalf("optStringCell(nil) != vazio")
+	}
+	if optStringCell(ptrString("Urbana")) != "Urbana" {
+		t.Fatalf("optStringCell(Urbana) = %v; want Urbana", optStringCell(ptrString("Urbana")))
+	}
+}
+
+// TestWriteSaudeOperacionalReportXLSX garante que o gerador genérico produz um
+// XLSX válido para o relatório de Saúde Operacional, com aba, título, cabeçalho
+// na linha 4 e dados a partir da linha 5.
+func TestWriteSaudeOperacionalReportXLSX(t *testing.T) {
+	rd := reportData{
+		Title:       "Relatório de Índice de Saúde Operacional por Escola",
+		SheetName:   "Saude Operacional",
+		FiltersLine: "Filtros aplicados — Ano: 2026",
+		Headers:     saudeOperacionalReportColumns,
+		Rows: [][]any{
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "12345678", "Escola Critica",
+				300, 10, 30.0, 35.0, 65.0, "Crítica",
+				40.0, 50.0, 30.0, 20.0, 60.0, 45.0, 55.0, 50.0},
+			{"", "DRE X", "Mun X", "", "", "Escola Sem Dados",
+				"", "", "", "", "", "Sem dados",
+				"", "", "", "", "", "", "", ""},
+		},
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		t.Fatalf("writeReportXLSX erro: %v", err)
+	}
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer erro: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("arquivo XLSX vazio")
+	}
+
+	if idx, err := f.GetSheetIndex("Saude Operacional"); err != nil || idx < 0 {
+		t.Fatalf("aba 'Saude Operacional' não encontrada (idx=%d, err=%v)", idx, err)
+	}
+	if v, err := f.GetCellValue("Saude Operacional", "A1"); err != nil || v != rd.Title {
+		t.Fatalf("A1 = %q (err=%v); want título", v, err)
+	}
+	if v, err := f.GetCellValue("Saude Operacional", "A4"); err != nil || v != "Região de Integração" {
+		t.Fatalf("A4 = %q (err=%v); want primeiro cabeçalho", v, err)
+	}
+	// Última coluna do cabeçalho (Governança) na coluna T (20ª).
+	if v, err := f.GetCellValue("Saude Operacional", "T4"); err != nil || v != "Governança" {
+		t.Fatalf("T4 = %q (err=%v); want 'Governança'", v, err)
+	}
+	// Status da primeira linha de dados na coluna L (12ª), linha 5.
+	if v, err := f.GetCellValue("Saude Operacional", "L5"); err != nil || v != "Crítica" {
+		t.Fatalf("L5 = %q (err=%v); want 'Crítica'", v, err)
+	}
+}
+
+// TestBuildSaudeOperacionalReportFileName garante o nome de arquivo com ano
+// específico, espelhando o exemplo da especificação.
+func TestBuildSaudeOperacionalReportFileName(t *testing.T) {
+	got := buildReportFileName("relatorio_saude_operacional_escolas", reportFilters{Year: 2026})
+	want := "relatorio_saude_operacional_escolas_2026.xlsx"
+	if got != want {
+		t.Fatalf("buildReportFileName = %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Resumo

Adiciona o relatório gerencial `saude-operacional-escolas`, exportando em XLSX o Índice de Saúde Operacional por escola.

## Escopo

* Adiciona `saude-operacional-escolas` ao catálogo de relatórios;
* Exporta todas as escolas do recorte, sem paginação;
* Inclui índice de saúde, criticidade, status e notas por dimensão;
* Inclui as dimensões Infraestrutura, Energia, Merenda, Segurança, Pessoal, Tecnologia, Pedagógico e Governança;
* Reaproveita a metodologia existente da aba Saúde Operacional;
* Reaproveita o gerador XLSX genérico já criado.

## Reaproveitamento da Saúde Operacional

Este PR extrai uma função interna reutilizável para concentrar o carregamento e cálculo base da Saúde Operacional:

```text
buildSaudeOperacionalDataset(...)
```

O endpoint analítico continua responsável por busca, ordenação, paginação e montagem do payload público.

O relatório usa a mesma base calculada para exportar todas as escolas do recorte.

## Garantias

Este PR não altera:

* metodologia do Índice de Saúde Operacional;
* pesos;
* cálculo de Infraestrutura;
* cálculo de Energia;
* cálculo de Merenda;
* cálculo de Segurança;
* cálculo de Pessoal;
* cálculo de Tecnologia;
* cálculo de Pedagógico;
* cálculo de Governança;
* projeção JSONB da Saúde Operacional;
* payload público do endpoint analítico;
* frontend;
* migrations;
* Google Sheets;
* cache;
* timeout;
* prefetch.

## Ordenação do relatório

O XLSX ordena as escolas por criticidade decrescente, priorizando as mais críticas.

Escolas `sem_dados` ficam ao final.

## Colunas principais

* Região de Integração;
* DRE;
* Município;
* Zona;
* Código INEP;
* Escola;
* Alunos;
* Salas;
* Alunos por sala;
* Índice de Saúde;
* Criticidade;
* Status;
* Infraestrutura;
* Energia;
* Merenda;
* Segurança;
* Pessoal;
* Tecnologia;
* Pedagógico;
* Governança.

## Validação

Executado com sucesso:

```bash
cd api
go test -count=1 ./...
go vet ./...
go build ./cmd/api/...
```

## Fora de escopo

* Frontend;
* PDF;
* Cache;
* Migrations;
* Alteração da metodologia;
* Alteração de pesos;
* Alteração de timeout;
* Alteração de prefetch.