### PR TITLE
feat(admin): adicionar relatorios de infraestrutura e merenda

### DIFF
--- a/api/cmd/api/reports.go
+++ b/api/cmd/api/reports.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -89,6 +90,114 @@ func (f reportFilters) describe() string {
 		parts = append(parts, "Zona: "+f.Zona)
 	}
 	return "Filtros aplicados — " + strings.Join(parts, " | ")
+}
+
+// resolveReportYearDefault resolve o ano de relatórios que dependem de respostas
+// de censo (Infraestrutura/Segurança, Merenda, ...). Diferente do relatório
+// piloto (Year = 0 ⇒ todos os anos), estes relatórios exigem um ano específico:
+// quando o filtro de ano está ausente ou inválido (Year = 0), usa o ano padrão
+// do dashboard (ano corrente), o mesmo critério da Saúde Operacional. Em
+// 2026-06-15 o ano corrente é 2026, conforme esperado pela especificação.
+func resolveReportYearDefault(f reportFilters, now time.Time) int {
+	if f.Year > 0 {
+		return f.Year
+	}
+	return now.Year()
+}
+
+// statusOperacionalPriority define a ordem de prioridade operacional usada por
+// relatórios temáticos (Infraestrutura/Segurança, Merenda): Crítico primeiro,
+// depois Atenção, Adequado e, por fim, escolas Sem dados.
+var statusOperacionalPriority = map[string]int{
+	statusOperacionalCritico:  0,
+	statusOperacionalAtencao:  1,
+	statusOperacionalAdequado: 2,
+	statusOperacionalSemDados: 3,
+}
+
+// Rótulos canônicos do Status Operacional dos relatórios temáticos.
+const (
+	statusOperacionalSemDados = "Sem dados"
+	statusOperacionalCritico  = "Crítico"
+	statusOperacionalAtencao  = "Atenção"
+	statusOperacionalAdequado = "Adequado"
+)
+
+// statusOperacionalRank devolve o peso de ordenação de um Status Operacional.
+// Um status desconhecido é jogado para o final (após "Sem dados").
+func statusOperacionalRank(status string) int {
+	if r, ok := statusOperacionalPriority[status]; ok {
+		return r
+	}
+	return len(statusOperacionalPriority)
+}
+
+// reportOperacionalRow é a linha intermediária dos relatórios temáticos: guarda
+// as chaves de ordenação (status + território) e a projeção final das células.
+type reportOperacionalRow struct {
+	Status    string
+	DRE       string
+	Municipio string
+	Escola    string
+	INEP      string
+	Cells     []any
+}
+
+// sortReportOperacional ordena, de forma estável e determinística, as linhas
+// de um relatório temático por prioridade operacional (Crítico, Atenção,
+// Adequado, Sem dados) e, em seguida, por DRE, Município, Escola e Código INEP
+// (comparação insensível a caixa e acento).
+func sortReportOperacional(rows []reportOperacionalRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if ra, rb := statusOperacionalRank(a.Status), statusOperacionalRank(b.Status); ra != rb {
+			return ra < rb
+		}
+		if c := strings.Compare(normalizeSaudeSearch(a.DRE), normalizeSaudeSearch(b.DRE)); c != 0 {
+			return c < 0
+		}
+		if c := strings.Compare(normalizeSaudeSearch(a.Municipio), normalizeSaudeSearch(b.Municipio)); c != 0 {
+			return c < 0
+		}
+		if c := strings.Compare(normalizeSaudeSearch(a.Escola), normalizeSaudeSearch(b.Escola)); c != 0 {
+			return c < 0
+		}
+		return a.INEP < b.INEP
+	})
+}
+
+// reportTextCell projeta uma célula textual de relatório temático: "Sem dados"
+// quando a escola não tem censo concluído no ano, "Não informado" quando o
+// campo está vazio, e o próprio valor caso contrário.
+func reportTextCell(hasCensus bool, v string) any {
+	if !hasCensus {
+		return statusOperacionalSemDados
+	}
+	if strings.TrimSpace(v) == "" {
+		return "Não informado"
+	}
+	return v
+}
+
+// reportSemDadosOr força "Sem dados" quando não há censo; caso contrário,
+// devolve o valor já derivado (que pode incluir "Não informado").
+func reportSemDadosOr(hasCensus bool, v string) any {
+	if !hasCensus {
+		return statusOperacionalSemDados
+	}
+	return v
+}
+
+// reportIntCell projeta uma quantidade inteira opcional: "Sem dados" sem censo,
+// "Não informado" quando ausente, e o inteiro caso contrário.
+func reportIntCell(hasCensus bool, v sql.NullFloat64) any {
+	if !hasCensus {
+		return statusOperacionalSemDados
+	}
+	if !v.Valid {
+		return "Não informado"
+	}
+	return int(v.Float64)
 }
 
 // normalizeReportFormat aplica o default xlsx quando o parâmetro está
@@ -177,6 +286,16 @@ func (app *application) AdminGetReport(w http.ResponseWriter, r *http.Request) {
 		// efetivamente usado (e não "todos os anos").
 		filters.Year = resolveSaudeOperacionalReportYear(filters, time.Now())
 		rd, err = app.buildSaudeOperacionalReportData(r.Context(), def, filters)
+	case reportInfraestruturaSegurancaID:
+		// Depende de um ano de censo específico: resolve antes de gerar dados e
+		// nome do arquivo, para que ambos reflitam o ano usado (não "todos").
+		filters.Year = resolveReportYearDefault(filters, time.Now())
+		rd, err = app.buildInfraestruturaReportData(r.Context(), def, filters)
+	case reportMerendaCondicoesID:
+		// Depende de um ano de censo específico: resolve antes de gerar dados e
+		// nome do arquivo, para que ambos reflitam o ano usado (não "todos").
+		filters.Year = resolveReportYearDefault(filters, time.Now())
+		rd, err = app.buildMerendaReportData(r.Context(), def, filters)
 	default:
 		// Catálogo e dispatch desalinhados: defensivo.
 		app.errorJSON(w, fmt.Errorf("relatório %q sem implementação", def.ID), http.StatusNotFound)

--- a/api/cmd/api/reports_catalog.go
+++ b/api/cmd/api/reports_catalog.go
@@ -26,6 +26,18 @@ const reportCensoPreenchimentoID = "censo-preenchimento-escolas"
 // aba "Saúde Operacional".
 const reportSaudeOperacionalID = "saude-operacional-escolas"
 
+// reportInfraestruturaSegurancaID é o identificador do relatório de
+// Infraestrutura, Energia e Segurança Escolar, que exporta todas as escolas do
+// recorte com os campos de prédio, energia e segurança e um Status Operacional
+// simples para priorização. Depende de um ano de censo específico.
+const reportInfraestruturaSegurancaID = "infraestrutura-seguranca-escolas"
+
+// reportMerendaCondicoesID é o identificador do relatório de Condições da
+// Merenda Escolar, que exporta todas as escolas do recorte com oferta,
+// qualidade, condições da cozinha, equipamentos e um Status Operacional simples
+// para priorização. Depende de um ano de censo específico.
+const reportMerendaCondicoesID = "merenda-escolar-condicoes"
+
 // ReportDefinition descreve os metadados de um relatório gerencial. Os
 // campos são suficientes para montar o cabeçalho do XLSX (Title), nomear
 // a aba (SheetName) e derivar o nome do arquivo (FileBase). A consulta e
@@ -54,6 +66,20 @@ var reportsCatalog = map[string]ReportDefinition{
 		Description: "Índice de Saúde Operacional por escola, com criticidade, status e notas por dimensão, para todas as escolas do recorte.",
 		SheetName:   "Saude Operacional",
 		FileBase:    "relatorio_saude_operacional_escolas",
+	},
+	reportInfraestruturaSegurancaID: {
+		ID:          reportInfraestruturaSegurancaID,
+		Title:       "Relatório de Infraestrutura, Energia e Segurança Escolar",
+		Description: "Infraestrutura, energia e segurança por escola, com Status Operacional simples para priorização, para todas as escolas do recorte.",
+		SheetName:   "Infra Segurança",
+		FileBase:    "relatorio_infraestrutura_seguranca_escolas",
+	},
+	reportMerendaCondicoesID: {
+		ID:          reportMerendaCondicoesID,
+		Title:       "Relatório de Condições da Merenda Escolar",
+		Description: "Condições da merenda escolar por escola, com oferta, qualidade, cozinha, equipamentos e Status Operacional simples para priorização, para todas as escolas do recorte.",
+		SheetName:   "Merenda Escolar",
+		FileBase:    "relatorio_merenda_escolar_condicoes",
 	},
 }
 

--- a/api/cmd/api/reports_infraestrutura.go
+++ b/api/cmd/api/reports_infraestrutura.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// =====================================================================
+// Relatório gerencial — Infraestrutura, Energia e Segurança Escolar
+// =====================================================================
+// Exporta, sem paginação, todas as escolas do recorte com os campos de
+// prédio, energia e segurança do censo e um Status Operacional simples
+// para priorização. Escolas sem censo concluído no ano permanecem no
+// recorte e aparecem como "Sem dados".
+//
+// Fonte: schools s LEFT JOIN census_responses cr (cr.year = $1 AND
+// cr.status = 'completed') + LEFT JOIN reg_integracao. Os filtros globais
+// incidem sobre schools s. Campos do JSONB são lidos com NULLIF/cast
+// seguro, conforme a convenção do projeto. Não reutiliza endpoints
+// analíticos: lê o JSONB diretamente para manter o relatório isolado.
+// =====================================================================
+
+// infraestruturaReportColumns são os cabeçalhos do relatório, na ordem exigida
+// pela especificação.
+var infraestruturaReportColumns = []string{
+	"Região de Integração",
+	"DRE",
+	"Município",
+	"Zona",
+	"Código INEP",
+	"Escola",
+	"Tipo de Prédio",
+	"Situação da Estrutura",
+	"Necessita Reforma",
+	"Reforma Crítica",
+	"Obra Parada",
+	"Rede Elétrica Atende",
+	"Suporta Novos Equipamentos",
+	"Energia",
+	"Estrutura para Climatização",
+	"Salas Climatizadas",
+	"Salas Não Climatizadas",
+	"Guarita",
+	"Botão de Pânico",
+	"Câmeras",
+	"Controle de Portão",
+	"Iluminação Externa",
+	"Muro/Cerca",
+	"Plano de Evacuação",
+	"Política contra Bullying",
+	"Status Operacional",
+}
+
+// Valores canônicos de situacao_estrutura relevantes para a classificação.
+// Espelham as opções do formulário (web/src/schemas/steps/general-data.ts) e
+// os scores da Saúde Operacional, sem duplicar a metodologia de pontuação.
+const (
+	situacaoReformaGeral   = "Necessita de reforma geral"
+	situacaoObraParada     = "Está em reforma, porém a obra está parada"
+	situacaoReformaParcial = "Necessita de reforma parcial (melhoria pontual)"
+	situacaoReformaAndando = "Reforma em andamento"
+	situacaoSemReforma     = "Não necessita de reforma."
+	situacaoReformada      = "Foi reformada recentemente"
+)
+
+// infraReportRow guarda os valores brutos de uma escola, já de-NULLificados
+// (categóricos como "" quando ausentes), para classificação e projeção.
+type infraReportRow struct {
+	Regiao    string
+	DRE       string
+	Municipio string
+	Zona      string
+	INEP      string
+	Escola    string
+
+	HasCensus bool
+
+	TipoPredio            string
+	SituacaoEstrutura     string
+	RedeEletricaAtende    string
+	SuportaNovosEquip     string
+	Energia               string
+	EstruturaClimatizacao string
+	SalasClimatizadas     sql.NullFloat64
+	QtdSalasAula          sql.NullFloat64
+	PossuiGuarita         string
+	BotaoPanico           string
+	Cameras               string
+	ControlePortao        string
+	IluminacaoExterna     string
+	MuroCerca             string
+	PlanoEvacuacao        string
+	PoliticaBullying      string
+}
+
+// infraNecessitaReforma deriva a coluna "Necessita Reforma" de situacao_estrutura.
+// Defensiva: só responde "Sim"/"Não" para valores conhecidos; demais viram
+// "Não informado".
+func infraNecessitaReforma(situacao string) string {
+	switch situacao {
+	case situacaoReformaGeral, situacaoObraParada, situacaoReformaParcial, situacaoReformaAndando:
+		return "Sim"
+	case situacaoSemReforma, situacaoReformada:
+		return "Não"
+	default:
+		return "Não informado"
+	}
+}
+
+// infraReformaCritica indica se a estrutura está em condição crítica de reforma
+// (necessita de reforma geral).
+func infraReformaCritica(situacao string) string {
+	if situacao == situacaoReformaGeral {
+		return "Sim"
+	}
+	if situacao == "" {
+		return "Não informado"
+	}
+	return "Não"
+}
+
+// infraObraParada indica se há obra de reforma parada.
+func infraObraParada(situacao string) string {
+	if situacao == situacaoObraParada {
+		return "Sim"
+	}
+	if situacao == "" {
+		return "Não informado"
+	}
+	return "Não"
+}
+
+// classifyInfraStatus classifica o Status Operacional de Infraestrutura,
+// conforme a tabela documentada na especificação. Critérios (defensivos, só
+// disparam em valores conhecidos):
+//
+//	Sem censo concluído                              -> Sem dados
+//	Crítico (qualquer um):
+//	  - estrutura: necessita de reforma geral
+//	  - obra de reforma parada
+//	  - rede elétrica não atende ("Não")
+//	  - energia ausente (campo vazio)
+//	Atenção (qualquer um):
+//	  - estrutura: necessita de reforma parcial
+//	  - rede elétrica atende parcialmente
+//	  - sem estrutura de climatização ("Não" / "Não, somente com adequações")
+//	  - câmeras "Não possui"
+//	  - iluminação externa "Insuficiente"
+//	  - sem muro/cerca ("Não possui")
+//	Sem problema relevante                           -> Adequado
+func classifyInfraStatus(r infraReportRow) string {
+	if !r.HasCensus {
+		return statusOperacionalSemDados
+	}
+	if isInfraCritico(r) {
+		return statusOperacionalCritico
+	}
+	if isInfraAtencao(r) {
+		return statusOperacionalAtencao
+	}
+	return statusOperacionalAdequado
+}
+
+func isInfraCritico(r infraReportRow) bool {
+	switch r.SituacaoEstrutura {
+	case situacaoReformaGeral, situacaoObraParada:
+		return true
+	}
+	if r.RedeEletricaAtende == "Não" {
+		return true
+	}
+	if strings.TrimSpace(r.Energia) == "" {
+		return true
+	}
+	return false
+}
+
+func isInfraAtencao(r infraReportRow) bool {
+	if r.SituacaoEstrutura == situacaoReformaParcial {
+		return true
+	}
+	if r.RedeEletricaAtende == "Parcialmente" {
+		return true
+	}
+	switch r.EstruturaClimatizacao {
+	case "Não", "Não, somente com adequações":
+		return true
+	}
+	if r.Cameras == "Não possui" {
+		return true
+	}
+	if r.IluminacaoExterna == "Insuficiente" {
+		return true
+	}
+	if r.MuroCerca == "Não possui" {
+		return true
+	}
+	return false
+}
+
+// infraSalasNaoClimatizadas replica a regra da vw_censo_enriquecida: salas não
+// climatizadas = max(qtd_salas_aula - salas_climatizadas, 0); NULL quando
+// qtd_salas_aula é desconhecido (não infla o numerador artificialmente).
+func infraSalasNaoClimatizadas(qtdSalas, salasClim sql.NullFloat64) sql.NullFloat64 {
+	if !qtdSalas.Valid {
+		return sql.NullFloat64{}
+	}
+	clim := 0.0
+	if salasClim.Valid {
+		clim = salasClim.Float64
+	}
+	diff := qtdSalas.Float64 - clim
+	if diff < 0 {
+		diff = 0
+	}
+	return sql.NullFloat64{Float64: diff, Valid: true}
+}
+
+// infraestruturaSelectSQL parte de schools s, com LEFT JOIN na resposta do ano
+// (status='completed') para manter escolas sem censo no recorte, e LEFT JOIN em
+// reg_integracao para a Região de Integração. Filtros globais incidem sobre
+// schools s (UPPER(TRIM(...)) tolera caixa/espaços). Não pagina; a ordenação
+// final por prioridade operacional é feita em Go.
+//
+// $1=year (sempre específico), $2=dre, $3=municipio, $4=zona, $5=regiao.
+const infraestruturaSelectSQL = `
+	SELECT
+		COALESCE(ri.regiao_de_integracao, '') AS regiao_integracao,
+		COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre,
+		COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio,
+		COALESCE(NULLIF(TRIM(s.zona), ''), '') AS zona,
+		COALESCE(s.codigo_inep, '') AS codigo_inep,
+		COALESCE(NULLIF(TRIM(s.nome_escola), ''), 'Sem nome') AS nome_escola,
+		(cr.id IS NOT NULL) AS has_censo,
+		COALESCE(NULLIF(cr.data->>'tipo_predio', ''), '')              AS tipo_predio,
+		COALESCE(NULLIF(cr.data->>'situacao_estrutura', ''), '')       AS situacao_estrutura,
+		COALESCE(NULLIF(cr.data->>'rede_eletrica_atende', ''), '')     AS rede_eletrica_atende,
+		COALESCE(NULLIF(cr.data->>'suporta_novos_equipamentos', ''), '') AS suporta_novos_equipamentos,
+		COALESCE(NULLIF(cr.data->>'energia', ''), '')                  AS energia,
+		COALESCE(NULLIF(cr.data->>'estrutura_climatizacao', ''), '')   AS estrutura_climatizacao,
+		CASE WHEN cr.data->>'salas_climatizadas' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'salas_climatizadas')::numeric END       AS salas_climatizadas,
+		CASE WHEN cr.data->>'qtd_salas_aula' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_salas_aula')::numeric END           AS qtd_salas_aula,
+		COALESCE(NULLIF(cr.data->>'possui_guarita', ''), '')          AS possui_guarita,
+		COALESCE(NULLIF(cr.data->>'possui_botao_panico', ''), '')     AS possui_botao_panico,
+		COALESCE(NULLIF(cr.data->>'cameras_funcionamento', ''), '')   AS cameras_funcionamento,
+		COALESCE(NULLIF(cr.data->>'controle_portao', ''), '')         AS controle_portao,
+		COALESCE(NULLIF(cr.data->>'iluminacao_externa', ''), '')      AS iluminacao_externa,
+		COALESCE(NULLIF(cr.data->>'muro_cerca', ''), '')              AS muro_cerca,
+		COALESCE(NULLIF(cr.data->>'plano_evacuacao', ''), '')         AS plano_evacuacao,
+		COALESCE(NULLIF(cr.data->>'politica_bullying', ''), '')       AS politica_bullying
+	FROM schools s
+	LEFT JOIN census_responses cr
+		ON cr.school_id = s.id AND cr.year = $1 AND cr.status = 'completed'
+	LEFT JOIN reg_integracao ri ON UPPER(TRIM(ri.municipio)) = UPPER(TRIM(s.municipio))
+	WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))
+	ORDER BY
+		UPPER(TRIM(s.dre)),
+		UPPER(TRIM(s.municipio)),
+		UPPER(TRIM(s.nome_escola)),
+		s.codigo_inep
+`
+
+// buildInfraestruturaReportData executa a consulta, classifica o Status
+// Operacional de cada escola, ordena por prioridade operacional e projeta as
+// colunas do XLSX. Não pagina.
+func (app *application) buildInfraestruturaReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, infraestruturaSelectSQL, f.args()...)
+	if err != nil {
+		return reportData{}, fmt.Errorf("consultar infraestrutura: %w", err)
+	}
+	defer dbRows.Close()
+
+	rows := make([]reportOperacionalRow, 0)
+	for dbRows.Next() {
+		var r infraReportRow
+		if err := dbRows.Scan(
+			&r.Regiao, &r.DRE, &r.Municipio, &r.Zona, &r.INEP, &r.Escola,
+			&r.HasCensus,
+			&r.TipoPredio, &r.SituacaoEstrutura, &r.RedeEletricaAtende, &r.SuportaNovosEquip,
+			&r.Energia, &r.EstruturaClimatizacao, &r.SalasClimatizadas, &r.QtdSalasAula,
+			&r.PossuiGuarita, &r.BotaoPanico, &r.Cameras, &r.ControlePortao,
+			&r.IluminacaoExterna, &r.MuroCerca, &r.PlanoEvacuacao, &r.PoliticaBullying,
+		); err != nil {
+			return reportData{}, fmt.Errorf("ler linha infraestrutura: %w", err)
+		}
+
+		status := classifyInfraStatus(r)
+		naoClim := infraSalasNaoClimatizadas(r.QtdSalasAula, r.SalasClimatizadas)
+
+		cells := []any{
+			r.Regiao,
+			r.DRE,
+			r.Municipio,
+			r.Zona,
+			r.INEP,
+			r.Escola,
+			reportTextCell(r.HasCensus, r.TipoPredio),
+			reportTextCell(r.HasCensus, r.SituacaoEstrutura),
+			reportSemDadosOr(r.HasCensus, infraNecessitaReforma(r.SituacaoEstrutura)),
+			reportSemDadosOr(r.HasCensus, infraReformaCritica(r.SituacaoEstrutura)),
+			reportSemDadosOr(r.HasCensus, infraObraParada(r.SituacaoEstrutura)),
+			reportTextCell(r.HasCensus, r.RedeEletricaAtende),
+			reportTextCell(r.HasCensus, r.SuportaNovosEquip),
+			reportTextCell(r.HasCensus, r.Energia),
+			reportTextCell(r.HasCensus, r.EstruturaClimatizacao),
+			reportIntCell(r.HasCensus, r.SalasClimatizadas),
+			reportIntCell(r.HasCensus, naoClim),
+			reportTextCell(r.HasCensus, r.PossuiGuarita),
+			reportTextCell(r.HasCensus, r.BotaoPanico),
+			reportTextCell(r.HasCensus, r.Cameras),
+			reportTextCell(r.HasCensus, r.ControlePortao),
+			reportTextCell(r.HasCensus, r.IluminacaoExterna),
+			reportTextCell(r.HasCensus, r.MuroCerca),
+			reportTextCell(r.HasCensus, r.PlanoEvacuacao),
+			reportTextCell(r.HasCensus, r.PoliticaBullying),
+			status,
+		}
+
+		rows = append(rows, reportOperacionalRow{
+			Status:    status,
+			DRE:       r.DRE,
+			Municipio: r.Municipio,
+			Escola:    r.Escola,
+			INEP:      r.INEP,
+			Cells:     cells,
+		})
+	}
+	if err := dbRows.Err(); err != nil {
+		return reportData{}, fmt.Errorf("iterar linhas infraestrutura: %w", err)
+	}
+
+	sortReportOperacional(rows)
+
+	data := make([][]any, 0, len(rows))
+	for _, row := range rows {
+		data = append(data, row.Cells)
+	}
+
+	return reportData{
+		Title:       def.Title,
+		SheetName:   def.SheetName,
+		FiltersLine: f.describe(),
+		Headers:     infraestruturaReportColumns,
+		Rows:        data,
+	}, nil
+}

--- a/api/cmd/api/reports_infraestrutura_test.go
+++ b/api/cmd/api/reports_infraestrutura_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReportsCatalogRecognizesInfraestrutura garante que o relatório de
+// Infraestrutura/Segurança está registrado com os metadados esperados.
+func TestReportsCatalogRecognizesInfraestrutura(t *testing.T) {
+	def, ok := lookupReport(reportInfraestruturaSegurancaID)
+	if !ok {
+		t.Fatalf("lookupReport(%q) = not found", reportInfraestruturaSegurancaID)
+	}
+	if def.Title != "Relatório de Infraestrutura, Energia e Segurança Escolar" {
+		t.Fatalf("Title = %q; inesperado", def.Title)
+	}
+	if def.SheetName != "Infra Segurança" {
+		t.Fatalf("SheetName = %q; want %q", def.SheetName, "Infra Segurança")
+	}
+	if def.FileBase != "relatorio_infraestrutura_seguranca_escolas" {
+		t.Fatalf("FileBase = %q; inesperado", def.FileBase)
+	}
+}
+
+// TestInfraestruturaReportColumns trava a ordem e o conteúdo das colunas.
+func TestInfraestruturaReportColumns(t *testing.T) {
+	want := []string{
+		"Região de Integração", "DRE", "Município", "Zona", "Código INEP", "Escola",
+		"Tipo de Prédio", "Situação da Estrutura", "Necessita Reforma", "Reforma Crítica",
+		"Obra Parada", "Rede Elétrica Atende", "Suporta Novos Equipamentos", "Energia",
+		"Estrutura para Climatização", "Salas Climatizadas", "Salas Não Climatizadas",
+		"Guarita", "Botão de Pânico", "Câmeras", "Controle de Portão", "Iluminação Externa",
+		"Muro/Cerca", "Plano de Evacuação", "Política contra Bullying", "Status Operacional",
+	}
+	if len(infraestruturaReportColumns) != len(want) {
+		t.Fatalf("len colunas = %d; want %d", len(infraestruturaReportColumns), len(want))
+	}
+	for i := range want {
+		if infraestruturaReportColumns[i] != want[i] {
+			t.Fatalf("coluna[%d] = %q; want %q", i, infraestruturaReportColumns[i], want[i])
+		}
+	}
+	if infraestruturaReportColumns[len(infraestruturaReportColumns)-1] != "Status Operacional" {
+		t.Fatalf("última coluna deve ser Status Operacional")
+	}
+}
+
+// TestClassifyInfraStatus cobre a tabela de classificação operacional.
+func TestClassifyInfraStatus(t *testing.T) {
+	base := infraReportRow{
+		HasCensus:             true,
+		SituacaoEstrutura:     situacaoSemReforma,
+		RedeEletricaAtende:    "Sim",
+		Energia:               "Concessionária de energia - Equatorial",
+		EstruturaClimatizacao: "Sim",
+		Cameras:               "Sim, funcionando plenamente",
+		IluminacaoExterna:     "Adequada",
+		MuroCerca:             "Sim, muro",
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(r *infraReportRow)
+		want   string
+	}{
+		{"sem censo", func(r *infraReportRow) { r.HasCensus = false }, statusOperacionalSemDados},
+		{"adequado", func(r *infraReportRow) {}, statusOperacionalAdequado},
+		{"critico reforma geral", func(r *infraReportRow) { r.SituacaoEstrutura = situacaoReformaGeral }, statusOperacionalCritico},
+		{"critico obra parada", func(r *infraReportRow) { r.SituacaoEstrutura = situacaoObraParada }, statusOperacionalCritico},
+		{"critico rede nao atende", func(r *infraReportRow) { r.RedeEletricaAtende = "Não" }, statusOperacionalCritico},
+		{"critico energia ausente", func(r *infraReportRow) { r.Energia = "" }, statusOperacionalCritico},
+		{"atencao reforma parcial", func(r *infraReportRow) { r.SituacaoEstrutura = situacaoReformaParcial }, statusOperacionalAtencao},
+		{"atencao rede parcial", func(r *infraReportRow) { r.RedeEletricaAtende = "Parcialmente" }, statusOperacionalAtencao},
+		{"atencao sem climatizacao", func(r *infraReportRow) { r.EstruturaClimatizacao = "Não" }, statusOperacionalAtencao},
+		{"atencao sem cameras", func(r *infraReportRow) { r.Cameras = "Não possui" }, statusOperacionalAtencao},
+		{"atencao iluminacao insuficiente", func(r *infraReportRow) { r.IluminacaoExterna = "Insuficiente" }, statusOperacionalAtencao},
+		{"atencao sem muro", func(r *infraReportRow) { r.MuroCerca = "Não possui" }, statusOperacionalAtencao},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := base
+			tt.mutate(&r)
+			if got := classifyInfraStatus(r); got != tt.want {
+				t.Fatalf("classifyInfraStatus = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyInfraStatusCriticoPrecedeAtencao garante que crítico tem
+// prioridade quando há problemas dos dois níveis simultaneamente.
+func TestClassifyInfraStatusCriticoPrecedeAtencao(t *testing.T) {
+	r := infraReportRow{
+		HasCensus:         true,
+		SituacaoEstrutura: situacaoReformaGeral, // crítico
+		Cameras:           "Não possui",         // atenção
+		Energia:           "Geração própria",
+	}
+	if got := classifyInfraStatus(r); got != statusOperacionalCritico {
+		t.Fatalf("classifyInfraStatus = %q; want Crítico", got)
+	}
+}
+
+// TestInfraDerivedReformColumns cobre as colunas derivadas de situacao_estrutura.
+func TestInfraDerivedReformColumns(t *testing.T) {
+	tests := []struct {
+		situacao                 string
+		necessita, critica, obra string
+	}{
+		{situacaoReformaGeral, "Sim", "Sim", "Não"},
+		{situacaoObraParada, "Sim", "Não", "Sim"},
+		{situacaoReformaParcial, "Sim", "Não", "Não"},
+		{situacaoSemReforma, "Não", "Não", "Não"},
+		{situacaoReformada, "Não", "Não", "Não"},
+		{"", "Não informado", "Não informado", "Não informado"},
+	}
+	for _, tt := range tests {
+		if got := infraNecessitaReforma(tt.situacao); got != tt.necessita {
+			t.Fatalf("infraNecessitaReforma(%q) = %q; want %q", tt.situacao, got, tt.necessita)
+		}
+		if got := infraReformaCritica(tt.situacao); got != tt.critica {
+			t.Fatalf("infraReformaCritica(%q) = %q; want %q", tt.situacao, got, tt.critica)
+		}
+		if got := infraObraParada(tt.situacao); got != tt.obra {
+			t.Fatalf("infraObraParada(%q) = %q; want %q", tt.situacao, got, tt.obra)
+		}
+	}
+}
+
+// TestInfraSalasNaoClimatizadas valida a regra max(salas - climatizadas, 0).
+func TestInfraSalasNaoClimatizadas(t *testing.T) {
+	nf := func(v float64) sql.NullFloat64 { return sql.NullFloat64{Float64: v, Valid: true} }
+	null := sql.NullFloat64{}
+
+	if got := infraSalasNaoClimatizadas(null, nf(2)); got.Valid {
+		t.Fatalf("salas_aula NULL deve produzir NULL; got %+v", got)
+	}
+	if got := infraSalasNaoClimatizadas(nf(10), nf(3)); !got.Valid || got.Float64 != 7 {
+		t.Fatalf("10-3 = %+v; want 7", got)
+	}
+	if got := infraSalasNaoClimatizadas(nf(5), nf(8)); !got.Valid || got.Float64 != 0 {
+		t.Fatalf("piso 0 falhou: %+v", got)
+	}
+	if got := infraSalasNaoClimatizadas(nf(4), null); !got.Valid || got.Float64 != 4 {
+		t.Fatalf("climatizadas NULL deve tratar como 0: %+v", got)
+	}
+}
+
+// TestSortReportOperacionalPriority garante a ordem Crítico > Atenção >
+// Adequado > Sem dados e os desempates territoriais.
+func TestSortReportOperacionalPriority(t *testing.T) {
+	rows := []reportOperacionalRow{
+		{Status: statusOperacionalSemDados, DRE: "A", Municipio: "A", Escola: "A", INEP: "1"},
+		{Status: statusOperacionalAdequado, DRE: "A", Municipio: "A", Escola: "A", INEP: "2"},
+		{Status: statusOperacionalCritico, DRE: "Z", Municipio: "Z", Escola: "Z", INEP: "3"},
+		{Status: statusOperacionalCritico, DRE: "A", Municipio: "A", Escola: "A", INEP: "4"},
+		{Status: statusOperacionalAtencao, DRE: "A", Municipio: "A", Escola: "A", INEP: "5"},
+	}
+	sortReportOperacional(rows)
+
+	wantINEP := []string{"4", "3", "5", "2", "1"}
+	for i, w := range wantINEP {
+		if rows[i].INEP != w {
+			t.Fatalf("ordem[%d] INEP = %q; want %q (rows=%+v)", i, rows[i].INEP, w, rows)
+		}
+	}
+}
+
+// TestResolveReportYearDefault garante ano específico (não "todos os anos").
+func TestResolveReportYearDefault(t *testing.T) {
+	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	if got := resolveReportYearDefault(reportFilters{Year: 2025}, now); got != 2025 {
+		t.Fatalf("year explícito = %d; want 2025", got)
+	}
+	if got := resolveReportYearDefault(reportFilters{Year: 0}, now); got != 2026 {
+		t.Fatalf("year ausente = %d; want 2026 (ano corrente)", got)
+	}
+	if got := resolveReportYearDefault(reportFilters{}, now); got == 0 {
+		t.Fatalf("year padrão não pode ser 0 (todos os anos)")
+	}
+}
+
+// TestWriteInfraestruturaXLSX garante a geração do XLSX com a aba e colunas.
+func TestWriteInfraestruturaXLSX(t *testing.T) {
+	rd := reportData{
+		Title:       "Relatório de Infraestrutura, Energia e Segurança Escolar",
+		SheetName:   "Infra Segurança",
+		FiltersLine: "Filtros aplicados — Ano: 2026",
+		Headers:     infraestruturaReportColumns,
+		Rows: [][]any{
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "12345678", "Escola Crítica",
+				"Próprio", "Necessita de reforma geral", "Sim", "Sim", "Não", "Não",
+				"Não", "Geração própria", "Não", 2, 8, "Sim", "Não",
+				"Não possui", "Manual", "Insuficiente", "Não possui", "Não", "Não possui",
+				statusOperacionalCritico},
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "87654321", "Escola Sem Dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				statusOperacionalSemDados},
+		},
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		t.Fatalf("writeReportXLSX erro: %v", err)
+	}
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer erro: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("XLSX vazio")
+	}
+	if idx, err := f.GetSheetIndex("Infra Segurança"); err != nil || idx < 0 {
+		t.Fatalf("aba 'Infra Segurança' não encontrada (idx=%d, err=%v)", idx, err)
+	}
+	if v, err := f.GetCellValue("Infra Segurança", "A4"); err != nil || v != "Região de Integração" {
+		t.Fatalf("A4 = %q (err=%v); want primeiro cabeçalho", v, err)
+	}
+	// Última coluna (Z = 26ª) na linha 5 deve ser o status.
+	if v, err := f.GetCellValue("Infra Segurança", "Z5"); err != nil || v != statusOperacionalCritico {
+		t.Fatalf("Z5 = %q (err=%v); want %q", v, err, statusOperacionalCritico)
+	}
+}
+
+// TestInfraestruturaSelectSQLShape valida que a consulta parte de schools s com
+// LEFT JOIN no censo concluído do ano (mantendo escolas sem dados) e aplica os
+// filtros globais sobre schools s.
+func TestInfraestruturaSelectSQLShape(t *testing.T) {
+	q := infraestruturaSelectSQL
+	mustContain := []string{
+		"FROM schools s",
+		"LEFT JOIN census_responses cr",
+		"cr.year = $1 AND cr.status = 'completed'",
+		"LEFT JOIN reg_integracao ri",
+		"(cr.id IS NOT NULL) AS has_censo",
+		"cr.data->>'situacao_estrutura'",
+		"cr.data->>'plano_evacuacao'",
+		"($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(q, frag) {
+			t.Fatalf("infraestruturaSelectSQL não contém %q", frag)
+		}
+	}
+	if strings.Contains(q, "INNER JOIN") {
+		t.Fatalf("query não pode usar INNER JOIN (excluiria escolas sem dados)")
+	}
+}

--- a/api/cmd/api/reports_merenda.go
+++ b/api/cmd/api/reports_merenda.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// =====================================================================
+// Relatório gerencial — Condições da Merenda Escolar
+// =====================================================================
+// Exporta, sem paginação, todas as escolas do recorte com a oferta, a
+// qualidade, as condições da cozinha, os equipamentos e um Status
+// Operacional simples para priorização. Escolas sem censo concluído no
+// ano permanecem no recorte e aparecem como "Sem dados".
+//
+// Fonte: schools s LEFT JOIN census_responses cr (cr.year = $1 AND
+// cr.status = 'completed') + LEFT JOIN reg_integracao. Os filtros globais
+// incidem sobre schools s. Campos do JSONB são lidos com NULLIF/cast
+// seguro, conforme a convenção do projeto.
+//
+// Observação de mapeamento: o censo registra o estoque de EPIs e
+// extintores num único campo (estoque_epi_extintor: Completo/Parcial/
+// Inexistente). Por isso as colunas "EPIs" e "Extintores" refletem esse
+// mesmo campo, enquanto "Manutenção Preventiva" usa manutencao_extintores
+// (Está na validade/Validade vencida).
+// =====================================================================
+
+// merendaReportColumns são os cabeçalhos do relatório, na ordem exigida pela
+// especificação.
+var merendaReportColumns = []string{
+	"Região de Integração",
+	"DRE",
+	"Município",
+	"Zona",
+	"Código INEP",
+	"Escola",
+	"Oferta Regular",
+	"Qualidade da Merenda",
+	"Atende Necessidades",
+	"Condições da Cozinha",
+	"Tamanho da Cozinha",
+	"Possui Refeitório",
+	"Refeitório Adequado",
+	"Freezers",
+	"Geladeiras",
+	"Fogões",
+	"Bebedouros",
+	"Despensa Exclusiva",
+	"Depósito de Conserva",
+	"EPIs",
+	"Extintores",
+	"Manutenção Preventiva",
+	"Status Operacional",
+}
+
+// merendaReportRow guarda os valores brutos de uma escola, já de-NULLificados
+// (categóricos como "" quando ausentes), para classificação e projeção.
+type merendaReportRow struct {
+	Regiao    string
+	DRE       string
+	Municipio string
+	Zona      string
+	INEP      string
+	Escola    string
+
+	HasCensus bool
+
+	OfertaRegular      string
+	QualidadeMerenda   string
+	AtendeNecessidades string
+	CondicoesCozinha   string
+	TamanhoCozinha     string
+	PossuiRefeitorio   string
+	RefeitorioAdequado string
+	QtdFreezers        sql.NullFloat64
+	QtdGeladeiras      sql.NullFloat64
+	QtdFogoes          sql.NullFloat64
+	QtdBebedouros      sql.NullFloat64
+	DespensaExclusiva  string
+	DepositoConserva   string
+	EstoqueEpiExtintor string
+	ManutencaoExtint   string
+}
+
+// classifyMerendaStatus classifica o Status Operacional de Merenda, conforme a
+// tabela documentada na especificação. Critérios (defensivos, só disparam em
+// valores conhecidos):
+//
+//	Sem censo concluído                              -> Sem dados
+//	Crítico (qualquer um):
+//	  - sem oferta regular (oferta_regular = "Não")
+//	  - não atende necessidades (atende_necessidades = "Não")
+//	  - cozinha ruim/precária (condicoes_cozinha = "Precária")
+//	Atenção (qualquer um):
+//	  - oferta com falhas
+//	  - qualidade da merenda Regular ou Ruim
+//	  - atende necessidades apenas Parcialmente
+//	  - condições da cozinha Regular
+//	  - refeitório inadequado (refeitorio_adequado = "Não")
+//	  - equipamentos insuficientes (sem refrigeração: 0 freezers e 0 geladeiras,
+//	    ou estoque de EPI/extintor inexistente)
+//	Sem problema relevante                           -> Adequado
+func classifyMerendaStatus(r merendaReportRow) string {
+	if !r.HasCensus {
+		return statusOperacionalSemDados
+	}
+	if isMerendaCritico(r) {
+		return statusOperacionalCritico
+	}
+	if isMerendaAtencao(r) {
+		return statusOperacionalAtencao
+	}
+	return statusOperacionalAdequado
+}
+
+func isMerendaCritico(r merendaReportRow) bool {
+	if r.OfertaRegular == "Não" {
+		return true
+	}
+	if r.AtendeNecessidades == "Não" {
+		return true
+	}
+	if r.CondicoesCozinha == "Precária" {
+		return true
+	}
+	return false
+}
+
+func isMerendaAtencao(r merendaReportRow) bool {
+	if r.OfertaRegular == "Sim, com falhas" {
+		return true
+	}
+	switch r.QualidadeMerenda {
+	case "Regular", "Ruim":
+		return true
+	}
+	if r.AtendeNecessidades == "Parcialmente" {
+		return true
+	}
+	if r.CondicoesCozinha == "Regular" {
+		return true
+	}
+	if r.RefeitorioAdequado == "Não" {
+		return true
+	}
+	if merendaSemRefrigeracao(r) {
+		return true
+	}
+	if r.EstoqueEpiExtintor == "Inexistente" {
+		return true
+	}
+	return false
+}
+
+// merendaSemRefrigeracao indica ausência de refrigeração quando tanto freezers
+// quanto geladeiras são conhecidos e iguais a zero. Quantidades ausentes (NULL)
+// não disparam o sinal — defensivo, não infla a criticidade.
+func merendaSemRefrigeracao(r merendaReportRow) bool {
+	return r.QtdFreezers.Valid && r.QtdFreezers.Float64 == 0 &&
+		r.QtdGeladeiras.Valid && r.QtdGeladeiras.Float64 == 0
+}
+
+// merendaSelectSQL parte de schools s, com LEFT JOIN na resposta do ano
+// (status='completed') para manter escolas sem censo no recorte, e LEFT JOIN em
+// reg_integracao para a Região de Integração. Filtros globais incidem sobre
+// schools s. Não pagina; a ordenação final por prioridade operacional é em Go.
+//
+// $1=year (sempre específico), $2=dre, $3=municipio, $4=zona, $5=regiao.
+const merendaSelectSQL = `
+	SELECT
+		COALESCE(ri.regiao_de_integracao, '') AS regiao_integracao,
+		COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre,
+		COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio,
+		COALESCE(NULLIF(TRIM(s.zona), ''), '') AS zona,
+		COALESCE(s.codigo_inep, '') AS codigo_inep,
+		COALESCE(NULLIF(TRIM(s.nome_escola), ''), 'Sem nome') AS nome_escola,
+		(cr.id IS NOT NULL) AS has_censo,
+		COALESCE(NULLIF(cr.data->>'oferta_regular', ''), '')      AS oferta_regular,
+		COALESCE(NULLIF(cr.data->>'qualidade_merenda', ''), '')   AS qualidade_merenda,
+		COALESCE(NULLIF(cr.data->>'atende_necessidades', ''), '') AS atende_necessidades,
+		COALESCE(NULLIF(cr.data->>'condicoes_cozinha', ''), '')   AS condicoes_cozinha,
+		COALESCE(NULLIF(cr.data->>'tamanho_cozinha', ''), '')     AS tamanho_cozinha,
+		COALESCE(NULLIF(cr.data->>'possui_refeitorio', ''), '')   AS possui_refeitorio,
+		COALESCE(NULLIF(cr.data->>'refeitorio_adequado', ''), '') AS refeitorio_adequado,
+		CASE WHEN cr.data->>'qtd_freezers' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_freezers')::numeric END         AS qtd_freezers,
+		CASE WHEN cr.data->>'qtd_geladeiras' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_geladeiras')::numeric END       AS qtd_geladeiras,
+		CASE WHEN cr.data->>'qtd_fogoes' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_fogoes')::numeric END           AS qtd_fogoes,
+		CASE WHEN cr.data->>'qtd_bebedouros' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_bebedouros')::numeric END       AS qtd_bebedouros,
+		COALESCE(NULLIF(cr.data->>'despensa_exclusiva', ''), '')   AS despensa_exclusiva,
+		COALESCE(NULLIF(cr.data->>'deposito_conserva', ''), '')    AS deposito_conserva,
+		COALESCE(NULLIF(cr.data->>'estoque_epi_extintor', ''), '')  AS estoque_epi_extintor,
+		COALESCE(NULLIF(cr.data->>'manutencao_extintores', ''), '') AS manutencao_extintores
+	FROM schools s
+	LEFT JOIN census_responses cr
+		ON cr.school_id = s.id AND cr.year = $1 AND cr.status = 'completed'
+	LEFT JOIN reg_integracao ri ON UPPER(TRIM(ri.municipio)) = UPPER(TRIM(s.municipio))
+	WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))
+	ORDER BY
+		UPPER(TRIM(s.dre)),
+		UPPER(TRIM(s.municipio)),
+		UPPER(TRIM(s.nome_escola)),
+		s.codigo_inep
+`
+
+// buildMerendaReportData executa a consulta, classifica o Status Operacional de
+// cada escola, ordena por prioridade operacional e projeta as colunas do XLSX.
+// Não pagina.
+func (app *application) buildMerendaReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, merendaSelectSQL, f.args()...)
+	if err != nil {
+		return reportData{}, fmt.Errorf("consultar merenda: %w", err)
+	}
+	defer dbRows.Close()
+
+	rows := make([]reportOperacionalRow, 0)
+	for dbRows.Next() {
+		var r merendaReportRow
+		if err := dbRows.Scan(
+			&r.Regiao, &r.DRE, &r.Municipio, &r.Zona, &r.INEP, &r.Escola,
+			&r.HasCensus,
+			&r.OfertaRegular, &r.QualidadeMerenda, &r.AtendeNecessidades,
+			&r.CondicoesCozinha, &r.TamanhoCozinha, &r.PossuiRefeitorio, &r.RefeitorioAdequado,
+			&r.QtdFreezers, &r.QtdGeladeiras, &r.QtdFogoes, &r.QtdBebedouros,
+			&r.DespensaExclusiva, &r.DepositoConserva, &r.EstoqueEpiExtintor, &r.ManutencaoExtint,
+		); err != nil {
+			return reportData{}, fmt.Errorf("ler linha merenda: %w", err)
+		}
+
+		status := classifyMerendaStatus(r)
+
+		cells := []any{
+			r.Regiao,
+			r.DRE,
+			r.Municipio,
+			r.Zona,
+			r.INEP,
+			r.Escola,
+			reportTextCell(r.HasCensus, r.OfertaRegular),
+			reportTextCell(r.HasCensus, r.QualidadeMerenda),
+			reportTextCell(r.HasCensus, r.AtendeNecessidades),
+			reportTextCell(r.HasCensus, r.CondicoesCozinha),
+			reportTextCell(r.HasCensus, r.TamanhoCozinha),
+			reportTextCell(r.HasCensus, r.PossuiRefeitorio),
+			reportTextCell(r.HasCensus, r.RefeitorioAdequado),
+			reportIntCell(r.HasCensus, r.QtdFreezers),
+			reportIntCell(r.HasCensus, r.QtdGeladeiras),
+			reportIntCell(r.HasCensus, r.QtdFogoes),
+			reportIntCell(r.HasCensus, r.QtdBebedouros),
+			reportTextCell(r.HasCensus, r.DespensaExclusiva),
+			reportTextCell(r.HasCensus, r.DepositoConserva),
+			reportTextCell(r.HasCensus, r.EstoqueEpiExtintor),
+			reportTextCell(r.HasCensus, r.EstoqueEpiExtintor),
+			reportTextCell(r.HasCensus, r.ManutencaoExtint),
+			status,
+		}
+
+		rows = append(rows, reportOperacionalRow{
+			Status:    status,
+			DRE:       r.DRE,
+			Municipio: r.Municipio,
+			Escola:    r.Escola,
+			INEP:      r.INEP,
+			Cells:     cells,
+		})
+	}
+	if err := dbRows.Err(); err != nil {
+		return reportData{}, fmt.Errorf("iterar linhas merenda: %w", err)
+	}
+
+	sortReportOperacional(rows)
+
+	data := make([][]any, 0, len(rows))
+	for _, row := range rows {
+		data = append(data, row.Cells)
+	}
+
+	return reportData{
+		Title:       def.Title,
+		SheetName:   def.SheetName,
+		FiltersLine: f.describe(),
+		Headers:     merendaReportColumns,
+		Rows:        data,
+	}, nil
+}

--- a/api/cmd/api/reports_merenda_test.go
+++ b/api/cmd/api/reports_merenda_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+// TestReportsCatalogRecognizesMerenda garante que o relatório de Merenda está
+// registrado com os metadados esperados.
+func TestReportsCatalogRecognizesMerenda(t *testing.T) {
+	def, ok := lookupReport(reportMerendaCondicoesID)
+	if !ok {
+		t.Fatalf("lookupReport(%q) = not found", reportMerendaCondicoesID)
+	}
+	if def.Title != "Relatório de Condições da Merenda Escolar" {
+		t.Fatalf("Title = %q; inesperado", def.Title)
+	}
+	if def.SheetName != "Merenda Escolar" {
+		t.Fatalf("SheetName = %q; want %q", def.SheetName, "Merenda Escolar")
+	}
+	if def.FileBase != "relatorio_merenda_escolar_condicoes" {
+		t.Fatalf("FileBase = %q; inesperado", def.FileBase)
+	}
+}
+
+// TestMerendaReportColumns trava a ordem e o conteúdo das colunas.
+func TestMerendaReportColumns(t *testing.T) {
+	want := []string{
+		"Região de Integração", "DRE", "Município", "Zona", "Código INEP", "Escola",
+		"Oferta Regular", "Qualidade da Merenda", "Atende Necessidades", "Condições da Cozinha",
+		"Tamanho da Cozinha", "Possui Refeitório", "Refeitório Adequado", "Freezers",
+		"Geladeiras", "Fogões", "Bebedouros", "Despensa Exclusiva", "Depósito de Conserva",
+		"EPIs", "Extintores", "Manutenção Preventiva", "Status Operacional",
+	}
+	if len(merendaReportColumns) != len(want) {
+		t.Fatalf("len colunas = %d; want %d", len(merendaReportColumns), len(want))
+	}
+	for i := range want {
+		if merendaReportColumns[i] != want[i] {
+			t.Fatalf("coluna[%d] = %q; want %q", i, merendaReportColumns[i], want[i])
+		}
+	}
+	if merendaReportColumns[len(merendaReportColumns)-1] != "Status Operacional" {
+		t.Fatalf("última coluna deve ser Status Operacional")
+	}
+}
+
+// TestClassifyMerendaStatus cobre a tabela de classificação operacional.
+func TestClassifyMerendaStatus(t *testing.T) {
+	nf := func(v float64) sql.NullFloat64 { return sql.NullFloat64{Float64: v, Valid: true} }
+	base := merendaReportRow{
+		HasCensus:          true,
+		OfertaRegular:      "Sim",
+		QualidadeMerenda:   "Boa",
+		AtendeNecessidades: "Sim",
+		CondicoesCozinha:   "Boa",
+		RefeitorioAdequado: "Sim",
+		EstoqueEpiExtintor: "Completo",
+		QtdFreezers:        nf(1),
+		QtdGeladeiras:      nf(1),
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(r *merendaReportRow)
+		want   string
+	}{
+		{"sem censo", func(r *merendaReportRow) { r.HasCensus = false }, statusOperacionalSemDados},
+		{"adequado", func(r *merendaReportRow) {}, statusOperacionalAdequado},
+		{"critico sem oferta", func(r *merendaReportRow) { r.OfertaRegular = "Não" }, statusOperacionalCritico},
+		{"critico nao atende", func(r *merendaReportRow) { r.AtendeNecessidades = "Não" }, statusOperacionalCritico},
+		{"critico cozinha precaria", func(r *merendaReportRow) { r.CondicoesCozinha = "Precária" }, statusOperacionalCritico},
+		{"atencao oferta com falhas", func(r *merendaReportRow) { r.OfertaRegular = "Sim, com falhas" }, statusOperacionalAtencao},
+		{"atencao qualidade regular", func(r *merendaReportRow) { r.QualidadeMerenda = "Regular" }, statusOperacionalAtencao},
+		{"atencao qualidade ruim", func(r *merendaReportRow) { r.QualidadeMerenda = "Ruim" }, statusOperacionalAtencao},
+		{"atencao atende parcial", func(r *merendaReportRow) { r.AtendeNecessidades = "Parcialmente" }, statusOperacionalAtencao},
+		{"atencao cozinha regular", func(r *merendaReportRow) { r.CondicoesCozinha = "Regular" }, statusOperacionalAtencao},
+		{"atencao refeitorio inadequado", func(r *merendaReportRow) { r.RefeitorioAdequado = "Não" }, statusOperacionalAtencao},
+		{"atencao sem refrigeracao", func(r *merendaReportRow) { r.QtdFreezers = nf(0); r.QtdGeladeiras = nf(0) }, statusOperacionalAtencao},
+		{"atencao epi inexistente", func(r *merendaReportRow) { r.EstoqueEpiExtintor = "Inexistente" }, statusOperacionalAtencao},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := base
+			tt.mutate(&r)
+			if got := classifyMerendaStatus(r); got != tt.want {
+				t.Fatalf("classifyMerendaStatus = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyMerendaCriticoPrecedeAtencao garante a precedência de crítico.
+func TestClassifyMerendaCriticoPrecedeAtencao(t *testing.T) {
+	r := merendaReportRow{
+		HasCensus:        true,
+		OfertaRegular:    "Não",     // crítico
+		QualidadeMerenda: "Regular", // atenção
+	}
+	if got := classifyMerendaStatus(r); got != statusOperacionalCritico {
+		t.Fatalf("classifyMerendaStatus = %q; want Crítico", got)
+	}
+}
+
+// TestMerendaSemRefrigeracao garante que NULLs não disparam o sinal.
+func TestMerendaSemRefrigeracao(t *testing.T) {
+	nf := func(v float64) sql.NullFloat64 { return sql.NullFloat64{Float64: v, Valid: true} }
+	null := sql.NullFloat64{}
+
+	if merendaSemRefrigeracao(merendaReportRow{QtdFreezers: null, QtdGeladeiras: null}) {
+		t.Fatalf("NULL/NULL não deveria sinalizar sem refrigeração")
+	}
+	if merendaSemRefrigeracao(merendaReportRow{QtdFreezers: nf(0), QtdGeladeiras: null}) {
+		t.Fatalf("0/NULL não deveria sinalizar (geladeiras desconhecidas)")
+	}
+	if !merendaSemRefrigeracao(merendaReportRow{QtdFreezers: nf(0), QtdGeladeiras: nf(0)}) {
+		t.Fatalf("0/0 deveria sinalizar sem refrigeração")
+	}
+	if merendaSemRefrigeracao(merendaReportRow{QtdFreezers: nf(0), QtdGeladeiras: nf(2)}) {
+		t.Fatalf("0/2 não deveria sinalizar (há geladeiras)")
+	}
+}
+
+// TestWriteMerendaXLSX garante a geração do XLSX com a aba e colunas.
+func TestWriteMerendaXLSX(t *testing.T) {
+	rd := reportData{
+		Title:       "Relatório de Condições da Merenda Escolar",
+		SheetName:   "Merenda Escolar",
+		FiltersLine: "Filtros aplicados — Ano: 2026",
+		Headers:     merendaReportColumns,
+		Rows: [][]any{
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "12345678", "Escola Crítica",
+				"Não", "Ruim", "Não", "Precária", "Pequena", "Não", "Não informado",
+				0, 0, 1, 2, "Não", "Não", "Inexistente", "Inexistente", "Validade vencida",
+				statusOperacionalCritico},
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "87654321", "Escola Sem Dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				"Sem dados", "Sem dados", "Sem dados", statusOperacionalSemDados},
+		},
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		t.Fatalf("writeReportXLSX erro: %v", err)
+	}
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer erro: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("XLSX vazio")
+	}
+	if idx, err := f.GetSheetIndex("Merenda Escolar"); err != nil || idx < 0 {
+		t.Fatalf("aba 'Merenda Escolar' não encontrada (idx=%d, err=%v)", idx, err)
+	}
+	if v, err := f.GetCellValue("Merenda Escolar", "A4"); err != nil || v != "Região de Integração" {
+		t.Fatalf("A4 = %q (err=%v); want primeiro cabeçalho", v, err)
+	}
+	// Última coluna (W = 23ª) na linha 5 deve ser o status.
+	if v, err := f.GetCellValue("Merenda Escolar", "W5"); err != nil || v != statusOperacionalCritico {
+		t.Fatalf("W5 = %q (err=%v); want %q", v, err, statusOperacionalCritico)
+	}
+}
+
+// TestMerendaSelectSQLShape valida o formato da consulta.
+func TestMerendaSelectSQLShape(t *testing.T) {
+	q := merendaSelectSQL
+	mustContain := []string{
+		"FROM schools s",
+		"LEFT JOIN census_responses cr",
+		"cr.year = $1 AND cr.status = 'completed'",
+		"LEFT JOIN reg_integracao ri",
+		"(cr.id IS NOT NULL) AS has_censo",
+		"cr.data->>'oferta_regular'",
+		"cr.data->>'manutencao_extintores'",
+		"($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(q, frag) {
+			t.Fatalf("merendaSelectSQL não contém %q", frag)
+		}
+	}
+	if strings.Contains(q, "INNER JOIN") {
+		t.Fatalf("query não pode usar INNER JOIN (excluiria escolas sem dados)")
+	}
+}


### PR DESCRIPTION
## Resumo

Adiciona dois novos relatórios gerenciais backend em XLSX:

* `infraestrutura-seguranca-escolas`
* `merenda-escolar-condicoes`

Esses relatórios ampliam a camada de relatórios gerenciais já criada, permitindo exportação nominal de escolas por dimensão operacional.

## Relatórios adicionados

### `infraestrutura-seguranca-escolas`

Relatório de Infraestrutura, Energia e Segurança Escolar.

Inclui informações como:

* tipo de prédio;
* situação da estrutura;
* rede elétrica;
* energia;
* estrutura para climatização;
* salas climatizadas e não climatizadas;
* guarita;
* botão de pânico;
* câmeras;
* controle de portão;
* iluminação externa;
* muro/cerca;
* plano de evacuação;
* política contra bullying;
* status operacional.

### `merenda-escolar-condicoes`

Relatório de Condições da Merenda Escolar.

Inclui informações como:

* oferta regular;
* qualidade da merenda;
* atendimento das necessidades;
* condições da cozinha;
* tamanho da cozinha;
* refeitório;
* freezers;
* geladeiras;
* fogões;
* bebedouros;
* despensa exclusiva;
* depósito de conserva;
* EPIs;
* extintores;
* manutenção preventiva;
* status operacional.

## Escopo

* Adiciona os dois relatórios ao catálogo;
* Exporta todas as escolas do recorte, sem paginação;
* Parte de `schools s` com `LEFT JOIN census_responses`;
* Inclui escolas sem censo concluído como `Sem dados`;
* Respeita filtros globais;
* Classifica status operacional simples para priorização;
* Ordena por prioridade operacional: `Crítico`, `Atenção`, `Adequado`, `Sem dados`;
* Reaproveita o gerador XLSX genérico já existente.

## Status operacional

Os relatórios usam uma classificação simples e defensiva:

* `Crítico`;
* `Atenção`;
* `Adequado`;
* `Sem dados`.

A classificação é feita em Go, testada e documentada no código.

## Observação sobre Merenda

O censo registra EPIs e extintores no campo combinado:

```text
estoque_epi_extintor
```

Por isso, nesta primeira versão, as colunas `EPIs` e `Extintores` refletem esse mesmo campo. A coluna `Manutenção Preventiva` usa `manutencao_extintores`.

## Validação

Executado com sucesso:

```bash
cd api
go test -count=1 ./...
go vet ./...
go build ./cmd/api/...
```

## Fora de escopo

* Frontend;
* PDF;
* Cache;
* Migrations;
* Google Sheets;
* Alteração de Saúde Operacional;
* Alteração de Pedagógico;
* Alteração de Governança;
* Alteração de endpoints analíticos existentes;
* Alteração de timeout;
* Alteração de prefetch.