### PR TITLE
Feat/admin report buttons

### DIFF
--- a/api/cmd/api/analytics_saude_operacional.go
+++ b/api/cmd/api/analytics_saude_operacional.go
@@ -1108,6 +1108,102 @@ func buildSaudeOperacionalQuery(year int, f saudeOperacionalFilters) (string, []
 	}
 }
 
+// saudeOperacionalDatasetTimings carrega a medição por etapa do carregamento
+// base da Saúde Operacional (pedagógico, query e iteração/cálculo). Permite que
+// o handler analítico preserve o log de performance existente mesmo após a
+// extração de buildSaudeOperacionalDataset.
+type saudeOperacionalDatasetTimings struct {
+	PedagogicoMs  int64
+	QueryMs       int64
+	IterateCalcMs int64
+	CalcMs        int64
+}
+
+// buildSaudeOperacionalDataset concentra o carregamento e o cálculo base de
+// TODAS as escolas do recorte (filtros globais) para um dado ano de censo,
+// devolvendo as escolas já pontuadas (saúde, criticidade, status e dimensões) e
+// a medição por etapa. NÃO filtra por busca, não ordena e não pagina — essas
+// responsabilidades permanecem em quem consome o dataset:
+//   - o endpoint analítico aplica busca/ordenação/paginação para a tela;
+//   - o relatório gerencial exporta todas as escolas do recorte.
+//
+// Mantém a instrumentação de erro por etapa (saude_operacional_perf_error) e a
+// regra de cálculo das dimensões intacta — a lógica de pontuação não é
+// duplicada em nenhum dos consumidores.
+func (app *application) buildSaudeOperacionalDataset(
+	ctx context.Context,
+	year int,
+	filters saudeOperacionalFilters,
+) ([]SaudeOperacionalEscola, saudeOperacionalDatasetTimings, error) {
+	var timings saudeOperacionalDatasetTimings
+
+	// Nota Pedagógico (IDEB) por escola, do último ano disponível em
+	// ideb_resultados. Independe do ano do censo: é o resultado oficial mais
+	// recente aplicado a cada escola pontuada.
+	pedStart := time.Now()
+	pedagogicoPorEscola, err := app.loadPedagogicoPorEscola(ctx)
+	if err != nil {
+		app.logger.Printf("saude_operacional_perf_error: stage=load_pedagogico elapsed_ms=%d error=%q",
+			time.Since(pedStart).Milliseconds(), err.Error())
+		return nil, timings, err
+	}
+	timings.PedagogicoMs = time.Since(pedStart).Milliseconds()
+
+	query, args := buildSaudeOperacionalQuery(year, filters)
+
+	queryStart := time.Now()
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		app.logger.Printf("saude_operacional_perf_error: stage=query elapsed_ms=%d error=%q",
+			time.Since(queryStart).Milliseconds(), err.Error())
+		return nil, timings, fmt.Errorf("consultar saúde operacional das escolas: %v", err)
+	}
+	defer dbRows.Close()
+	timings.QueryMs = time.Since(queryStart).Milliseconds()
+
+	// iterateStart cobre todo o loop (scan + build). calcDuration acumula apenas o
+	// tempo de buildSaudeOperacionalEscola (decode JSONB + cálculo das dimensões),
+	// permitindo separar "iteração das linhas" de "decode/cálculo".
+	iterateStart := time.Now()
+	var calcDuration time.Duration
+	allEscolas := make([]SaudeOperacionalEscola, 0)
+	for dbRows.Next() {
+		var row saudeOperacionalDBRow
+		if err := dbRows.Scan(
+			&row.SchoolID,
+			&row.CodigoINEP,
+			&row.Escola,
+			&row.Municipio,
+			&row.DRE,
+			&row.Zona,
+			&row.CensusID,
+			&row.Data,
+		); err != nil {
+			app.logger.Printf("saude_operacional_perf_error: stage=scan elapsed_ms=%d error=%q",
+				time.Since(iterateStart).Milliseconds(), err.Error())
+			return nil, timings, fmt.Errorf("ler escola da saúde operacional: %v", err)
+		}
+		calcStart := time.Now()
+		escola, err := buildSaudeOperacionalEscola(row, pedagogicoPorEscola[row.SchoolID])
+		calcDuration += time.Since(calcStart)
+		if err != nil {
+			app.logger.Printf("saude_operacional_perf_error: stage=build_escola elapsed_ms=%d error=%q",
+				time.Since(iterateStart).Milliseconds(), err.Error())
+			return nil, timings, err
+		}
+		allEscolas = append(allEscolas, escola)
+	}
+	if err := dbRows.Err(); err != nil {
+		app.logger.Printf("saude_operacional_perf_error: stage=rows_err elapsed_ms=%d error=%q",
+			time.Since(iterateStart).Milliseconds(), err.Error())
+		return nil, timings, fmt.Errorf("iterar escolas da saúde operacional: %v", err)
+	}
+	timings.IterateCalcMs = time.Since(iterateStart).Milliseconds()
+	timings.CalcMs = calcDuration.Milliseconds()
+
+	return allEscolas, timings, nil
+}
+
 // AdminAnalyticsSaudeOperacionalEscolas retorna escolas com índice de saúde operacional.
 // Parâmetros opcionais: year, page, page_size, search, sort, direction.
 // Filtros globais opcionais: dre, municipio, zona, regiao_integracao.
@@ -1160,11 +1256,10 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 	}
 
 	filters := parseSaudeOperacionalFilters(q)
-	query, args := buildSaudeOperacionalQuery(year, filters)
 
-	// parseMs cobre todo o parse/validação dos parâmetros e a montagem da query
-	// (etapas acima). has_* registram apenas presença/ausência dos filtros — nunca
-	// os valores em si, para não vazar termos de busca/dados nos logs.
+	// parseMs cobre todo o parse/validação dos parâmetros (etapas acima). has_*
+	// registram apenas presença/ausência dos filtros — nunca os valores em si,
+	// para não vazar termos de busca/dados nos logs.
 	parseMs := time.Since(routeStart).Milliseconds()
 	hasSearch := strings.TrimSpace(searchQuery) != ""
 	hasDRE := filters.DRE != ""
@@ -1172,72 +1267,18 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 	hasZona := filters.Zona != ""
 	hasRegiao := filters.RegiaoIntegracao != ""
 
-	// Nota Pedagógico (IDEB) por escola, do último ano disponível em
-	// ideb_resultados. Independe do ano do censo: é o resultado oficial mais
-	// recente aplicado a cada escola pontuada.
-	pedStart := time.Now()
-	pedagogicoPorEscola, err := app.loadPedagogicoPorEscola(r.Context())
+	// Carregamento e cálculo base de todas as escolas do recorte. A função
+	// reaproveitável também alimenta o relatório gerencial de Saúde Operacional;
+	// o handler segue responsável por busca, ordenação e paginação.
+	allEscolas, timings, err := app.buildSaudeOperacionalDataset(r.Context(), year, filters)
 	if err != nil {
-		app.logger.Printf("saude_operacional_perf_error: stage=load_pedagogico elapsed_ms=%d error=%q",
-			time.Since(pedStart).Milliseconds(), err.Error())
 		app.errorJSON(w, err, http.StatusInternalServerError)
 		return
 	}
-	pedagogicoMs := time.Since(pedStart).Milliseconds()
-
-	queryStart := time.Now()
-	dbRows, err := app.models.Schools.DB.QueryContext(r.Context(), query, args...)
-	if err != nil {
-		app.logger.Printf("saude_operacional_perf_error: stage=query elapsed_ms=%d error=%q",
-			time.Since(queryStart).Milliseconds(), err.Error())
-		app.errorJSON(w, fmt.Errorf("consultar saúde operacional das escolas: %v", err), http.StatusInternalServerError)
-		return
-	}
-	defer dbRows.Close()
-	queryMs := time.Since(queryStart).Milliseconds()
-
-	// iterateStart cobre todo o loop (scan + build). calcDuration acumula apenas o
-	// tempo de buildSaudeOperacionalEscola (decode JSONB + cálculo das dimensões),
-	// permitindo separar "iteração das linhas" de "decode/cálculo".
-	iterateStart := time.Now()
-	var calcDuration time.Duration
-	allEscolas := make([]SaudeOperacionalEscola, 0)
-	for dbRows.Next() {
-		var row saudeOperacionalDBRow
-		if err := dbRows.Scan(
-			&row.SchoolID,
-			&row.CodigoINEP,
-			&row.Escola,
-			&row.Municipio,
-			&row.DRE,
-			&row.Zona,
-			&row.CensusID,
-			&row.Data,
-		); err != nil {
-			app.logger.Printf("saude_operacional_perf_error: stage=scan elapsed_ms=%d error=%q",
-				time.Since(iterateStart).Milliseconds(), err.Error())
-			app.errorJSON(w, fmt.Errorf("ler escola da saúde operacional: %v", err), http.StatusInternalServerError)
-			return
-		}
-		calcStart := time.Now()
-		escola, err := buildSaudeOperacionalEscola(row, pedagogicoPorEscola[row.SchoolID])
-		calcDuration += time.Since(calcStart)
-		if err != nil {
-			app.logger.Printf("saude_operacional_perf_error: stage=build_escola elapsed_ms=%d error=%q",
-				time.Since(iterateStart).Milliseconds(), err.Error())
-			app.errorJSON(w, err, http.StatusInternalServerError)
-			return
-		}
-		allEscolas = append(allEscolas, escola)
-	}
-	if err := dbRows.Err(); err != nil {
-		app.logger.Printf("saude_operacional_perf_error: stage=rows_err elapsed_ms=%d error=%q",
-			time.Since(iterateStart).Milliseconds(), err.Error())
-		app.errorJSON(w, fmt.Errorf("iterar escolas da saúde operacional: %v", err), http.StatusInternalServerError)
-		return
-	}
-	iterateCalcMs := time.Since(iterateStart).Milliseconds()
-	calcMs := calcDuration.Milliseconds()
+	pedagogicoMs := timings.PedagogicoMs
+	queryMs := timings.QueryMs
+	iterateCalcMs := timings.IterateCalcMs
+	calcMs := timings.CalcMs
 
 	paginateStart := time.Now()
 	pageSlice, resumo, totalFiltrado, totalPages, page := buildSaudeOperacionalPage(

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -380,6 +380,10 @@ func (app *application) routes() http.Handler {
 
 			// Filtros globais do dashboard.
 			protected.Get("/admin/analytics/filtros/opcoes", app.AdminAnalyticsFiltrosOpcoes)
+
+			// Relatórios gerenciais por aba (XLSX). Camada extensível; o
+			// report_id é resolvido contra reportsCatalog.
+			protected.Get("/admin/reports/{report_id}", app.AdminGetReport)
 		})
 	})
 

--- a/api/cmd/api/reports.go
+++ b/api/cmd/api/reports.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -170,6 +171,12 @@ func (app *application) AdminGetReport(w http.ResponseWriter, r *http.Request) {
 	switch def.ID {
 	case reportCensoPreenchimentoID:
 		rd, err = app.buildCensoPreenchimentoReportData(r.Context(), def, filters)
+	case reportSaudeOperacionalID:
+		// Saúde Operacional depende de um ano de censo específico. Resolve o ano
+		// antes de gerar dados e nome do arquivo, para que ambos reflitam o ano
+		// efetivamente usado (e não "todos os anos").
+		filters.Year = resolveSaudeOperacionalReportYear(filters, time.Now())
+		rd, err = app.buildSaudeOperacionalReportData(r.Context(), def, filters)
 	default:
 		// Catálogo e dispatch desalinhados: defensivo.
 		app.errorJSON(w, fmt.Errorf("relatório %q sem implementação", def.ID), http.StatusNotFound)

--- a/api/cmd/api/reports.go
+++ b/api/cmd/api/reports.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// =====================================================================
+// Relatórios gerenciais — handler HTTP e relatório piloto
+// =====================================================================
+// Rota: GET /v1/admin/reports/{report_id} (protegida por requireAdminAuth).
+// Respostas:
+//   - 401: token ausente/inválido (tratado pelo middleware).
+//   - 404: report_id não consta no catálogo.
+//   - 400: format diferente de xlsx.
+//   - 500: erro interno (consulta/geração).
+//   - 200: arquivo XLSX como anexo.
+//
+// Esta camada é independente dos endpoints analíticos: não altera
+// consultas, views nem cálculos existentes. Reaproveita apenas o padrão
+// de filtros globais (year, dre, municipio, zona, regiao_integracao).
+// =====================================================================
+
+// reportFormatXLSX é o único formato suportado nesta fase.
+const reportFormatXLSX = "xlsx"
+
+// reportFilters reúne os filtros globais aplicáveis ao relatório. Difere
+// de AnalyticsFilters num ponto importante: year ausente/ inválido
+// significa "todos os anos" (Year = 0), e não o ano corrente — um
+// relatório de acompanhamento deve poder consolidar o histórico.
+type reportFilters struct {
+	Year             int // 0 = todos os anos
+	DRE              string
+	Municipio        string
+	Zona             string
+	RegiaoIntegracao string
+}
+
+// parseReportFilters lê os filtros da query string, removendo espaços. Um
+// year ausente, em branco, não numérico, zero ou negativo desativa o
+// filtro de ano (Year = 0).
+func parseReportFilters(q url.Values) reportFilters {
+	f := reportFilters{
+		DRE:              strings.TrimSpace(q.Get("dre")),
+		Municipio:        strings.TrimSpace(q.Get("municipio")),
+		Zona:             strings.TrimSpace(q.Get("zona")),
+		RegiaoIntegracao: strings.TrimSpace(q.Get("regiao_integracao")),
+	}
+	if y, err := strconv.Atoi(strings.TrimSpace(q.Get("year"))); err == nil && y > 0 {
+		f.Year = y
+	}
+	return f
+}
+
+// args devolve os argumentos posicionais na ordem usada pelas consultas de
+// relatório: $1=year (0 = sem filtro), $2=dre, $3=municipio, $4=zona,
+// $5=regiao_integracao.
+func (f reportFilters) args() []any {
+	return []any{f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao}
+}
+
+// describe monta a linha 2 do XLSX ("Filtros aplicados — ..."). Sempre
+// informa o recorte de ano; filtros territoriais só aparecem quando ativos.
+func (f reportFilters) describe() string {
+	parts := make([]string, 0, 5)
+	if f.Year > 0 {
+		parts = append(parts, "Ano: "+strconv.Itoa(f.Year))
+	} else {
+		parts = append(parts, "Ano: todos")
+	}
+	if f.RegiaoIntegracao != "" {
+		parts = append(parts, "Região de Integração: "+f.RegiaoIntegracao)
+	}
+	if f.DRE != "" {
+		parts = append(parts, "DRE: "+f.DRE)
+	}
+	if f.Municipio != "" {
+		parts = append(parts, "Município: "+f.Municipio)
+	}
+	if f.Zona != "" {
+		parts = append(parts, "Zona: "+f.Zona)
+	}
+	return "Filtros aplicados — " + strings.Join(parts, " | ")
+}
+
+// normalizeReportFormat aplica o default xlsx quando o parâmetro está
+// ausente e normaliza caixa/espaços para a validação.
+func normalizeReportFormat(raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return reportFormatXLSX
+	}
+	return raw
+}
+
+// censoStatusLabel classifica o status gerencial de uma escola a partir do
+// status técnico do censo (hasCensus=false quando não há resposta) e do
+// estado de sincronização com a planilha. Espelha a tabela documentada na
+// especificação:
+//
+//	sem resposta                                   -> Pendente
+//	draft                                          -> Rascunho
+//	completed + sheet_synced_at IS NULL            -> Pendente de Sincronização
+//	completed + sheet_synced_at IS NOT NULL        -> Concluído
+//	qualquer outro                                 -> Verificar
+func censoStatusLabel(status string, hasCensus, synced bool) string {
+	if !hasCensus {
+		return "Pendente"
+	}
+	switch status {
+	case "draft":
+		return "Rascunho"
+	case "completed":
+		if synced {
+			return "Concluído"
+		}
+		return "Pendente de Sincronização"
+	default:
+		return "Verificar"
+	}
+}
+
+// situacaoOperacional é a coluna complementar "Situação Operacional".
+// Inicialmente deriva do status gerencial, traduzindo-o para uma frase de
+// leitura operacional pelas DREs (documentado em código, conforme a spec).
+func situacaoOperacional(statusLabel string) string {
+	switch statusLabel {
+	case "Pendente":
+		return "Aguardando preenchimento"
+	case "Rascunho":
+		return "Preenchimento em andamento"
+	case "Pendente de Sincronização":
+		return "Concluído, aguardando sincronização"
+	case "Concluído":
+		return "Concluído e sincronizado"
+	default:
+		return "Verificar manualmente"
+	}
+}
+
+// AdminGetReport é o handler da rota GET /v1/admin/reports/{report_id}.
+func (app *application) AdminGetReport(w http.ResponseWriter, r *http.Request) {
+	reportID := strings.TrimSpace(chi.URLParam(r, "report_id"))
+
+	def, ok := lookupReport(reportID)
+	if !ok {
+		app.errorJSON(w, fmt.Errorf("relatório %q não encontrado", reportID), http.StatusNotFound)
+		return
+	}
+
+	format := normalizeReportFormat(r.URL.Query().Get("format"))
+	if format != reportFormatXLSX {
+		app.errorJSON(w, fmt.Errorf("formato %q não suportado; use format=xlsx", format), http.StatusBadRequest)
+		return
+	}
+
+	filters := parseReportFilters(r.URL.Query())
+
+	var (
+		rd  reportData
+		err error
+	)
+	switch def.ID {
+	case reportCensoPreenchimentoID:
+		rd, err = app.buildCensoPreenchimentoReportData(r.Context(), def, filters)
+	default:
+		// Catálogo e dispatch desalinhados: defensivo.
+		app.errorJSON(w, fmt.Errorf("relatório %q sem implementação", def.ID), http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		app.logger.Printf("AdminGetReport %s: %v", def.ID, err)
+		app.errorJSON(w, fmt.Errorf("erro ao gerar relatório"), http.StatusInternalServerError)
+		return
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		app.logger.Printf("AdminGetReport %s: gerar xlsx: %v", def.ID, err)
+		app.errorJSON(w, fmt.Errorf("erro ao gerar arquivo"), http.StatusInternalServerError)
+		return
+	}
+
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		app.logger.Printf("AdminGetReport %s: serializar xlsx: %v", def.ID, err)
+		app.errorJSON(w, fmt.Errorf("erro ao gerar arquivo"), http.StatusInternalServerError)
+		return
+	}
+
+	filename := buildReportFileName(def.FileBase, filters)
+	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		app.logger.Printf("AdminGetReport %s: escrever resposta: %v", def.ID, err)
+	}
+}
+
+// censoPreenchimentoReportColumns são os cabeçalhos do relatório piloto, na
+// ordem exigida pela especificação (colunas territoriais comuns seguidas
+// dos campos de acompanhamento).
+var censoPreenchimentoReportColumns = []string{
+	"Região de Integração",
+	"DRE",
+	"Município",
+	"Zona",
+	"Código INEP",
+	"Escola",
+	"Status do Censo",
+	"Ano",
+	"Última Atualização",
+	"Sincronizado com Planilha",
+	"Data de Sincronização",
+	"Situação Operacional",
+}
+
+// censoPreenchimentoSelectSQL parte de schools s com LEFT JOIN na resposta
+// de censo mais recente (CTE latest_census) para que escolas sem resposta
+// permaneçam no recorte e apareçam como pendentes. A Região de Integração
+// vem de um LEFT JOIN em reg_integracao (mesma grafia por município usada
+// nos demais endpoints). NÃO reutiliza censusListSelectSQL/AnalyticsFilters,
+// que fazem JOIN obrigatório com census_responses e excluiriam pendentes.
+//
+// Ano: $1 = 0 considera todas as respostas (pega a mais recente por escola);
+// $1 > 0 restringe à resposta daquele ano. Demais filtros incidem sobre
+// schools s com UPPER(TRIM(...)) para tolerar caixa e espaços.
+//
+// A ordenação segue a prioridade gerencial (Pendente, Rascunho, Pendente de
+// Sincronização, Concluído, Verificar) e depois DRE, Município, Escola, INEP.
+const censoPreenchimentoSelectSQL = `
+	WITH latest_census AS (
+		SELECT DISTINCT ON (school_id)
+			school_id, status, year, updated_at, sheet_synced_at
+		FROM census_responses
+		WHERE ($1 = 0 OR year = $1)
+		ORDER BY school_id, updated_at DESC, id DESC
+	)
+	SELECT
+		COALESCE(ri.regiao_de_integracao, '') AS regiao_integracao,
+		COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre,
+		COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio,
+		COALESCE(NULLIF(TRIM(s.zona), ''), '') AS zona,
+		COALESCE(s.codigo_inep, '') AS codigo_inep,
+		COALESCE(NULLIF(TRIM(s.nome_escola), ''), 'Sem nome') AS nome_escola,
+		cr.status,
+		cr.year,
+		cr.updated_at,
+		(cr.sheet_synced_at IS NOT NULL) AS synced,
+		cr.sheet_synced_at
+	FROM schools s
+	LEFT JOIN latest_census cr ON cr.school_id = s.id
+	LEFT JOIN reg_integracao ri ON UPPER(TRIM(ri.municipio)) = UPPER(TRIM(s.municipio))
+	WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))
+	ORDER BY
+		CASE
+			WHEN cr.status IS NULL THEN 1
+			WHEN cr.status = 'draft' THEN 2
+			WHEN cr.status = 'completed' AND cr.sheet_synced_at IS NULL THEN 3
+			WHEN cr.status = 'completed' AND cr.sheet_synced_at IS NOT NULL THEN 4
+			ELSE 5
+		END,
+		UPPER(TRIM(s.dre)),
+		UPPER(TRIM(s.municipio)),
+		UPPER(TRIM(s.nome_escola)),
+		s.codigo_inep
+`
+
+// reportDateLayout é o formato pt-BR usado para datas no XLSX.
+const reportDateLayout = "02/01/2006 15:04"
+
+// buildCensoPreenchimentoReportData executa a consulta do relatório piloto
+// e monta o reportData (sem paginar). Datas chegam formatadas em pt-BR; o
+// ano vem como inteiro quando há resposta, ou célula vazia quando pendente.
+func (app *application) buildCensoPreenchimentoReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
+	rows, err := app.models.Schools.DB.QueryContext(ctx, censoPreenchimentoSelectSQL, f.args()...)
+	if err != nil {
+		return reportData{}, fmt.Errorf("consultar preenchimento: %w", err)
+	}
+	defer rows.Close()
+
+	data := make([][]any, 0)
+	for rows.Next() {
+		var (
+			regiao, dre, municipio, zona, inep, escola string
+			status                                     sql.NullString
+			year                                       sql.NullInt64
+			updatedAt, syncedAt                        sql.NullTime
+			synced                                     bool
+		)
+		if err := rows.Scan(&regiao, &dre, &municipio, &zona, &inep, &escola,
+			&status, &year, &updatedAt, &synced, &syncedAt); err != nil {
+			return reportData{}, fmt.Errorf("ler linha: %w", err)
+		}
+
+		label := censoStatusLabel(status.String, status.Valid, synced)
+
+		anoCell := any("")
+		if year.Valid {
+			anoCell = int(year.Int64)
+		}
+		updatedCell := ""
+		if updatedAt.Valid {
+			updatedCell = updatedAt.Time.Format(reportDateLayout)
+		}
+		syncedCell := "Não"
+		if synced {
+			syncedCell = "Sim"
+		}
+		syncDateCell := ""
+		if syncedAt.Valid {
+			syncDateCell = syncedAt.Time.Format(reportDateLayout)
+		}
+
+		data = append(data, []any{
+			regiao,
+			dre,
+			municipio,
+			zona,
+			inep,
+			escola,
+			label,
+			anoCell,
+			updatedCell,
+			syncedCell,
+			syncDateCell,
+			situacaoOperacional(label),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return reportData{}, fmt.Errorf("iterar linhas: %w", err)
+	}
+
+	return reportData{
+		Title:       def.Title,
+		SheetName:   def.SheetName,
+		FiltersLine: f.describe(),
+		Headers:     censoPreenchimentoReportColumns,
+		Rows:        data,
+	}, nil
+}

--- a/api/cmd/api/reports.go
+++ b/api/cmd/api/reports.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -89,6 +90,114 @@ func (f reportFilters) describe() string {
 		parts = append(parts, "Zona: "+f.Zona)
 	}
 	return "Filtros aplicados — " + strings.Join(parts, " | ")
+}
+
+// resolveReportYearDefault resolve o ano de relatórios que dependem de respostas
+// de censo (Infraestrutura/Segurança, Merenda, ...). Diferente do relatório
+// piloto (Year = 0 ⇒ todos os anos), estes relatórios exigem um ano específico:
+// quando o filtro de ano está ausente ou inválido (Year = 0), usa o ano padrão
+// do dashboard (ano corrente), o mesmo critério da Saúde Operacional. Em
+// 2026-06-15 o ano corrente é 2026, conforme esperado pela especificação.
+func resolveReportYearDefault(f reportFilters, now time.Time) int {
+	if f.Year > 0 {
+		return f.Year
+	}
+	return now.Year()
+}
+
+// statusOperacionalPriority define a ordem de prioridade operacional usada por
+// relatórios temáticos (Infraestrutura/Segurança, Merenda): Crítico primeiro,
+// depois Atenção, Adequado e, por fim, escolas Sem dados.
+var statusOperacionalPriority = map[string]int{
+	statusOperacionalCritico:  0,
+	statusOperacionalAtencao:  1,
+	statusOperacionalAdequado: 2,
+	statusOperacionalSemDados: 3,
+}
+
+// Rótulos canônicos do Status Operacional dos relatórios temáticos.
+const (
+	statusOperacionalSemDados = "Sem dados"
+	statusOperacionalCritico  = "Crítico"
+	statusOperacionalAtencao  = "Atenção"
+	statusOperacionalAdequado = "Adequado"
+)
+
+// statusOperacionalRank devolve o peso de ordenação de um Status Operacional.
+// Um status desconhecido é jogado para o final (após "Sem dados").
+func statusOperacionalRank(status string) int {
+	if r, ok := statusOperacionalPriority[status]; ok {
+		return r
+	}
+	return len(statusOperacionalPriority)
+}
+
+// reportOperacionalRow é a linha intermediária dos relatórios temáticos: guarda
+// as chaves de ordenação (status + território) e a projeção final das células.
+type reportOperacionalRow struct {
+	Status    string
+	DRE       string
+	Municipio string
+	Escola    string
+	INEP      string
+	Cells     []any
+}
+
+// sortReportOperacional ordena, de forma estável e determinística, as linhas
+// de um relatório temático por prioridade operacional (Crítico, Atenção,
+// Adequado, Sem dados) e, em seguida, por DRE, Município, Escola e Código INEP
+// (comparação insensível a caixa e acento).
+func sortReportOperacional(rows []reportOperacionalRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if ra, rb := statusOperacionalRank(a.Status), statusOperacionalRank(b.Status); ra != rb {
+			return ra < rb
+		}
+		if c := strings.Compare(normalizeSaudeSearch(a.DRE), normalizeSaudeSearch(b.DRE)); c != 0 {
+			return c < 0
+		}
+		if c := strings.Compare(normalizeSaudeSearch(a.Municipio), normalizeSaudeSearch(b.Municipio)); c != 0 {
+			return c < 0
+		}
+		if c := strings.Compare(normalizeSaudeSearch(a.Escola), normalizeSaudeSearch(b.Escola)); c != 0 {
+			return c < 0
+		}
+		return a.INEP < b.INEP
+	})
+}
+
+// reportTextCell projeta uma célula textual de relatório temático: "Sem dados"
+// quando a escola não tem censo concluído no ano, "Não informado" quando o
+// campo está vazio, e o próprio valor caso contrário.
+func reportTextCell(hasCensus bool, v string) any {
+	if !hasCensus {
+		return statusOperacionalSemDados
+	}
+	if strings.TrimSpace(v) == "" {
+		return "Não informado"
+	}
+	return v
+}
+
+// reportSemDadosOr força "Sem dados" quando não há censo; caso contrário,
+// devolve o valor já derivado (que pode incluir "Não informado").
+func reportSemDadosOr(hasCensus bool, v string) any {
+	if !hasCensus {
+		return statusOperacionalSemDados
+	}
+	return v
+}
+
+// reportIntCell projeta uma quantidade inteira opcional: "Sem dados" sem censo,
+// "Não informado" quando ausente, e o inteiro caso contrário.
+func reportIntCell(hasCensus bool, v sql.NullFloat64) any {
+	if !hasCensus {
+		return statusOperacionalSemDados
+	}
+	if !v.Valid {
+		return "Não informado"
+	}
+	return int(v.Float64)
 }
 
 // normalizeReportFormat aplica o default xlsx quando o parâmetro está
@@ -177,6 +286,16 @@ func (app *application) AdminGetReport(w http.ResponseWriter, r *http.Request) {
 		// efetivamente usado (e não "todos os anos").
 		filters.Year = resolveSaudeOperacionalReportYear(filters, time.Now())
 		rd, err = app.buildSaudeOperacionalReportData(r.Context(), def, filters)
+	case reportInfraestruturaSegurancaID:
+		// Depende de um ano de censo específico: resolve antes de gerar dados e
+		// nome do arquivo, para que ambos reflitam o ano usado (não "todos").
+		filters.Year = resolveReportYearDefault(filters, time.Now())
+		rd, err = app.buildInfraestruturaReportData(r.Context(), def, filters)
+	case reportMerendaCondicoesID:
+		// Depende de um ano de censo específico: resolve antes de gerar dados e
+		// nome do arquivo, para que ambos reflitam o ano usado (não "todos").
+		filters.Year = resolveReportYearDefault(filters, time.Now())
+		rd, err = app.buildMerendaReportData(r.Context(), def, filters)
 	default:
 		// Catálogo e dispatch desalinhados: defensivo.
 		app.errorJSON(w, fmt.Errorf("relatório %q sem implementação", def.ID), http.StatusNotFound)

--- a/api/cmd/api/reports_catalog.go
+++ b/api/cmd/api/reports_catalog.go
@@ -1,0 +1,52 @@
+package main
+
+// =====================================================================
+// Catálogo de relatórios gerenciais por aba
+// =====================================================================
+// Camada extensível: cada relatório exportável é descrito por uma
+// ReportDefinition e registrado em reportsCatalog. A rota
+// GET /v1/admin/reports/{report_id} resolve o report_id contra este
+// catálogo (404 quando não existe) e o handler dispara o builder
+// específico do relatório.
+//
+// Nesta primeira fase só existe o relatório piloto
+// "censo-preenchimento-escolas". Novos relatórios (saúde operacional,
+// infraestrutura, merenda, tecnologia, ...) devem ser adicionados aqui
+// com seu próprio builder no handler, sem alterar a rota nem o gerador
+// XLSX genérico.
+// =====================================================================
+
+// reportCensoPreenchimentoID é o identificador do relatório piloto de
+// acompanhamento do preenchimento do censo.
+const reportCensoPreenchimentoID = "censo-preenchimento-escolas"
+
+// ReportDefinition descreve os metadados de um relatório gerencial. Os
+// campos são suficientes para montar o cabeçalho do XLSX (Title), nomear
+// a aba (SheetName) e derivar o nome do arquivo (FileBase). A consulta e
+// a montagem das linhas ficam no builder específico de cada relatório,
+// mantendo o catálogo livre de dependências de banco e de excelize.
+type ReportDefinition struct {
+	ID          string
+	Title       string
+	Description string
+	SheetName   string
+	FileBase    string
+}
+
+// reportsCatalog é o registro de relatórios disponíveis, indexado por ID.
+var reportsCatalog = map[string]ReportDefinition{
+	reportCensoPreenchimentoID: {
+		ID:          reportCensoPreenchimentoID,
+		Title:       "Relatório de Acompanhamento do Preenchimento do Censo",
+		Description: "Acompanhamento nominal do preenchimento do censo por escola, incluindo escolas ainda pendentes.",
+		SheetName:   "Preenchimento Censo",
+		FileBase:    "relatorio_censo_preenchimento_escolas",
+	},
+}
+
+// lookupReport devolve a definição do relatório e um booleano indicando
+// se ela existe no catálogo.
+func lookupReport(id string) (ReportDefinition, bool) {
+	def, ok := reportsCatalog[id]
+	return def, ok
+}

--- a/api/cmd/api/reports_catalog.go
+++ b/api/cmd/api/reports_catalog.go
@@ -26,6 +26,18 @@ const reportCensoPreenchimentoID = "censo-preenchimento-escolas"
 // aba "Saúde Operacional".
 const reportSaudeOperacionalID = "saude-operacional-escolas"
 
+// reportInfraestruturaSegurancaID é o identificador do relatório de
+// Infraestrutura, Energia e Segurança Escolar, que exporta todas as escolas do
+// recorte com os campos de prédio, energia e segurança e um Status Operacional
+// simples para priorização. Depende de um ano de censo específico.
+const reportInfraestruturaSegurancaID = "infraestrutura-seguranca-escolas"
+
+// reportMerendaCondicoesID é o identificador do relatório de Condições da
+// Merenda Escolar, que exporta todas as escolas do recorte com oferta,
+// qualidade, condições da cozinha, equipamentos e um Status Operacional simples
+// para priorização. Depende de um ano de censo específico.
+const reportMerendaCondicoesID = "merenda-escolar-condicoes"
+
 // ReportDefinition descreve os metadados de um relatório gerencial. Os
 // campos são suficientes para montar o cabeçalho do XLSX (Title), nomear
 // a aba (SheetName) e derivar o nome do arquivo (FileBase). A consulta e
@@ -54,6 +66,20 @@ var reportsCatalog = map[string]ReportDefinition{
 		Description: "Índice de Saúde Operacional por escola, com criticidade, status e notas por dimensão, para todas as escolas do recorte.",
 		SheetName:   "Saude Operacional",
 		FileBase:    "relatorio_saude_operacional_escolas",
+	},
+	reportInfraestruturaSegurancaID: {
+		ID:          reportInfraestruturaSegurancaID,
+		Title:       "Relatório de Infraestrutura, Energia e Segurança Escolar",
+		Description: "Infraestrutura, energia e segurança por escola, com Status Operacional simples para priorização, para todas as escolas do recorte.",
+		SheetName:   "Infra Segurança",
+		FileBase:    "relatorio_infraestrutura_seguranca_escolas",
+	},
+	reportMerendaCondicoesID: {
+		ID:          reportMerendaCondicoesID,
+		Title:       "Relatório de Condições da Merenda Escolar",
+		Description: "Condições da merenda escolar por escola, com oferta, qualidade, cozinha, equipamentos e Status Operacional simples para priorização, para todas as escolas do recorte.",
+		SheetName:   "Merenda Escolar",
+		FileBase:    "relatorio_merenda_escolar_condicoes",
 	},
 }
 

--- a/api/cmd/api/reports_catalog.go
+++ b/api/cmd/api/reports_catalog.go
@@ -20,6 +20,12 @@ package main
 // acompanhamento do preenchimento do censo.
 const reportCensoPreenchimentoID = "censo-preenchimento-escolas"
 
+// reportSaudeOperacionalID é o identificador do relatório de Índice de Saúde
+// Operacional por escola, que exporta todas as escolas do recorte com índice,
+// criticidade, status e notas por dimensão, reaproveitando a metodologia da
+// aba "Saúde Operacional".
+const reportSaudeOperacionalID = "saude-operacional-escolas"
+
 // ReportDefinition descreve os metadados de um relatório gerencial. Os
 // campos são suficientes para montar o cabeçalho do XLSX (Title), nomear
 // a aba (SheetName) e derivar o nome do arquivo (FileBase). A consulta e
@@ -41,6 +47,13 @@ var reportsCatalog = map[string]ReportDefinition{
 		Description: "Acompanhamento nominal do preenchimento do censo por escola, incluindo escolas ainda pendentes.",
 		SheetName:   "Preenchimento Censo",
 		FileBase:    "relatorio_censo_preenchimento_escolas",
+	},
+	reportSaudeOperacionalID: {
+		ID:          reportSaudeOperacionalID,
+		Title:       "Relatório de Índice de Saúde Operacional por Escola",
+		Description: "Índice de Saúde Operacional por escola, com criticidade, status e notas por dimensão, para todas as escolas do recorte.",
+		SheetName:   "Saude Operacional",
+		FileBase:    "relatorio_saude_operacional_escolas",
 	},
 }
 

--- a/api/cmd/api/reports_infraestrutura.go
+++ b/api/cmd/api/reports_infraestrutura.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// =====================================================================
+// Relatório gerencial — Infraestrutura, Energia e Segurança Escolar
+// =====================================================================
+// Exporta, sem paginação, todas as escolas do recorte com os campos de
+// prédio, energia e segurança do censo e um Status Operacional simples
+// para priorização. Escolas sem censo concluído no ano permanecem no
+// recorte e aparecem como "Sem dados".
+//
+// Fonte: schools s LEFT JOIN census_responses cr (cr.year = $1 AND
+// cr.status = 'completed') + LEFT JOIN reg_integracao. Os filtros globais
+// incidem sobre schools s. Campos do JSONB são lidos com NULLIF/cast
+// seguro, conforme a convenção do projeto. Não reutiliza endpoints
+// analíticos: lê o JSONB diretamente para manter o relatório isolado.
+// =====================================================================
+
+// infraestruturaReportColumns são os cabeçalhos do relatório, na ordem exigida
+// pela especificação.
+var infraestruturaReportColumns = []string{
+	"Região de Integração",
+	"DRE",
+	"Município",
+	"Zona",
+	"Código INEP",
+	"Escola",
+	"Tipo de Prédio",
+	"Situação da Estrutura",
+	"Necessita Reforma",
+	"Reforma Crítica",
+	"Obra Parada",
+	"Rede Elétrica Atende",
+	"Suporta Novos Equipamentos",
+	"Energia",
+	"Estrutura para Climatização",
+	"Salas Climatizadas",
+	"Salas Não Climatizadas",
+	"Guarita",
+	"Botão de Pânico",
+	"Câmeras",
+	"Controle de Portão",
+	"Iluminação Externa",
+	"Muro/Cerca",
+	"Plano de Evacuação",
+	"Política contra Bullying",
+	"Status Operacional",
+}
+
+// Valores canônicos de situacao_estrutura relevantes para a classificação.
+// Espelham as opções do formulário (web/src/schemas/steps/general-data.ts) e
+// os scores da Saúde Operacional, sem duplicar a metodologia de pontuação.
+const (
+	situacaoReformaGeral   = "Necessita de reforma geral"
+	situacaoObraParada     = "Está em reforma, porém a obra está parada"
+	situacaoReformaParcial = "Necessita de reforma parcial (melhoria pontual)"
+	situacaoReformaAndando = "Reforma em andamento"
+	situacaoSemReforma     = "Não necessita de reforma."
+	situacaoReformada      = "Foi reformada recentemente"
+)
+
+// infraReportRow guarda os valores brutos de uma escola, já de-NULLificados
+// (categóricos como "" quando ausentes), para classificação e projeção.
+type infraReportRow struct {
+	Regiao    string
+	DRE       string
+	Municipio string
+	Zona      string
+	INEP      string
+	Escola    string
+
+	HasCensus bool
+
+	TipoPredio            string
+	SituacaoEstrutura     string
+	RedeEletricaAtende    string
+	SuportaNovosEquip     string
+	Energia               string
+	EstruturaClimatizacao string
+	SalasClimatizadas     sql.NullFloat64
+	QtdSalasAula          sql.NullFloat64
+	PossuiGuarita         string
+	BotaoPanico           string
+	Cameras               string
+	ControlePortao        string
+	IluminacaoExterna     string
+	MuroCerca             string
+	PlanoEvacuacao        string
+	PoliticaBullying      string
+}
+
+// infraNecessitaReforma deriva a coluna "Necessita Reforma" de situacao_estrutura.
+// Defensiva: só responde "Sim"/"Não" para valores conhecidos; demais viram
+// "Não informado".
+func infraNecessitaReforma(situacao string) string {
+	switch situacao {
+	case situacaoReformaGeral, situacaoObraParada, situacaoReformaParcial, situacaoReformaAndando:
+		return "Sim"
+	case situacaoSemReforma, situacaoReformada:
+		return "Não"
+	default:
+		return "Não informado"
+	}
+}
+
+// infraReformaCritica indica se a estrutura está em condição crítica de reforma
+// (necessita de reforma geral).
+func infraReformaCritica(situacao string) string {
+	if situacao == situacaoReformaGeral {
+		return "Sim"
+	}
+	if situacao == "" {
+		return "Não informado"
+	}
+	return "Não"
+}
+
+// infraObraParada indica se há obra de reforma parada.
+func infraObraParada(situacao string) string {
+	if situacao == situacaoObraParada {
+		return "Sim"
+	}
+	if situacao == "" {
+		return "Não informado"
+	}
+	return "Não"
+}
+
+// classifyInfraStatus classifica o Status Operacional de Infraestrutura,
+// conforme a tabela documentada na especificação. Critérios (defensivos, só
+// disparam em valores conhecidos):
+//
+//	Sem censo concluído                              -> Sem dados
+//	Crítico (qualquer um):
+//	  - estrutura: necessita de reforma geral
+//	  - obra de reforma parada
+//	  - rede elétrica não atende ("Não")
+//	  - energia ausente (campo vazio)
+//	Atenção (qualquer um):
+//	  - estrutura: necessita de reforma parcial
+//	  - rede elétrica atende parcialmente
+//	  - sem estrutura de climatização ("Não" / "Não, somente com adequações")
+//	  - câmeras "Não possui"
+//	  - iluminação externa "Insuficiente"
+//	  - sem muro/cerca ("Não possui")
+//	Sem problema relevante                           -> Adequado
+func classifyInfraStatus(r infraReportRow) string {
+	if !r.HasCensus {
+		return statusOperacionalSemDados
+	}
+	if isInfraCritico(r) {
+		return statusOperacionalCritico
+	}
+	if isInfraAtencao(r) {
+		return statusOperacionalAtencao
+	}
+	return statusOperacionalAdequado
+}
+
+func isInfraCritico(r infraReportRow) bool {
+	switch r.SituacaoEstrutura {
+	case situacaoReformaGeral, situacaoObraParada:
+		return true
+	}
+	if r.RedeEletricaAtende == "Não" {
+		return true
+	}
+	if strings.TrimSpace(r.Energia) == "" {
+		return true
+	}
+	return false
+}
+
+func isInfraAtencao(r infraReportRow) bool {
+	if r.SituacaoEstrutura == situacaoReformaParcial {
+		return true
+	}
+	if r.RedeEletricaAtende == "Parcialmente" {
+		return true
+	}
+	switch r.EstruturaClimatizacao {
+	case "Não", "Não, somente com adequações":
+		return true
+	}
+	if r.Cameras == "Não possui" {
+		return true
+	}
+	if r.IluminacaoExterna == "Insuficiente" {
+		return true
+	}
+	if r.MuroCerca == "Não possui" {
+		return true
+	}
+	return false
+}
+
+// infraSalasNaoClimatizadas replica a regra da vw_censo_enriquecida: salas não
+// climatizadas = max(qtd_salas_aula - salas_climatizadas, 0); NULL quando
+// qtd_salas_aula é desconhecido (não infla o numerador artificialmente).
+func infraSalasNaoClimatizadas(qtdSalas, salasClim sql.NullFloat64) sql.NullFloat64 {
+	if !qtdSalas.Valid {
+		return sql.NullFloat64{}
+	}
+	clim := 0.0
+	if salasClim.Valid {
+		clim = salasClim.Float64
+	}
+	diff := qtdSalas.Float64 - clim
+	if diff < 0 {
+		diff = 0
+	}
+	return sql.NullFloat64{Float64: diff, Valid: true}
+}
+
+// infraestruturaSelectSQL parte de schools s, com LEFT JOIN na resposta do ano
+// (status='completed') para manter escolas sem censo no recorte, e LEFT JOIN em
+// reg_integracao para a Região de Integração. Filtros globais incidem sobre
+// schools s (UPPER(TRIM(...)) tolera caixa/espaços). Não pagina; a ordenação
+// final por prioridade operacional é feita em Go.
+//
+// $1=year (sempre específico), $2=dre, $3=municipio, $4=zona, $5=regiao.
+const infraestruturaSelectSQL = `
+	SELECT
+		COALESCE(ri.regiao_de_integracao, '') AS regiao_integracao,
+		COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre,
+		COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio,
+		COALESCE(NULLIF(TRIM(s.zona), ''), '') AS zona,
+		COALESCE(s.codigo_inep, '') AS codigo_inep,
+		COALESCE(NULLIF(TRIM(s.nome_escola), ''), 'Sem nome') AS nome_escola,
+		(cr.id IS NOT NULL) AS has_censo,
+		COALESCE(NULLIF(cr.data->>'tipo_predio', ''), '')              AS tipo_predio,
+		COALESCE(NULLIF(cr.data->>'situacao_estrutura', ''), '')       AS situacao_estrutura,
+		COALESCE(NULLIF(cr.data->>'rede_eletrica_atende', ''), '')     AS rede_eletrica_atende,
+		COALESCE(NULLIF(cr.data->>'suporta_novos_equipamentos', ''), '') AS suporta_novos_equipamentos,
+		COALESCE(NULLIF(cr.data->>'energia', ''), '')                  AS energia,
+		COALESCE(NULLIF(cr.data->>'estrutura_climatizacao', ''), '')   AS estrutura_climatizacao,
+		CASE WHEN cr.data->>'salas_climatizadas' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'salas_climatizadas')::numeric END       AS salas_climatizadas,
+		CASE WHEN cr.data->>'qtd_salas_aula' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_salas_aula')::numeric END           AS qtd_salas_aula,
+		COALESCE(NULLIF(cr.data->>'possui_guarita', ''), '')          AS possui_guarita,
+		COALESCE(NULLIF(cr.data->>'possui_botao_panico', ''), '')     AS possui_botao_panico,
+		COALESCE(NULLIF(cr.data->>'cameras_funcionamento', ''), '')   AS cameras_funcionamento,
+		COALESCE(NULLIF(cr.data->>'controle_portao', ''), '')         AS controle_portao,
+		COALESCE(NULLIF(cr.data->>'iluminacao_externa', ''), '')      AS iluminacao_externa,
+		COALESCE(NULLIF(cr.data->>'muro_cerca', ''), '')              AS muro_cerca,
+		COALESCE(NULLIF(cr.data->>'plano_evacuacao', ''), '')         AS plano_evacuacao,
+		COALESCE(NULLIF(cr.data->>'politica_bullying', ''), '')       AS politica_bullying
+	FROM schools s
+	LEFT JOIN census_responses cr
+		ON cr.school_id = s.id AND cr.year = $1 AND cr.status = 'completed'
+	LEFT JOIN reg_integracao ri ON UPPER(TRIM(ri.municipio)) = UPPER(TRIM(s.municipio))
+	WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))
+	ORDER BY
+		UPPER(TRIM(s.dre)),
+		UPPER(TRIM(s.municipio)),
+		UPPER(TRIM(s.nome_escola)),
+		s.codigo_inep
+`
+
+// buildInfraestruturaReportData executa a consulta, classifica o Status
+// Operacional de cada escola, ordena por prioridade operacional e projeta as
+// colunas do XLSX. Não pagina.
+func (app *application) buildInfraestruturaReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, infraestruturaSelectSQL, f.args()...)
+	if err != nil {
+		return reportData{}, fmt.Errorf("consultar infraestrutura: %w", err)
+	}
+	defer dbRows.Close()
+
+	rows := make([]reportOperacionalRow, 0)
+	for dbRows.Next() {
+		var r infraReportRow
+		if err := dbRows.Scan(
+			&r.Regiao, &r.DRE, &r.Municipio, &r.Zona, &r.INEP, &r.Escola,
+			&r.HasCensus,
+			&r.TipoPredio, &r.SituacaoEstrutura, &r.RedeEletricaAtende, &r.SuportaNovosEquip,
+			&r.Energia, &r.EstruturaClimatizacao, &r.SalasClimatizadas, &r.QtdSalasAula,
+			&r.PossuiGuarita, &r.BotaoPanico, &r.Cameras, &r.ControlePortao,
+			&r.IluminacaoExterna, &r.MuroCerca, &r.PlanoEvacuacao, &r.PoliticaBullying,
+		); err != nil {
+			return reportData{}, fmt.Errorf("ler linha infraestrutura: %w", err)
+		}
+
+		status := classifyInfraStatus(r)
+		naoClim := infraSalasNaoClimatizadas(r.QtdSalasAula, r.SalasClimatizadas)
+
+		cells := []any{
+			r.Regiao,
+			r.DRE,
+			r.Municipio,
+			r.Zona,
+			r.INEP,
+			r.Escola,
+			reportTextCell(r.HasCensus, r.TipoPredio),
+			reportTextCell(r.HasCensus, r.SituacaoEstrutura),
+			reportSemDadosOr(r.HasCensus, infraNecessitaReforma(r.SituacaoEstrutura)),
+			reportSemDadosOr(r.HasCensus, infraReformaCritica(r.SituacaoEstrutura)),
+			reportSemDadosOr(r.HasCensus, infraObraParada(r.SituacaoEstrutura)),
+			reportTextCell(r.HasCensus, r.RedeEletricaAtende),
+			reportTextCell(r.HasCensus, r.SuportaNovosEquip),
+			reportTextCell(r.HasCensus, r.Energia),
+			reportTextCell(r.HasCensus, r.EstruturaClimatizacao),
+			reportIntCell(r.HasCensus, r.SalasClimatizadas),
+			reportIntCell(r.HasCensus, naoClim),
+			reportTextCell(r.HasCensus, r.PossuiGuarita),
+			reportTextCell(r.HasCensus, r.BotaoPanico),
+			reportTextCell(r.HasCensus, r.Cameras),
+			reportTextCell(r.HasCensus, r.ControlePortao),
+			reportTextCell(r.HasCensus, r.IluminacaoExterna),
+			reportTextCell(r.HasCensus, r.MuroCerca),
+			reportTextCell(r.HasCensus, r.PlanoEvacuacao),
+			reportTextCell(r.HasCensus, r.PoliticaBullying),
+			status,
+		}
+
+		rows = append(rows, reportOperacionalRow{
+			Status:    status,
+			DRE:       r.DRE,
+			Municipio: r.Municipio,
+			Escola:    r.Escola,
+			INEP:      r.INEP,
+			Cells:     cells,
+		})
+	}
+	if err := dbRows.Err(); err != nil {
+		return reportData{}, fmt.Errorf("iterar linhas infraestrutura: %w", err)
+	}
+
+	sortReportOperacional(rows)
+
+	data := make([][]any, 0, len(rows))
+	for _, row := range rows {
+		data = append(data, row.Cells)
+	}
+
+	return reportData{
+		Title:       def.Title,
+		SheetName:   def.SheetName,
+		FiltersLine: f.describe(),
+		Headers:     infraestruturaReportColumns,
+		Rows:        data,
+	}, nil
+}

--- a/api/cmd/api/reports_infraestrutura_test.go
+++ b/api/cmd/api/reports_infraestrutura_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReportsCatalogRecognizesInfraestrutura garante que o relatório de
+// Infraestrutura/Segurança está registrado com os metadados esperados.
+func TestReportsCatalogRecognizesInfraestrutura(t *testing.T) {
+	def, ok := lookupReport(reportInfraestruturaSegurancaID)
+	if !ok {
+		t.Fatalf("lookupReport(%q) = not found", reportInfraestruturaSegurancaID)
+	}
+	if def.Title != "Relatório de Infraestrutura, Energia e Segurança Escolar" {
+		t.Fatalf("Title = %q; inesperado", def.Title)
+	}
+	if def.SheetName != "Infra Segurança" {
+		t.Fatalf("SheetName = %q; want %q", def.SheetName, "Infra Segurança")
+	}
+	if def.FileBase != "relatorio_infraestrutura_seguranca_escolas" {
+		t.Fatalf("FileBase = %q; inesperado", def.FileBase)
+	}
+}
+
+// TestInfraestruturaReportColumns trava a ordem e o conteúdo das colunas.
+func TestInfraestruturaReportColumns(t *testing.T) {
+	want := []string{
+		"Região de Integração", "DRE", "Município", "Zona", "Código INEP", "Escola",
+		"Tipo de Prédio", "Situação da Estrutura", "Necessita Reforma", "Reforma Crítica",
+		"Obra Parada", "Rede Elétrica Atende", "Suporta Novos Equipamentos", "Energia",
+		"Estrutura para Climatização", "Salas Climatizadas", "Salas Não Climatizadas",
+		"Guarita", "Botão de Pânico", "Câmeras", "Controle de Portão", "Iluminação Externa",
+		"Muro/Cerca", "Plano de Evacuação", "Política contra Bullying", "Status Operacional",
+	}
+	if len(infraestruturaReportColumns) != len(want) {
+		t.Fatalf("len colunas = %d; want %d", len(infraestruturaReportColumns), len(want))
+	}
+	for i := range want {
+		if infraestruturaReportColumns[i] != want[i] {
+			t.Fatalf("coluna[%d] = %q; want %q", i, infraestruturaReportColumns[i], want[i])
+		}
+	}
+	if infraestruturaReportColumns[len(infraestruturaReportColumns)-1] != "Status Operacional" {
+		t.Fatalf("última coluna deve ser Status Operacional")
+	}
+}
+
+// TestClassifyInfraStatus cobre a tabela de classificação operacional.
+func TestClassifyInfraStatus(t *testing.T) {
+	base := infraReportRow{
+		HasCensus:             true,
+		SituacaoEstrutura:     situacaoSemReforma,
+		RedeEletricaAtende:    "Sim",
+		Energia:               "Concessionária de energia - Equatorial",
+		EstruturaClimatizacao: "Sim",
+		Cameras:               "Sim, funcionando plenamente",
+		IluminacaoExterna:     "Adequada",
+		MuroCerca:             "Sim, muro",
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(r *infraReportRow)
+		want   string
+	}{
+		{"sem censo", func(r *infraReportRow) { r.HasCensus = false }, statusOperacionalSemDados},
+		{"adequado", func(r *infraReportRow) {}, statusOperacionalAdequado},
+		{"critico reforma geral", func(r *infraReportRow) { r.SituacaoEstrutura = situacaoReformaGeral }, statusOperacionalCritico},
+		{"critico obra parada", func(r *infraReportRow) { r.SituacaoEstrutura = situacaoObraParada }, statusOperacionalCritico},
+		{"critico rede nao atende", func(r *infraReportRow) { r.RedeEletricaAtende = "Não" }, statusOperacionalCritico},
+		{"critico energia ausente", func(r *infraReportRow) { r.Energia = "" }, statusOperacionalCritico},
+		{"atencao reforma parcial", func(r *infraReportRow) { r.SituacaoEstrutura = situacaoReformaParcial }, statusOperacionalAtencao},
+		{"atencao rede parcial", func(r *infraReportRow) { r.RedeEletricaAtende = "Parcialmente" }, statusOperacionalAtencao},
+		{"atencao sem climatizacao", func(r *infraReportRow) { r.EstruturaClimatizacao = "Não" }, statusOperacionalAtencao},
+		{"atencao sem cameras", func(r *infraReportRow) { r.Cameras = "Não possui" }, statusOperacionalAtencao},
+		{"atencao iluminacao insuficiente", func(r *infraReportRow) { r.IluminacaoExterna = "Insuficiente" }, statusOperacionalAtencao},
+		{"atencao sem muro", func(r *infraReportRow) { r.MuroCerca = "Não possui" }, statusOperacionalAtencao},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := base
+			tt.mutate(&r)
+			if got := classifyInfraStatus(r); got != tt.want {
+				t.Fatalf("classifyInfraStatus = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyInfraStatusCriticoPrecedeAtencao garante que crítico tem
+// prioridade quando há problemas dos dois níveis simultaneamente.
+func TestClassifyInfraStatusCriticoPrecedeAtencao(t *testing.T) {
+	r := infraReportRow{
+		HasCensus:         true,
+		SituacaoEstrutura: situacaoReformaGeral, // crítico
+		Cameras:           "Não possui",         // atenção
+		Energia:           "Geração própria",
+	}
+	if got := classifyInfraStatus(r); got != statusOperacionalCritico {
+		t.Fatalf("classifyInfraStatus = %q; want Crítico", got)
+	}
+}
+
+// TestInfraDerivedReformColumns cobre as colunas derivadas de situacao_estrutura.
+func TestInfraDerivedReformColumns(t *testing.T) {
+	tests := []struct {
+		situacao                 string
+		necessita, critica, obra string
+	}{
+		{situacaoReformaGeral, "Sim", "Sim", "Não"},
+		{situacaoObraParada, "Sim", "Não", "Sim"},
+		{situacaoReformaParcial, "Sim", "Não", "Não"},
+		{situacaoSemReforma, "Não", "Não", "Não"},
+		{situacaoReformada, "Não", "Não", "Não"},
+		{"", "Não informado", "Não informado", "Não informado"},
+	}
+	for _, tt := range tests {
+		if got := infraNecessitaReforma(tt.situacao); got != tt.necessita {
+			t.Fatalf("infraNecessitaReforma(%q) = %q; want %q", tt.situacao, got, tt.necessita)
+		}
+		if got := infraReformaCritica(tt.situacao); got != tt.critica {
+			t.Fatalf("infraReformaCritica(%q) = %q; want %q", tt.situacao, got, tt.critica)
+		}
+		if got := infraObraParada(tt.situacao); got != tt.obra {
+			t.Fatalf("infraObraParada(%q) = %q; want %q", tt.situacao, got, tt.obra)
+		}
+	}
+}
+
+// TestInfraSalasNaoClimatizadas valida a regra max(salas - climatizadas, 0).
+func TestInfraSalasNaoClimatizadas(t *testing.T) {
+	nf := func(v float64) sql.NullFloat64 { return sql.NullFloat64{Float64: v, Valid: true} }
+	null := sql.NullFloat64{}
+
+	if got := infraSalasNaoClimatizadas(null, nf(2)); got.Valid {
+		t.Fatalf("salas_aula NULL deve produzir NULL; got %+v", got)
+	}
+	if got := infraSalasNaoClimatizadas(nf(10), nf(3)); !got.Valid || got.Float64 != 7 {
+		t.Fatalf("10-3 = %+v; want 7", got)
+	}
+	if got := infraSalasNaoClimatizadas(nf(5), nf(8)); !got.Valid || got.Float64 != 0 {
+		t.Fatalf("piso 0 falhou: %+v", got)
+	}
+	if got := infraSalasNaoClimatizadas(nf(4), null); !got.Valid || got.Float64 != 4 {
+		t.Fatalf("climatizadas NULL deve tratar como 0: %+v", got)
+	}
+}
+
+// TestSortReportOperacionalPriority garante a ordem Crítico > Atenção >
+// Adequado > Sem dados e os desempates territoriais.
+func TestSortReportOperacionalPriority(t *testing.T) {
+	rows := []reportOperacionalRow{
+		{Status: statusOperacionalSemDados, DRE: "A", Municipio: "A", Escola: "A", INEP: "1"},
+		{Status: statusOperacionalAdequado, DRE: "A", Municipio: "A", Escola: "A", INEP: "2"},
+		{Status: statusOperacionalCritico, DRE: "Z", Municipio: "Z", Escola: "Z", INEP: "3"},
+		{Status: statusOperacionalCritico, DRE: "A", Municipio: "A", Escola: "A", INEP: "4"},
+		{Status: statusOperacionalAtencao, DRE: "A", Municipio: "A", Escola: "A", INEP: "5"},
+	}
+	sortReportOperacional(rows)
+
+	wantINEP := []string{"4", "3", "5", "2", "1"}
+	for i, w := range wantINEP {
+		if rows[i].INEP != w {
+			t.Fatalf("ordem[%d] INEP = %q; want %q (rows=%+v)", i, rows[i].INEP, w, rows)
+		}
+	}
+}
+
+// TestResolveReportYearDefault garante ano específico (não "todos os anos").
+func TestResolveReportYearDefault(t *testing.T) {
+	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	if got := resolveReportYearDefault(reportFilters{Year: 2025}, now); got != 2025 {
+		t.Fatalf("year explícito = %d; want 2025", got)
+	}
+	if got := resolveReportYearDefault(reportFilters{Year: 0}, now); got != 2026 {
+		t.Fatalf("year ausente = %d; want 2026 (ano corrente)", got)
+	}
+	if got := resolveReportYearDefault(reportFilters{}, now); got == 0 {
+		t.Fatalf("year padrão não pode ser 0 (todos os anos)")
+	}
+}
+
+// TestWriteInfraestruturaXLSX garante a geração do XLSX com a aba e colunas.
+func TestWriteInfraestruturaXLSX(t *testing.T) {
+	rd := reportData{
+		Title:       "Relatório de Infraestrutura, Energia e Segurança Escolar",
+		SheetName:   "Infra Segurança",
+		FiltersLine: "Filtros aplicados — Ano: 2026",
+		Headers:     infraestruturaReportColumns,
+		Rows: [][]any{
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "12345678", "Escola Crítica",
+				"Próprio", "Necessita de reforma geral", "Sim", "Sim", "Não", "Não",
+				"Não", "Geração própria", "Não", 2, 8, "Sim", "Não",
+				"Não possui", "Manual", "Insuficiente", "Não possui", "Não", "Não possui",
+				statusOperacionalCritico},
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "87654321", "Escola Sem Dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				statusOperacionalSemDados},
+		},
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		t.Fatalf("writeReportXLSX erro: %v", err)
+	}
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer erro: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("XLSX vazio")
+	}
+	if idx, err := f.GetSheetIndex("Infra Segurança"); err != nil || idx < 0 {
+		t.Fatalf("aba 'Infra Segurança' não encontrada (idx=%d, err=%v)", idx, err)
+	}
+	if v, err := f.GetCellValue("Infra Segurança", "A4"); err != nil || v != "Região de Integração" {
+		t.Fatalf("A4 = %q (err=%v); want primeiro cabeçalho", v, err)
+	}
+	// Última coluna (Z = 26ª) na linha 5 deve ser o status.
+	if v, err := f.GetCellValue("Infra Segurança", "Z5"); err != nil || v != statusOperacionalCritico {
+		t.Fatalf("Z5 = %q (err=%v); want %q", v, err, statusOperacionalCritico)
+	}
+}
+
+// TestInfraestruturaSelectSQLShape valida que a consulta parte de schools s com
+// LEFT JOIN no censo concluído do ano (mantendo escolas sem dados) e aplica os
+// filtros globais sobre schools s.
+func TestInfraestruturaSelectSQLShape(t *testing.T) {
+	q := infraestruturaSelectSQL
+	mustContain := []string{
+		"FROM schools s",
+		"LEFT JOIN census_responses cr",
+		"cr.year = $1 AND cr.status = 'completed'",
+		"LEFT JOIN reg_integracao ri",
+		"(cr.id IS NOT NULL) AS has_censo",
+		"cr.data->>'situacao_estrutura'",
+		"cr.data->>'plano_evacuacao'",
+		"($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(q, frag) {
+			t.Fatalf("infraestruturaSelectSQL não contém %q", frag)
+		}
+	}
+	if strings.Contains(q, "INNER JOIN") {
+		t.Fatalf("query não pode usar INNER JOIN (excluiria escolas sem dados)")
+	}
+}

--- a/api/cmd/api/reports_merenda.go
+++ b/api/cmd/api/reports_merenda.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// =====================================================================
+// Relatório gerencial — Condições da Merenda Escolar
+// =====================================================================
+// Exporta, sem paginação, todas as escolas do recorte com a oferta, a
+// qualidade, as condições da cozinha, os equipamentos e um Status
+// Operacional simples para priorização. Escolas sem censo concluído no
+// ano permanecem no recorte e aparecem como "Sem dados".
+//
+// Fonte: schools s LEFT JOIN census_responses cr (cr.year = $1 AND
+// cr.status = 'completed') + LEFT JOIN reg_integracao. Os filtros globais
+// incidem sobre schools s. Campos do JSONB são lidos com NULLIF/cast
+// seguro, conforme a convenção do projeto.
+//
+// Observação de mapeamento: o censo registra o estoque de EPIs e
+// extintores num único campo (estoque_epi_extintor: Completo/Parcial/
+// Inexistente). Por isso as colunas "EPIs" e "Extintores" refletem esse
+// mesmo campo, enquanto "Manutenção Preventiva" usa manutencao_extintores
+// (Está na validade/Validade vencida).
+// =====================================================================
+
+// merendaReportColumns são os cabeçalhos do relatório, na ordem exigida pela
+// especificação.
+var merendaReportColumns = []string{
+	"Região de Integração",
+	"DRE",
+	"Município",
+	"Zona",
+	"Código INEP",
+	"Escola",
+	"Oferta Regular",
+	"Qualidade da Merenda",
+	"Atende Necessidades",
+	"Condições da Cozinha",
+	"Tamanho da Cozinha",
+	"Possui Refeitório",
+	"Refeitório Adequado",
+	"Freezers",
+	"Geladeiras",
+	"Fogões",
+	"Bebedouros",
+	"Despensa Exclusiva",
+	"Depósito de Conserva",
+	"EPIs",
+	"Extintores",
+	"Manutenção Preventiva",
+	"Status Operacional",
+}
+
+// merendaReportRow guarda os valores brutos de uma escola, já de-NULLificados
+// (categóricos como "" quando ausentes), para classificação e projeção.
+type merendaReportRow struct {
+	Regiao    string
+	DRE       string
+	Municipio string
+	Zona      string
+	INEP      string
+	Escola    string
+
+	HasCensus bool
+
+	OfertaRegular      string
+	QualidadeMerenda   string
+	AtendeNecessidades string
+	CondicoesCozinha   string
+	TamanhoCozinha     string
+	PossuiRefeitorio   string
+	RefeitorioAdequado string
+	QtdFreezers        sql.NullFloat64
+	QtdGeladeiras      sql.NullFloat64
+	QtdFogoes          sql.NullFloat64
+	QtdBebedouros      sql.NullFloat64
+	DespensaExclusiva  string
+	DepositoConserva   string
+	EstoqueEpiExtintor string
+	ManutencaoExtint   string
+}
+
+// classifyMerendaStatus classifica o Status Operacional de Merenda, conforme a
+// tabela documentada na especificação. Critérios (defensivos, só disparam em
+// valores conhecidos):
+//
+//	Sem censo concluído                              -> Sem dados
+//	Crítico (qualquer um):
+//	  - sem oferta regular (oferta_regular = "Não")
+//	  - não atende necessidades (atende_necessidades = "Não")
+//	  - cozinha ruim/precária (condicoes_cozinha = "Precária")
+//	Atenção (qualquer um):
+//	  - oferta com falhas
+//	  - qualidade da merenda Regular ou Ruim
+//	  - atende necessidades apenas Parcialmente
+//	  - condições da cozinha Regular
+//	  - refeitório inadequado (refeitorio_adequado = "Não")
+//	  - equipamentos insuficientes (sem refrigeração: 0 freezers e 0 geladeiras,
+//	    ou estoque de EPI/extintor inexistente)
+//	Sem problema relevante                           -> Adequado
+func classifyMerendaStatus(r merendaReportRow) string {
+	if !r.HasCensus {
+		return statusOperacionalSemDados
+	}
+	if isMerendaCritico(r) {
+		return statusOperacionalCritico
+	}
+	if isMerendaAtencao(r) {
+		return statusOperacionalAtencao
+	}
+	return statusOperacionalAdequado
+}
+
+func isMerendaCritico(r merendaReportRow) bool {
+	if r.OfertaRegular == "Não" {
+		return true
+	}
+	if r.AtendeNecessidades == "Não" {
+		return true
+	}
+	if r.CondicoesCozinha == "Precária" {
+		return true
+	}
+	return false
+}
+
+func isMerendaAtencao(r merendaReportRow) bool {
+	if r.OfertaRegular == "Sim, com falhas" {
+		return true
+	}
+	switch r.QualidadeMerenda {
+	case "Regular", "Ruim":
+		return true
+	}
+	if r.AtendeNecessidades == "Parcialmente" {
+		return true
+	}
+	if r.CondicoesCozinha == "Regular" {
+		return true
+	}
+	if r.RefeitorioAdequado == "Não" {
+		return true
+	}
+	if merendaSemRefrigeracao(r) {
+		return true
+	}
+	if r.EstoqueEpiExtintor == "Inexistente" {
+		return true
+	}
+	return false
+}
+
+// merendaSemRefrigeracao indica ausência de refrigeração quando tanto freezers
+// quanto geladeiras são conhecidos e iguais a zero. Quantidades ausentes (NULL)
+// não disparam o sinal — defensivo, não infla a criticidade.
+func merendaSemRefrigeracao(r merendaReportRow) bool {
+	return r.QtdFreezers.Valid && r.QtdFreezers.Float64 == 0 &&
+		r.QtdGeladeiras.Valid && r.QtdGeladeiras.Float64 == 0
+}
+
+// merendaSelectSQL parte de schools s, com LEFT JOIN na resposta do ano
+// (status='completed') para manter escolas sem censo no recorte, e LEFT JOIN em
+// reg_integracao para a Região de Integração. Filtros globais incidem sobre
+// schools s. Não pagina; a ordenação final por prioridade operacional é em Go.
+//
+// $1=year (sempre específico), $2=dre, $3=municipio, $4=zona, $5=regiao.
+const merendaSelectSQL = `
+	SELECT
+		COALESCE(ri.regiao_de_integracao, '') AS regiao_integracao,
+		COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre,
+		COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio,
+		COALESCE(NULLIF(TRIM(s.zona), ''), '') AS zona,
+		COALESCE(s.codigo_inep, '') AS codigo_inep,
+		COALESCE(NULLIF(TRIM(s.nome_escola), ''), 'Sem nome') AS nome_escola,
+		(cr.id IS NOT NULL) AS has_censo,
+		COALESCE(NULLIF(cr.data->>'oferta_regular', ''), '')      AS oferta_regular,
+		COALESCE(NULLIF(cr.data->>'qualidade_merenda', ''), '')   AS qualidade_merenda,
+		COALESCE(NULLIF(cr.data->>'atende_necessidades', ''), '') AS atende_necessidades,
+		COALESCE(NULLIF(cr.data->>'condicoes_cozinha', ''), '')   AS condicoes_cozinha,
+		COALESCE(NULLIF(cr.data->>'tamanho_cozinha', ''), '')     AS tamanho_cozinha,
+		COALESCE(NULLIF(cr.data->>'possui_refeitorio', ''), '')   AS possui_refeitorio,
+		COALESCE(NULLIF(cr.data->>'refeitorio_adequado', ''), '') AS refeitorio_adequado,
+		CASE WHEN cr.data->>'qtd_freezers' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_freezers')::numeric END         AS qtd_freezers,
+		CASE WHEN cr.data->>'qtd_geladeiras' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_geladeiras')::numeric END       AS qtd_geladeiras,
+		CASE WHEN cr.data->>'qtd_fogoes' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_fogoes')::numeric END           AS qtd_fogoes,
+		CASE WHEN cr.data->>'qtd_bebedouros' ~ '^-?[0-9]+(\.[0-9]+)?$'
+			 THEN (cr.data->>'qtd_bebedouros')::numeric END       AS qtd_bebedouros,
+		COALESCE(NULLIF(cr.data->>'despensa_exclusiva', ''), '')   AS despensa_exclusiva,
+		COALESCE(NULLIF(cr.data->>'deposito_conserva', ''), '')    AS deposito_conserva,
+		COALESCE(NULLIF(cr.data->>'estoque_epi_extintor', ''), '')  AS estoque_epi_extintor,
+		COALESCE(NULLIF(cr.data->>'manutencao_extintores', ''), '') AS manutencao_extintores
+	FROM schools s
+	LEFT JOIN census_responses cr
+		ON cr.school_id = s.id AND cr.year = $1 AND cr.status = 'completed'
+	LEFT JOIN reg_integracao ri ON UPPER(TRIM(ri.municipio)) = UPPER(TRIM(s.municipio))
+	WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))
+	ORDER BY
+		UPPER(TRIM(s.dre)),
+		UPPER(TRIM(s.municipio)),
+		UPPER(TRIM(s.nome_escola)),
+		s.codigo_inep
+`
+
+// buildMerendaReportData executa a consulta, classifica o Status Operacional de
+// cada escola, ordena por prioridade operacional e projeta as colunas do XLSX.
+// Não pagina.
+func (app *application) buildMerendaReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, merendaSelectSQL, f.args()...)
+	if err != nil {
+		return reportData{}, fmt.Errorf("consultar merenda: %w", err)
+	}
+	defer dbRows.Close()
+
+	rows := make([]reportOperacionalRow, 0)
+	for dbRows.Next() {
+		var r merendaReportRow
+		if err := dbRows.Scan(
+			&r.Regiao, &r.DRE, &r.Municipio, &r.Zona, &r.INEP, &r.Escola,
+			&r.HasCensus,
+			&r.OfertaRegular, &r.QualidadeMerenda, &r.AtendeNecessidades,
+			&r.CondicoesCozinha, &r.TamanhoCozinha, &r.PossuiRefeitorio, &r.RefeitorioAdequado,
+			&r.QtdFreezers, &r.QtdGeladeiras, &r.QtdFogoes, &r.QtdBebedouros,
+			&r.DespensaExclusiva, &r.DepositoConserva, &r.EstoqueEpiExtintor, &r.ManutencaoExtint,
+		); err != nil {
+			return reportData{}, fmt.Errorf("ler linha merenda: %w", err)
+		}
+
+		status := classifyMerendaStatus(r)
+
+		cells := []any{
+			r.Regiao,
+			r.DRE,
+			r.Municipio,
+			r.Zona,
+			r.INEP,
+			r.Escola,
+			reportTextCell(r.HasCensus, r.OfertaRegular),
+			reportTextCell(r.HasCensus, r.QualidadeMerenda),
+			reportTextCell(r.HasCensus, r.AtendeNecessidades),
+			reportTextCell(r.HasCensus, r.CondicoesCozinha),
+			reportTextCell(r.HasCensus, r.TamanhoCozinha),
+			reportTextCell(r.HasCensus, r.PossuiRefeitorio),
+			reportTextCell(r.HasCensus, r.RefeitorioAdequado),
+			reportIntCell(r.HasCensus, r.QtdFreezers),
+			reportIntCell(r.HasCensus, r.QtdGeladeiras),
+			reportIntCell(r.HasCensus, r.QtdFogoes),
+			reportIntCell(r.HasCensus, r.QtdBebedouros),
+			reportTextCell(r.HasCensus, r.DespensaExclusiva),
+			reportTextCell(r.HasCensus, r.DepositoConserva),
+			reportTextCell(r.HasCensus, r.EstoqueEpiExtintor),
+			reportTextCell(r.HasCensus, r.EstoqueEpiExtintor),
+			reportTextCell(r.HasCensus, r.ManutencaoExtint),
+			status,
+		}
+
+		rows = append(rows, reportOperacionalRow{
+			Status:    status,
+			DRE:       r.DRE,
+			Municipio: r.Municipio,
+			Escola:    r.Escola,
+			INEP:      r.INEP,
+			Cells:     cells,
+		})
+	}
+	if err := dbRows.Err(); err != nil {
+		return reportData{}, fmt.Errorf("iterar linhas merenda: %w", err)
+	}
+
+	sortReportOperacional(rows)
+
+	data := make([][]any, 0, len(rows))
+	for _, row := range rows {
+		data = append(data, row.Cells)
+	}
+
+	return reportData{
+		Title:       def.Title,
+		SheetName:   def.SheetName,
+		FiltersLine: f.describe(),
+		Headers:     merendaReportColumns,
+		Rows:        data,
+	}, nil
+}

--- a/api/cmd/api/reports_merenda_test.go
+++ b/api/cmd/api/reports_merenda_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+// TestReportsCatalogRecognizesMerenda garante que o relatório de Merenda está
+// registrado com os metadados esperados.
+func TestReportsCatalogRecognizesMerenda(t *testing.T) {
+	def, ok := lookupReport(reportMerendaCondicoesID)
+	if !ok {
+		t.Fatalf("lookupReport(%q) = not found", reportMerendaCondicoesID)
+	}
+	if def.Title != "Relatório de Condições da Merenda Escolar" {
+		t.Fatalf("Title = %q; inesperado", def.Title)
+	}
+	if def.SheetName != "Merenda Escolar" {
+		t.Fatalf("SheetName = %q; want %q", def.SheetName, "Merenda Escolar")
+	}
+	if def.FileBase != "relatorio_merenda_escolar_condicoes" {
+		t.Fatalf("FileBase = %q; inesperado", def.FileBase)
+	}
+}
+
+// TestMerendaReportColumns trava a ordem e o conteúdo das colunas.
+func TestMerendaReportColumns(t *testing.T) {
+	want := []string{
+		"Região de Integração", "DRE", "Município", "Zona", "Código INEP", "Escola",
+		"Oferta Regular", "Qualidade da Merenda", "Atende Necessidades", "Condições da Cozinha",
+		"Tamanho da Cozinha", "Possui Refeitório", "Refeitório Adequado", "Freezers",
+		"Geladeiras", "Fogões", "Bebedouros", "Despensa Exclusiva", "Depósito de Conserva",
+		"EPIs", "Extintores", "Manutenção Preventiva", "Status Operacional",
+	}
+	if len(merendaReportColumns) != len(want) {
+		t.Fatalf("len colunas = %d; want %d", len(merendaReportColumns), len(want))
+	}
+	for i := range want {
+		if merendaReportColumns[i] != want[i] {
+			t.Fatalf("coluna[%d] = %q; want %q", i, merendaReportColumns[i], want[i])
+		}
+	}
+	if merendaReportColumns[len(merendaReportColumns)-1] != "Status Operacional" {
+		t.Fatalf("última coluna deve ser Status Operacional")
+	}
+}
+
+// TestClassifyMerendaStatus cobre a tabela de classificação operacional.
+func TestClassifyMerendaStatus(t *testing.T) {
+	nf := func(v float64) sql.NullFloat64 { return sql.NullFloat64{Float64: v, Valid: true} }
+	base := merendaReportRow{
+		HasCensus:          true,
+		OfertaRegular:      "Sim",
+		QualidadeMerenda:   "Boa",
+		AtendeNecessidades: "Sim",
+		CondicoesCozinha:   "Boa",
+		RefeitorioAdequado: "Sim",
+		EstoqueEpiExtintor: "Completo",
+		QtdFreezers:        nf(1),
+		QtdGeladeiras:      nf(1),
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(r *merendaReportRow)
+		want   string
+	}{
+		{"sem censo", func(r *merendaReportRow) { r.HasCensus = false }, statusOperacionalSemDados},
+		{"adequado", func(r *merendaReportRow) {}, statusOperacionalAdequado},
+		{"critico sem oferta", func(r *merendaReportRow) { r.OfertaRegular = "Não" }, statusOperacionalCritico},
+		{"critico nao atende", func(r *merendaReportRow) { r.AtendeNecessidades = "Não" }, statusOperacionalCritico},
+		{"critico cozinha precaria", func(r *merendaReportRow) { r.CondicoesCozinha = "Precária" }, statusOperacionalCritico},
+		{"atencao oferta com falhas", func(r *merendaReportRow) { r.OfertaRegular = "Sim, com falhas" }, statusOperacionalAtencao},
+		{"atencao qualidade regular", func(r *merendaReportRow) { r.QualidadeMerenda = "Regular" }, statusOperacionalAtencao},
+		{"atencao qualidade ruim", func(r *merendaReportRow) { r.QualidadeMerenda = "Ruim" }, statusOperacionalAtencao},
+		{"atencao atende parcial", func(r *merendaReportRow) { r.AtendeNecessidades = "Parcialmente" }, statusOperacionalAtencao},
+		{"atencao cozinha regular", func(r *merendaReportRow) { r.CondicoesCozinha = "Regular" }, statusOperacionalAtencao},
+		{"atencao refeitorio inadequado", func(r *merendaReportRow) { r.RefeitorioAdequado = "Não" }, statusOperacionalAtencao},
+		{"atencao sem refrigeracao", func(r *merendaReportRow) { r.QtdFreezers = nf(0); r.QtdGeladeiras = nf(0) }, statusOperacionalAtencao},
+		{"atencao epi inexistente", func(r *merendaReportRow) { r.EstoqueEpiExtintor = "Inexistente" }, statusOperacionalAtencao},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := base
+			tt.mutate(&r)
+			if got := classifyMerendaStatus(r); got != tt.want {
+				t.Fatalf("classifyMerendaStatus = %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyMerendaCriticoPrecedeAtencao garante a precedência de crítico.
+func TestClassifyMerendaCriticoPrecedeAtencao(t *testing.T) {
+	r := merendaReportRow{
+		HasCensus:        true,
+		OfertaRegular:    "Não",     // crítico
+		QualidadeMerenda: "Regular", // atenção
+	}
+	if got := classifyMerendaStatus(r); got != statusOperacionalCritico {
+		t.Fatalf("classifyMerendaStatus = %q; want Crítico", got)
+	}
+}
+
+// TestMerendaSemRefrigeracao garante que NULLs não disparam o sinal.
+func TestMerendaSemRefrigeracao(t *testing.T) {
+	nf := func(v float64) sql.NullFloat64 { return sql.NullFloat64{Float64: v, Valid: true} }
+	null := sql.NullFloat64{}
+
+	if merendaSemRefrigeracao(merendaReportRow{QtdFreezers: null, QtdGeladeiras: null}) {
+		t.Fatalf("NULL/NULL não deveria sinalizar sem refrigeração")
+	}
+	if merendaSemRefrigeracao(merendaReportRow{QtdFreezers: nf(0), QtdGeladeiras: null}) {
+		t.Fatalf("0/NULL não deveria sinalizar (geladeiras desconhecidas)")
+	}
+	if !merendaSemRefrigeracao(merendaReportRow{QtdFreezers: nf(0), QtdGeladeiras: nf(0)}) {
+		t.Fatalf("0/0 deveria sinalizar sem refrigeração")
+	}
+	if merendaSemRefrigeracao(merendaReportRow{QtdFreezers: nf(0), QtdGeladeiras: nf(2)}) {
+		t.Fatalf("0/2 não deveria sinalizar (há geladeiras)")
+	}
+}
+
+// TestWriteMerendaXLSX garante a geração do XLSX com a aba e colunas.
+func TestWriteMerendaXLSX(t *testing.T) {
+	rd := reportData{
+		Title:       "Relatório de Condições da Merenda Escolar",
+		SheetName:   "Merenda Escolar",
+		FiltersLine: "Filtros aplicados — Ano: 2026",
+		Headers:     merendaReportColumns,
+		Rows: [][]any{
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "12345678", "Escola Crítica",
+				"Não", "Ruim", "Não", "Precária", "Pequena", "Não", "Não informado",
+				0, 0, 1, 2, "Não", "Não", "Inexistente", "Inexistente", "Validade vencida",
+				statusOperacionalCritico},
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "87654321", "Escola Sem Dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				"Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados", "Sem dados",
+				"Sem dados", "Sem dados", "Sem dados", statusOperacionalSemDados},
+		},
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		t.Fatalf("writeReportXLSX erro: %v", err)
+	}
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer erro: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("XLSX vazio")
+	}
+	if idx, err := f.GetSheetIndex("Merenda Escolar"); err != nil || idx < 0 {
+		t.Fatalf("aba 'Merenda Escolar' não encontrada (idx=%d, err=%v)", idx, err)
+	}
+	if v, err := f.GetCellValue("Merenda Escolar", "A4"); err != nil || v != "Região de Integração" {
+		t.Fatalf("A4 = %q (err=%v); want primeiro cabeçalho", v, err)
+	}
+	// Última coluna (W = 23ª) na linha 5 deve ser o status.
+	if v, err := f.GetCellValue("Merenda Escolar", "W5"); err != nil || v != statusOperacionalCritico {
+		t.Fatalf("W5 = %q (err=%v); want %q", v, err, statusOperacionalCritico)
+	}
+}
+
+// TestMerendaSelectSQLShape valida o formato da consulta.
+func TestMerendaSelectSQLShape(t *testing.T) {
+	q := merendaSelectSQL
+	mustContain := []string{
+		"FROM schools s",
+		"LEFT JOIN census_responses cr",
+		"cr.year = $1 AND cr.status = 'completed'",
+		"LEFT JOIN reg_integracao ri",
+		"(cr.id IS NOT NULL) AS has_censo",
+		"cr.data->>'oferta_regular'",
+		"cr.data->>'manutencao_extintores'",
+		"($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(q, frag) {
+			t.Fatalf("merendaSelectSQL não contém %q", frag)
+		}
+	}
+	if strings.Contains(q, "INNER JOIN") {
+		t.Fatalf("query não pode usar INNER JOIN (excluiria escolas sem dados)")
+	}
+}

--- a/api/cmd/api/reports_saude_operacional.go
+++ b/api/cmd/api/reports_saude_operacional.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// =====================================================================
+// Relatório gerencial — Índice de Saúde Operacional por escola
+// =====================================================================
+// Exporta, sem paginação, todas as escolas do recorte com o Índice de
+// Saúde Operacional, criticidade, status e notas por dimensão. Reaproveita
+// integralmente a metodologia da aba "Saúde Operacional" via
+// buildSaudeOperacionalDataset — a regra de cálculo das dimensões NÃO é
+// duplicada aqui.
+//
+// Diferenças em relação ao relatório piloto (censo-preenchimento):
+//   - depende de um ano de censo específico (não existe "todos os anos");
+//   - a ordenação padrão é por criticidade decrescente (mais críticas
+//     primeiro), mantendo as escolas "sem_dados" ao final.
+// =====================================================================
+
+// saudeOperacionalReportColumns são os cabeçalhos do relatório, na ordem
+// exigida pela especificação: colunas territoriais, identificação, métricas
+// operacionais, índice/criticidade/status e, por fim, as notas por dimensão.
+var saudeOperacionalReportColumns = []string{
+	"Região de Integração",
+	"DRE",
+	"Município",
+	"Zona",
+	"Código INEP",
+	"Escola",
+	"Alunos",
+	"Salas",
+	"Alunos por sala",
+	"Índice de Saúde",
+	"Criticidade",
+	"Status",
+	"Infraestrutura",
+	"Energia",
+	"Merenda",
+	"Segurança",
+	"Pessoal",
+	"Tecnologia",
+	"Pedagógico",
+	"Governança",
+}
+
+// resolveSaudeOperacionalReportYear decide o ano de censo do relatório. Ao
+// contrário do relatório de preenchimento (Year = 0 ⇒ todos os anos), a Saúde
+// Operacional depende de um ano específico: quando o filtro de ano está ausente
+// ou inválido (Year = 0), usa o ano padrão do endpoint analítico (ano corrente),
+// preservando o comportamento da aba "Saúde Operacional".
+func resolveSaudeOperacionalReportYear(f reportFilters, now time.Time) int {
+	if f.Year > 0 {
+		return f.Year
+	}
+	return now.Year()
+}
+
+// saudeOperacionalStatusLabel traduz o status técnico do payload analítico
+// ("saudavel", "atencao", "critica", "sem_dados") para um rótulo legível na
+// coluna Status do XLSX. Não altera o payload público — é apresentação.
+func saudeOperacionalStatusLabel(status string) string {
+	switch status {
+	case "saudavel":
+		return "Saudável"
+	case "atencao":
+		return "Atenção"
+	case "critica":
+		return "Crítica"
+	default:
+		return "Sem dados"
+	}
+}
+
+// reportRegiaoSQL carrega o mapa município → Região de Integração a partir de
+// reg_integracao. A chave usa UPPER(TRIM(municipio)) para casar com schools.
+// municipio do mesmo jeito que os demais endpoints (sem unaccent nesta etapa).
+const reportRegiaoSQL = `
+	SELECT UPPER(TRIM(municipio)) AS municipio, COALESCE(regiao_de_integracao, '') AS regiao
+	FROM reg_integracao
+`
+
+// loadRegiaoPorMunicipio devolve o mapa município (normalizado) → Região de
+// Integração, usado para preencher a coluna territorial do relatório sem alterar
+// o payload da Saúde Operacional (que não expõe a região).
+func (app *application) loadRegiaoPorMunicipio(ctx context.Context) (map[string]string, error) {
+	rows, err := app.models.Schools.DB.QueryContext(ctx, reportRegiaoSQL)
+	if err != nil {
+		return nil, fmt.Errorf("consultar regiões de integração: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]string)
+	for rows.Next() {
+		var municipio, regiao string
+		if err := rows.Scan(&municipio, &regiao); err != nil {
+			return nil, fmt.Errorf("ler região de integração: %w", err)
+		}
+		if _, ok := out[municipio]; !ok {
+			out[municipio] = regiao
+		}
+	}
+	return out, rows.Err()
+}
+
+// normalizeReportMunicipio normaliza o município para casar com a chave de
+// reportRegiaoSQL (UPPER(TRIM(...))).
+func normalizeReportMunicipio(municipio string) string {
+	return strings.ToUpper(strings.TrimSpace(municipio))
+}
+
+// reportCriticidadeValue extrai a criticidade comparável de uma escola. Escolas
+// pontuadas sempre possuem criticidade; o valor sentinela negativo só protege
+// contra um nil inesperado, jogando-o para o fim do grupo de pontuadas.
+func reportCriticidadeValue(e SaudeOperacionalEscola) float64 {
+	if e.Criticidade == nil {
+		return -1
+	}
+	return *e.Criticidade
+}
+
+// reportINEPValue devolve o código INEP da escola (vazio quando ausente), usado
+// como critério final e estável de desempate.
+func reportINEPValue(e SaudeOperacionalEscola) string {
+	if e.CodigoINEP == nil {
+		return ""
+	}
+	return *e.CodigoINEP
+}
+
+// lessSaudeOperacionalReport ordena as escolas do relatório: escolas "sem_dados"
+// vão para o final; entre as pontuadas, criticidade decrescente (mais críticas
+// primeiro); empates por DRE, Município, Escola e Código INEP (texto case/acento
+// insensível). A ordenação é determinística.
+func lessSaudeOperacionalReport(a, b SaudeOperacionalEscola) bool {
+	aSemDados := a.Status == "sem_dados"
+	bSemDados := b.Status == "sem_dados"
+	if aSemDados != bSemDados {
+		// não-sem_dados vem antes.
+		return !aSemDados
+	}
+
+	if !aSemDados {
+		ac := reportCriticidadeValue(a)
+		bc := reportCriticidadeValue(b)
+		if ac != bc {
+			return ac > bc
+		}
+	}
+
+	if c := strings.Compare(normalizeSaudeSearch(a.DRE), normalizeSaudeSearch(b.DRE)); c != 0 {
+		return c < 0
+	}
+	if c := strings.Compare(normalizeSaudeSearch(a.Municipio), normalizeSaudeSearch(b.Municipio)); c != 0 {
+		return c < 0
+	}
+	if c := strings.Compare(normalizeSaudeSearch(a.Escola), normalizeSaudeSearch(b.Escola)); c != 0 {
+		return c < 0
+	}
+	return reportINEPValue(a) < reportINEPValue(b)
+}
+
+// sortSaudeOperacionalReport ordena uma cópia das escolas pela ordem do
+// relatório (ver lessSaudeOperacionalReport), sem alterar o slice de origem.
+func sortSaudeOperacionalReport(escolas []SaudeOperacionalEscola) []SaudeOperacionalEscola {
+	sorted := append([]SaudeOperacionalEscola(nil), escolas...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return lessSaudeOperacionalReport(sorted[i], sorted[j])
+	})
+	return sorted
+}
+
+// optFloatCell devolve a célula de um número opcional: célula vazia quando nil,
+// caso contrário o próprio valor (já arredondado pela metodologia).
+func optFloatCell(v *float64) any {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// optIntCell devolve a célula de um inteiro opcional: vazia quando nil.
+func optIntCell(v *int) any {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// optStringCell devolve a célula de uma string opcional: vazia quando nil.
+func optStringCell(v *string) any {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// buildSaudeOperacionalReportData monta o reportData do relatório de Saúde
+// Operacional: carrega o dataset base (todas as escolas do recorte, no ano
+// resolvido), resolve a Região de Integração por município, ordena por
+// criticidade decrescente e projeta as colunas do XLSX. Não pagina.
+func (app *application) buildSaudeOperacionalReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
+	soFilters := saudeOperacionalFilters{
+		DRE:              f.DRE,
+		Municipio:        f.Municipio,
+		Zona:             f.Zona,
+		RegiaoIntegracao: f.RegiaoIntegracao,
+	}
+
+	escolas, _, err := app.buildSaudeOperacionalDataset(ctx, f.Year, soFilters)
+	if err != nil {
+		return reportData{}, err
+	}
+
+	regiaoPorMunicipio, err := app.loadRegiaoPorMunicipio(ctx)
+	if err != nil {
+		return reportData{}, err
+	}
+
+	sorted := sortSaudeOperacionalReport(escolas)
+
+	rows := make([][]any, 0, len(sorted))
+	for _, e := range sorted {
+		regiao := regiaoPorMunicipio[normalizeReportMunicipio(e.Municipio)]
+		rows = append(rows, []any{
+			regiao,
+			e.DRE,
+			e.Municipio,
+			optStringCell(e.Zona),
+			optStringCell(e.CodigoINEP),
+			e.Escola,
+			optIntCell(e.TotalAlunos),
+			optIntCell(e.SalasAula),
+			optFloatCell(e.AlunosPorSala),
+			optFloatCell(e.Saude),
+			optFloatCell(e.Criticidade),
+			saudeOperacionalStatusLabel(e.Status),
+			optFloatCell(e.Dimensoes.Infraestrutura),
+			optFloatCell(e.Dimensoes.Energia),
+			optFloatCell(e.Dimensoes.Merenda),
+			optFloatCell(e.Dimensoes.Seguranca),
+			optFloatCell(e.Dimensoes.Pessoal),
+			optFloatCell(e.Dimensoes.Tecnologia),
+			optFloatCell(e.Dimensoes.Pedagogico),
+			optFloatCell(e.Dimensoes.Governanca),
+		})
+	}
+
+	return reportData{
+		Title:       def.Title,
+		SheetName:   def.SheetName,
+		FiltersLine: f.describe(),
+		Headers:     saudeOperacionalReportColumns,
+		Rows:        rows,
+	}, nil
+}

--- a/api/cmd/api/reports_saude_operacional_test.go
+++ b/api/cmd/api/reports_saude_operacional_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReportsCatalogRecognizesSaudeOperacional garante que o relatório de Saúde
+// Operacional está registrado com os metadados esperados.
+func TestReportsCatalogRecognizesSaudeOperacional(t *testing.T) {
+	def, ok := lookupReport(reportSaudeOperacionalID)
+	if !ok {
+		t.Fatalf("lookupReport(%q) = not found; esperado encontrado", reportSaudeOperacionalID)
+	}
+	if def.ID != reportSaudeOperacionalID {
+		t.Fatalf("ID = %q; want %q", def.ID, reportSaudeOperacionalID)
+	}
+	if def.SheetName != "Saude Operacional" {
+		t.Fatalf("SheetName = %q; want %q", def.SheetName, "Saude Operacional")
+	}
+	if def.FileBase != "relatorio_saude_operacional_escolas" {
+		t.Fatalf("FileBase = %q; want %q", def.FileBase, "relatorio_saude_operacional_escolas")
+	}
+	if def.Title != "Relatório de Índice de Saúde Operacional por Escola" {
+		t.Fatalf("Title = %q; inesperado", def.Title)
+	}
+}
+
+// TestResolveSaudeOperacionalReportYear cobre o ano específico e o fallback para
+// o ano corrente quando o filtro está ausente/inválido (Year = 0).
+func TestResolveSaudeOperacionalReportYear(t *testing.T) {
+	now := time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC)
+
+	if got := resolveSaudeOperacionalReportYear(reportFilters{Year: 2025}, now); got != 2025 {
+		t.Fatalf("ano específico = %d; want 2025", got)
+	}
+	if got := resolveSaudeOperacionalReportYear(reportFilters{Year: 0}, now); got != 2026 {
+		t.Fatalf("ano ausente = %d; want 2026 (ano corrente)", got)
+	}
+}
+
+// TestSaudeOperacionalStatusLabel garante a tradução dos status técnicos para
+// rótulos legíveis na coluna Status.
+func TestSaudeOperacionalStatusLabel(t *testing.T) {
+	tests := map[string]string{
+		"saudavel":   "Saudável",
+		"atencao":    "Atenção",
+		"critica":    "Crítica",
+		"sem_dados":  "Sem dados",
+		"inesperado": "Sem dados",
+	}
+	for in, want := range tests {
+		if got := saudeOperacionalStatusLabel(in); got != want {
+			t.Fatalf("saudeOperacionalStatusLabel(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+// TestSaudeOperacionalReportColumns garante a presença e ordem das colunas
+// exigidas, incluindo Pedagógico e Governança ao final.
+func TestSaudeOperacionalReportColumns(t *testing.T) {
+	want := []string{
+		"Região de Integração", "DRE", "Município", "Zona", "Código INEP", "Escola",
+		"Alunos", "Salas", "Alunos por sala", "Índice de Saúde", "Criticidade", "Status",
+		"Infraestrutura", "Energia", "Merenda", "Segurança", "Pessoal", "Tecnologia",
+		"Pedagógico", "Governança",
+	}
+	if len(saudeOperacionalReportColumns) != len(want) {
+		t.Fatalf("len(colunas) = %d; want %d", len(saudeOperacionalReportColumns), len(want))
+	}
+	for i := range want {
+		if saudeOperacionalReportColumns[i] != want[i] {
+			t.Fatalf("coluna[%d] = %q; want %q", i, saudeOperacionalReportColumns[i], want[i])
+		}
+	}
+}
+
+// TestSortSaudeOperacionalReport valida a ordenação: criticidade decrescente,
+// sem_dados ao final e desempate por DRE/Município/Escola/INEP.
+func TestSortSaudeOperacionalReport(t *testing.T) {
+	escola := func(nome, dre, mun, inep, status string, criticidade *float64) SaudeOperacionalEscola {
+		var inepPtr *string
+		if inep != "" {
+			inepPtr = ptrString(inep)
+		}
+		return SaudeOperacionalEscola{
+			Escola:      nome,
+			DRE:         dre,
+			Municipio:   mun,
+			CodigoINEP:  inepPtr,
+			Status:      status,
+			Criticidade: criticidade,
+		}
+	}
+
+	semDados := escola("Z Escola Sem Dados", "DRE A", "Mun A", "11111111", "sem_dados", nil)
+	critica := escola("Escola Critica", "DRE B", "Mun B", "22222222", "critica", ptrFloat(80))
+	atencao := escola("Escola Atencao", "DRE C", "Mun C", "33333333", "atencao", ptrFloat(40))
+	// Duas escolas com mesma criticidade para testar desempate por DRE.
+	empateZ := escola("Escola Empate", "DRE Z", "Mun Z", "44444444", "critica", ptrFloat(60))
+	empateA := escola("Escola Empate", "DRE A", "Mun A", "55555555", "critica", ptrFloat(60))
+
+	in := []SaudeOperacionalEscola{semDados, atencao, empateZ, critica, empateA}
+	got := sortSaudeOperacionalReport(in)
+
+	// Ordem esperada: critica(80), empateA(60, DRE A), empateZ(60, DRE Z), atencao(40), semDados.
+	wantINEP := []string{"22222222", "55555555", "44444444", "33333333", "11111111"}
+	if len(got) != len(wantINEP) {
+		t.Fatalf("len = %d; want %d", len(got), len(wantINEP))
+	}
+	for i, inep := range wantINEP {
+		if reportINEPValue(got[i]) != inep {
+			t.Fatalf("posição %d INEP = %q; want %q", i, reportINEPValue(got[i]), inep)
+		}
+	}
+
+	// O slice de origem não deve ser alterado.
+	if reportINEPValue(in[0]) != "11111111" {
+		t.Fatalf("slice de origem foi alterado: in[0] INEP = %q", reportINEPValue(in[0]))
+	}
+}
+
+// TestOptCellHelpers cobre as células opcionais (vazias quando nil).
+func TestOptCellHelpers(t *testing.T) {
+	if optFloatCell(nil) != "" {
+		t.Fatalf("optFloatCell(nil) != vazio")
+	}
+	if optFloatCell(ptrFloat(72.5)) != 72.5 {
+		t.Fatalf("optFloatCell(72.5) = %v; want 72.5", optFloatCell(ptrFloat(72.5)))
+	}
+	if optIntCell(nil) != "" {
+		t.Fatalf("optIntCell(nil) != vazio")
+	}
+	if optIntCell(ptrInt(120)) != 120 {
+		t.Fatalf("optIntCell(120) = %v; want 120", optIntCell(ptrInt(120)))
+	}
+	if optStringCell(nil) != "" {
+		t.Fatalf("optStringCell(nil) != vazio")
+	}
+	if optStringCell(ptrString("Urbana")) != "Urbana" {
+		t.Fatalf("optStringCell(Urbana) = %v; want Urbana", optStringCell(ptrString("Urbana")))
+	}
+}
+
+// TestWriteSaudeOperacionalReportXLSX garante que o gerador genérico produz um
+// XLSX válido para o relatório de Saúde Operacional, com aba, título, cabeçalho
+// na linha 4 e dados a partir da linha 5.
+func TestWriteSaudeOperacionalReportXLSX(t *testing.T) {
+	rd := reportData{
+		Title:       "Relatório de Índice de Saúde Operacional por Escola",
+		SheetName:   "Saude Operacional",
+		FiltersLine: "Filtros aplicados — Ano: 2026",
+		Headers:     saudeOperacionalReportColumns,
+		Rows: [][]any{
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "12345678", "Escola Critica",
+				300, 10, 30.0, 35.0, 65.0, "Crítica",
+				40.0, 50.0, 30.0, 20.0, 60.0, 45.0, 55.0, 50.0},
+			{"", "DRE X", "Mun X", "", "", "Escola Sem Dados",
+				"", "", "", "", "", "Sem dados",
+				"", "", "", "", "", "", "", ""},
+		},
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		t.Fatalf("writeReportXLSX erro: %v", err)
+	}
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer erro: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("arquivo XLSX vazio")
+	}
+
+	if idx, err := f.GetSheetIndex("Saude Operacional"); err != nil || idx < 0 {
+		t.Fatalf("aba 'Saude Operacional' não encontrada (idx=%d, err=%v)", idx, err)
+	}
+	if v, err := f.GetCellValue("Saude Operacional", "A1"); err != nil || v != rd.Title {
+		t.Fatalf("A1 = %q (err=%v); want título", v, err)
+	}
+	if v, err := f.GetCellValue("Saude Operacional", "A4"); err != nil || v != "Região de Integração" {
+		t.Fatalf("A4 = %q (err=%v); want primeiro cabeçalho", v, err)
+	}
+	// Última coluna do cabeçalho (Governança) na coluna T (20ª).
+	if v, err := f.GetCellValue("Saude Operacional", "T4"); err != nil || v != "Governança" {
+		t.Fatalf("T4 = %q (err=%v); want 'Governança'", v, err)
+	}
+	// Status da primeira linha de dados na coluna L (12ª), linha 5.
+	if v, err := f.GetCellValue("Saude Operacional", "L5"); err != nil || v != "Crítica" {
+		t.Fatalf("L5 = %q (err=%v); want 'Crítica'", v, err)
+	}
+}
+
+// TestBuildSaudeOperacionalReportFileName garante o nome de arquivo com ano
+// específico, espelhando o exemplo da especificação.
+func TestBuildSaudeOperacionalReportFileName(t *testing.T) {
+	got := buildReportFileName("relatorio_saude_operacional_escolas", reportFilters{Year: 2026})
+	want := "relatorio_saude_operacional_escolas_2026.xlsx"
+	if got != want {
+		t.Fatalf("buildReportFileName = %q; want %q", got, want)
+	}
+}

--- a/api/cmd/api/reports_test.go
+++ b/api/cmd/api/reports_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestReportsCatalogRecognizesPiloto garante que o relatório piloto está
+// registrado e expõe os metadados esperados.
+func TestReportsCatalogRecognizesPiloto(t *testing.T) {
+	def, ok := lookupReport(reportCensoPreenchimentoID)
+	if !ok {
+		t.Fatalf("lookupReport(%q) = not found; esperado encontrado", reportCensoPreenchimentoID)
+	}
+	if def.ID != reportCensoPreenchimentoID {
+		t.Fatalf("ID = %q; want %q", def.ID, reportCensoPreenchimentoID)
+	}
+	if def.SheetName != "Preenchimento Censo" {
+		t.Fatalf("SheetName = %q; want %q", def.SheetName, "Preenchimento Censo")
+	}
+	if def.FileBase != "relatorio_censo_preenchimento_escolas" {
+		t.Fatalf("FileBase = %q; inesperado", def.FileBase)
+	}
+	if strings.TrimSpace(def.Title) == "" {
+		t.Fatalf("Title vazio")
+	}
+}
+
+// TestReportsCatalogUnknownNotFound garante que um report_id inexistente
+// não é resolvido.
+func TestReportsCatalogUnknownNotFound(t *testing.T) {
+	if _, ok := lookupReport("relatorio-que-nao-existe"); ok {
+		t.Fatalf("lookupReport de id inexistente retornou ok=true")
+	}
+	if _, ok := lookupReport(""); ok {
+		t.Fatalf("lookupReport(\"\") retornou ok=true")
+	}
+}
+
+// TestNormalizeReportFormat cobre o default xlsx e a normalização de caixa.
+func TestNormalizeReportFormat(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", "xlsx"},
+		{"   ", "xlsx"},
+		{"xlsx", "xlsx"},
+		{"XLSX", "xlsx"},
+		{" Xlsx ", "xlsx"},
+		{"pdf", "pdf"},
+		{"csv", "csv"},
+	}
+	for _, tt := range tests {
+		if got := normalizeReportFormat(tt.in); got != tt.want {
+			t.Fatalf("normalizeReportFormat(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestParseReportFiltersYear garante que year ausente/inválido vira 0
+// (todos os anos) — diferente de parseAnalyticsFilters.
+func TestParseReportFiltersYear(t *testing.T) {
+	for _, invalid := range []string{"", "abc", "0", "-3", "  "} {
+		got := parseReportFilters(url.Values{"year": {invalid}})
+		if got.Year != 0 {
+			t.Fatalf("year %q = %d; want 0 (todos os anos)", invalid, got.Year)
+		}
+	}
+	got := parseReportFilters(url.Values{"year": {" 2026 "}})
+	if got.Year != 2026 {
+		t.Fatalf("year válido = %d; want 2026", got.Year)
+	}
+}
+
+// TestParseReportFiltersStringsAndArgs cobre a leitura dos filtros textuais
+// e a ordem posicional dos argumentos.
+func TestParseReportFiltersStringsAndArgs(t *testing.T) {
+	q := url.Values{
+		"year":              {"2026"},
+		"dre":               {"  BELEM  "},
+		"municipio":         {"Belém"},
+		"zona":              {"Urbana"},
+		"regiao_integracao": {"GUAJARA"},
+	}
+	f := parseReportFilters(q)
+	if f.DRE != "BELEM" || f.Municipio != "Belém" || f.Zona != "Urbana" || f.RegiaoIntegracao != "GUAJARA" {
+		t.Fatalf("filtros = %+v; leitura incorreta", f)
+	}
+	args := f.args()
+	want := []any{2026, "BELEM", "Belém", "Urbana", "GUAJARA"}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v; want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args[%d] = %v; want %v", i, args[i], want[i])
+		}
+	}
+}
+
+// TestCensoStatusLabel cobre a tabela de classificação gerencial.
+func TestCensoStatusLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    string
+		hasCensus bool
+		synced    bool
+		want      string
+	}{
+		{"sem resposta", "", false, false, "Pendente"},
+		{"rascunho", "draft", true, false, "Rascunho"},
+		{"completed nao sincronizado", "completed", true, false, "Pendente de Sincronização"},
+		{"completed sincronizado", "completed", true, true, "Concluído"},
+		{"status inesperado", "qualquer", true, false, "Verificar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := censoStatusLabel(tt.status, tt.hasCensus, tt.synced); got != tt.want {
+				t.Fatalf("censoStatusLabel(%q,%v,%v) = %q; want %q",
+					tt.status, tt.hasCensus, tt.synced, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSituacaoOperacional garante que cada status gerencial mapeia para uma
+// frase operacional distinta.
+func TestSituacaoOperacional(t *testing.T) {
+	labels := []string{"Pendente", "Rascunho", "Pendente de Sincronização", "Concluído", "Verificar"}
+	seen := map[string]bool{}
+	for _, l := range labels {
+		s := situacaoOperacional(l)
+		if strings.TrimSpace(s) == "" {
+			t.Fatalf("situacaoOperacional(%q) vazia", l)
+		}
+		if seen[s] {
+			t.Fatalf("situacaoOperacional(%q) = %q duplicada", l, s)
+		}
+		seen[s] = true
+	}
+}
+
+// TestSanitizeFileNamePart garante nomes seguros (minúsculas, sem acentos,
+// sem espaços, sem caracteres especiais).
+func TestSanitizeFileNamePart(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"DRE Belém", "dre_belem"},
+		{"  São Félix  ", "sao_felix"},
+		{"Conceição/Araguaia", "conceicao_araguaia"},
+		{"GUAJARÁ", "guajara"},
+		{"a..b__c", "a_b_c"},
+		{"!@#$", ""},
+		{"Já é 2026!", "ja_e_2026"},
+	}
+	for _, tt := range tests {
+		if got := sanitizeFileNamePart(tt.in); got != tt.want {
+			t.Fatalf("sanitizeFileNamePart(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestBuildReportFileName cobre os exemplos da especificação.
+func TestBuildReportFileName(t *testing.T) {
+	base := "relatorio_censo_preenchimento_escolas"
+
+	tests := []struct {
+		name    string
+		filters reportFilters
+		want    string
+	}{
+		{
+			name:    "ano especifico",
+			filters: reportFilters{Year: 2026},
+			want:    "relatorio_censo_preenchimento_escolas_2026.xlsx",
+		},
+		{
+			name:    "todos os anos",
+			filters: reportFilters{Year: 0},
+			want:    "relatorio_censo_preenchimento_escolas_todos_anos.xlsx",
+		},
+		{
+			name:    "ano e dre",
+			filters: reportFilters{Year: 2026, DRE: "Belém"},
+			want:    "relatorio_censo_preenchimento_escolas_2026_dre_belem.xlsx",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildReportFileName(base, tt.filters)
+			if got != tt.want {
+				t.Fatalf("buildReportFileName = %q; want %q", got, tt.want)
+			}
+			if strings.ContainsAny(got, " /\\") {
+				t.Fatalf("filename %q contém caractere inseguro", got)
+			}
+		})
+	}
+}
+
+// TestWriteReportXLSXNonEmpty garante que a geração produz um arquivo XLSX
+// não vazio com o título e os cabeçalhos esperados.
+func TestWriteReportXLSXNonEmpty(t *testing.T) {
+	rd := reportData{
+		Title:       "Relatório de Teste",
+		SheetName:   "Preenchimento Censo",
+		FiltersLine: "Filtros aplicados — Ano: 2026",
+		Headers:     censoPreenchimentoReportColumns,
+		Rows: [][]any{
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "12345678", "Escola X",
+				"Pendente", "", "", "Não", "", "Aguardando preenchimento"},
+			{"GUAJARA", "BELEM", "BELEM", "Urbana", "87654321", "Escola Y",
+				"Concluído", 2026, "01/06/2026 10:00", "Sim", "02/06/2026 11:00", "Concluído e sincronizado"},
+		},
+	}
+
+	f, err := writeReportXLSX(rd)
+	if err != nil {
+		t.Fatalf("writeReportXLSX erro: %v", err)
+	}
+
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer erro: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("arquivo XLSX vazio")
+	}
+
+	// A aba deve existir com o nome amigável.
+	if idx, err := f.GetSheetIndex("Preenchimento Censo"); err != nil || idx < 0 {
+		t.Fatalf("aba 'Preenchimento Censo' não encontrada (idx=%d, err=%v)", idx, err)
+	}
+
+	// Título na A1.
+	if v, err := f.GetCellValue("Preenchimento Censo", "A1"); err != nil || v != "Relatório de Teste" {
+		t.Fatalf("A1 = %q (err=%v); want título", v, err)
+	}
+
+	// Primeiro cabeçalho na linha 4.
+	if v, err := f.GetCellValue("Preenchimento Censo", "A4"); err != nil || v != "Região de Integração" {
+		t.Fatalf("A4 = %q (err=%v); want primeiro cabeçalho", v, err)
+	}
+
+	// Primeira linha de dados na linha 5.
+	if v, err := f.GetCellValue("Preenchimento Censo", "G5"); err != nil || v != "Pendente" {
+		t.Fatalf("G5 = %q (err=%v); want 'Pendente'", v, err)
+	}
+}
+
+// TestCensoPreenchimentoQueryShape valida o formato da consulta do piloto:
+// parte de schools s, usa LEFT JOIN (inclui escolas pendentes), filtro de
+// ano opcional ($1 = 0 OR year = $1), filtros globais por AND e ordenação
+// por prioridade gerencial. Não pode exigir status='completed' no WHERE.
+func TestCensoPreenchimentoQueryShape(t *testing.T) {
+	q := censoPreenchimentoSelectSQL
+
+	mustContain := []string{
+		"FROM schools s",
+		"LEFT JOIN latest_census cr",
+		"LEFT JOIN reg_integracao ri",
+		"DISTINCT ON (school_id)",
+		"($1 = 0 OR year = $1)",
+		"($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))",
+		"($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))",
+		"($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))",
+		"FROM reg_integracao",
+		"UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))",
+		"WHEN cr.status IS NULL THEN 1",
+		"WHEN cr.status = 'draft' THEN 2",
+	}
+	for _, frag := range mustContain {
+		if !strings.Contains(q, frag) {
+			t.Fatalf("query não contém %q", frag)
+		}
+	}
+
+	if strings.Contains(q, "INNER JOIN") {
+		t.Fatalf("query usa INNER JOIN; o LEFT JOIN deve incluir escolas pendentes")
+	}
+	if strings.Contains(q, "AND status = 'completed'") || strings.Contains(q, "s.status = 'completed'") {
+		t.Fatalf("query exige status='completed' no WHERE geral; pendentes/rascunhos seriam excluídos")
+	}
+}

--- a/api/cmd/api/reports_xlsx.go
+++ b/api/cmd/api/reports_xlsx.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/xuri/excelize/v2"
+)
+
+// =====================================================================
+// Gerador XLSX genérico de relatórios
+// =====================================================================
+// Recebe um reportData (título, filtros, cabeçalhos e linhas já prontos
+// pelo builder do relatório) e produz um *excelize.File com o layout
+// padrão da primeira fase:
+//
+//   Linha 1: título do relatório (negrito, mesclado sobre as colunas)
+//   Linha 2: filtros aplicados
+//   Linha 3: em branco
+//   Linha 4: cabeçalhos (negrito, painel congelado abaixo)
+//   Linha 5+: dados
+//
+// Sem design avançado: negrito no cabeçalho, freeze pane, largura básica
+// das colunas e nome de aba amigável. Reaproveita a dependência já
+// existente github.com/xuri/excelize/v2 (nenhuma dependência nova).
+// =====================================================================
+
+// reportData é o contrato neutro entre os builders de relatório e o
+// gerador XLSX. As células de Rows podem ser string, int, float64 ou
+// já-formatadas (datas chegam como string no padrão pt-BR).
+type reportData struct {
+	Title       string
+	SheetName   string
+	FiltersLine string
+	Headers     []string
+	Rows        [][]any
+}
+
+// dataInicialRow é a primeira linha de dados (linha 5; cabeçalho na 4).
+const (
+	reportHeaderRow = 4
+	reportDataRow   = 5
+)
+
+// writeReportXLSX monta o arquivo XLSX a partir do reportData. Nunca
+// pagina: escreve todas as linhas recebidas.
+func writeReportXLSX(rd reportData) (*excelize.File, error) {
+	f := excelize.NewFile()
+
+	sheet := strings.TrimSpace(rd.SheetName)
+	if sheet == "" {
+		sheet = "Relatório"
+	}
+	// excelize cria "Sheet1" por padrão; renomeia para o nome amigável.
+	if err := f.SetSheetName("Sheet1", sheet); err != nil {
+		return nil, fmt.Errorf("nomear aba: %w", err)
+	}
+
+	numCols := len(rd.Headers)
+	if numCols == 0 {
+		numCols = 1
+	}
+	lastColName, err := excelize.ColumnNumberToName(numCols)
+	if err != nil {
+		return nil, fmt.Errorf("calcular última coluna: %w", err)
+	}
+
+	// Título (linha 1) e filtros (linha 2).
+	if err := f.SetCellValue(sheet, "A1", rd.Title); err != nil {
+		return nil, err
+	}
+	if err := f.SetCellValue(sheet, "A2", rd.FiltersLine); err != nil {
+		return nil, err
+	}
+	// Mescla o título sobre as colunas do relatório para ficar legível.
+	if numCols > 1 {
+		if err := f.MergeCell(sheet, "A1", lastColName+"1"); err != nil {
+			return nil, err
+		}
+	}
+
+	// Estilos: título em negrito maior, cabeçalho em negrito.
+	titleStyle, err := f.NewStyle(&excelize.Style{
+		Font: &excelize.Font{Bold: true, Size: 14},
+	})
+	if err != nil {
+		return nil, err
+	}
+	headerStyle, err := f.NewStyle(&excelize.Style{
+		Font: &excelize.Font{Bold: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := f.SetCellStyle(sheet, "A1", "A1", titleStyle); err != nil {
+		return nil, err
+	}
+
+	// Cabeçalhos (linha 4).
+	for i, h := range rd.Headers {
+		cell, err := excelize.CoordinatesToCellName(i+1, reportHeaderRow)
+		if err != nil {
+			return nil, err
+		}
+		if err := f.SetCellValue(sheet, cell, h); err != nil {
+			return nil, err
+		}
+	}
+	if len(rd.Headers) > 0 {
+		headerLast, _ := excelize.CoordinatesToCellName(numCols, reportHeaderRow)
+		if err := f.SetCellStyle(sheet, "A4", headerLast, headerStyle); err != nil {
+			return nil, err
+		}
+	}
+
+	// Dados (linha 5 em diante).
+	for r, row := range rd.Rows {
+		for c, val := range row {
+			cell, err := excelize.CoordinatesToCellName(c+1, reportDataRow+r)
+			if err != nil {
+				return nil, err
+			}
+			if err := f.SetCellValue(sheet, cell, val); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Largura básica das colunas; nada sofisticado.
+	if err := f.SetColWidth(sheet, "A", lastColName, 20); err != nil {
+		return nil, err
+	}
+
+	// Congela o painel abaixo do cabeçalho, mantendo-o visível na rolagem.
+	if err := f.SetPanes(sheet, &excelize.Panes{
+		Freeze:      true,
+		YSplit:      reportHeaderRow,
+		TopLeftCell: "A" + fmt.Sprint(reportDataRow),
+		ActivePane:  "bottomLeft",
+	}); err != nil {
+		return nil, err
+	}
+
+	if idx, err := f.GetSheetIndex(sheet); err == nil {
+		f.SetActiveSheet(idx)
+	}
+
+	return f, nil
+}
+
+// buildReportFileName deriva um nome de arquivo seguro (sem acentos, sem
+// espaços) a partir do FileBase do relatório e dos filtros aplicados.
+// Sempre inclui o recorte de ano (ano específico ou "todos_anos") e, em
+// seguida, os filtros territoriais presentes. Exemplos:
+//
+//	relatorio_censo_preenchimento_escolas_2026.xlsx
+//	relatorio_censo_preenchimento_escolas_todos_anos.xlsx
+//	relatorio_censo_preenchimento_escolas_2026_dre_belem.xlsx
+func buildReportFileName(fileBase string, f reportFilters) string {
+	parts := []string{sanitizeFileNamePart(fileBase)}
+
+	if f.Year > 0 {
+		parts = append(parts, fmt.Sprintf("%d", f.Year))
+	} else {
+		parts = append(parts, "todos_anos")
+	}
+
+	if f.RegiaoIntegracao != "" {
+		parts = append(parts, "regiao", sanitizeFileNamePart(f.RegiaoIntegracao))
+	}
+	if f.DRE != "" {
+		parts = append(parts, "dre", sanitizeFileNamePart(f.DRE))
+	}
+	if f.Municipio != "" {
+		parts = append(parts, "municipio", sanitizeFileNamePart(f.Municipio))
+	}
+	if f.Zona != "" {
+		parts = append(parts, "zona", sanitizeFileNamePart(f.Zona))
+	}
+
+	name := strings.Join(parts, "_")
+	name = strings.Trim(name, "_")
+	if name == "" {
+		name = "relatorio"
+	}
+	return name + ".xlsx"
+}
+
+// accentReplacer mapeia os caracteres acentuados comuns do português para
+// seus equivalentes ASCII, evitando depender de golang.org/x/text só para
+// normalizar nomes de arquivo.
+var accentReplacer = strings.NewReplacer(
+	"á", "a", "à", "a", "â", "a", "ã", "a", "ä", "a",
+	"é", "e", "è", "e", "ê", "e", "ë", "e",
+	"í", "i", "ì", "i", "î", "i", "ï", "i",
+	"ó", "o", "ò", "o", "ô", "o", "õ", "o", "ö", "o",
+	"ú", "u", "ù", "u", "û", "u", "ü", "u",
+	"ç", "c", "ñ", "n",
+	"Á", "A", "À", "A", "Â", "A", "Ã", "A", "Ä", "A",
+	"É", "E", "È", "E", "Ê", "E", "Ë", "E",
+	"Í", "I", "Ì", "I", "Î", "I", "Ï", "I",
+	"Ó", "O", "Ò", "O", "Ô", "O", "Õ", "O", "Ö", "O",
+	"Ú", "U", "Ù", "U", "Û", "U", "Ü", "U",
+	"Ç", "C", "Ñ", "N",
+)
+
+// sanitizeFileNamePart normaliza um trecho para uso em nome de arquivo:
+// minúsculas, sem acentos, e qualquer caractere não alfanumérico vira um
+// único underscore. Garante um nome seguro para o header Content-Disposition.
+func sanitizeFileNamePart(s string) string {
+	s = accentReplacer.Replace(strings.TrimSpace(s))
+	s = strings.ToLower(s)
+
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastUnderscore = false
+		default:
+			if !lastUnderscore {
+				b.WriteByte('_')
+				lastUnderscore = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}

--- a/web/src/components/admin/AbaInfraestruturaSeguranca.tsx
+++ b/web/src/components/admin/AbaInfraestruturaSeguranca.tsx
@@ -15,6 +15,7 @@ import type {
   InfraCondicoes, InfraSeguranca, InfraEnergia, DashboardFilters,
 } from "./shared/types";
 import { buildPostgresSourceLabel } from "./shared/sourceLabel";
+import { ReportButton } from "./shared/ReportButton";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -134,10 +135,18 @@ export function AbaInfraestruturaSeguranca({
 
   return (
     <div className="space-y-6">
-      {/* Badge de fonte */}
-      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
-        <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
+      {/* Badge de fonte + ação de relatório */}
+      <div data-pres-hide="true" className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs text-emerald-700">
+          <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
+          <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
+        </div>
+        <ReportButton
+          reportId="infraestrutura-seguranca-escolas"
+          token={token}
+          filters={filters}
+          onUnauth={onUnauth}
+        />
       </div>
 
       {/* Banners de erro parcial */}

--- a/web/src/components/admin/AbaMerenda.tsx
+++ b/web/src/components/admin/AbaMerenda.tsx
@@ -17,6 +17,7 @@ import type {
   MerendaCondicoesSanitarias, DashboardFilters,
 } from "./shared/types";
 import { buildPostgresSourceLabel } from "./shared/sourceLabel";
+import { ReportButton } from "./shared/ReportButton";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -327,10 +328,18 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
 
   return (
     <div className="space-y-6">
-      {/* Badge de fonte */}
-      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
-        <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
+      {/* Badge de fonte + ação de relatório */}
+      <div data-pres-hide="true" className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs text-emerald-700">
+          <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
+          <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
+        </div>
+        <ReportButton
+          reportId="merenda-escolar-condicoes"
+          token={token}
+          filters={filters}
+          onUnauth={onUnauth}
+        />
       </div>
 
       {/* Banners de erro parcial */}

--- a/web/src/components/admin/AbaPorDre.tsx
+++ b/web/src/components/admin/AbaPorDre.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { AlertCircle, Loader2, MapPinned } from "lucide-react";
 import { apiFetch } from "./shared/api";
 import { C } from "./shared/constants";
+import { ReportButton } from "./shared/ReportButton";
 import type { DashboardFilters, PreenchimentoDrePayload } from "./shared/types";
 
 const ENDPOINT_BASE = "/v1/admin/analytics/preenchimento/dre";
@@ -125,6 +126,14 @@ export function AbaPorDre({
           <p className="text-[11px] text-slate-400 mt-1.5">
             Município, Região de Integração e Zona reduzem o conjunto de escolas antes do agrupamento por DRE.
           </p>
+        </div>
+        <div className="ml-auto shrink-0">
+          <ReportButton
+            reportId="censo-preenchimento-escolas"
+            token={token}
+            filters={filters}
+            onUnauth={onUnauth}
+          />
         </div>
       </div>
 

--- a/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
+++ b/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { apiFetch, sanitize } from "./shared/api";
 import { C } from "./shared/constants";
+import { ReportButton } from "./shared/ReportButton";
 import SaudeOperacionalMetodologiaInfo from "./SaudeOperacionalMetodologiaInfo";
 import type {
   SaudeOperacionalEscola,
@@ -410,6 +411,14 @@ export function AbaSaudeOperacionalEscolas({
               {payload.total_escolas.toLocaleString("pt-BR")} escolas cadastradas
             </span>
             <SaudeOperacionalMetodologiaInfo />
+          </div>
+          <div className="mt-3 flex lg:justify-end">
+            <ReportButton
+              reportId="saude-operacional-escolas"
+              token={token}
+              filters={filters}
+              onUnauth={onUnauth}
+            />
           </div>
           <p className="mt-2 text-xs text-slate-500 lg:text-right">
             Escolas sem censo concluído no ano aparecem como pendentes de censo.

--- a/web/src/components/admin/shared/ReportButton.tsx
+++ b/web/src/components/admin/shared/ReportButton.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+// Botão reutilizável de geração de relatórios gerenciais XLSX.
+// Consome a rota genérica protegida GET /v1/admin/reports/{reportId}, já existente
+// e validada no backend. Repassa os filtros globais ativos do dashboard, baixa o
+// arquivo respeitando o filename do header Content-Disposition e trata loading,
+// autenticação expirada (401) e erros amigáveis sem quebrar a UI.
+
+import React, { useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { API, DASHBOARD_REFERENCE_YEAR } from "./constants";
+import type { DashboardFilters } from "./types";
+
+type ReportButtonProps = {
+  reportId: string;
+  token: string;
+  filters?: DashboardFilters;
+  onUnauth: () => void;
+  label?: string;
+  className?: string;
+};
+
+// Monta a query string do relatório: format=xlsx + ano de referência + filtros
+// globais ativos. Filtros vazios não são enviados.
+function buildReportQuery(filters?: DashboardFilters): string {
+  const p = new URLSearchParams();
+  p.set("format", "xlsx");
+
+  const year = filters?.ano ?? DASHBOARD_REFERENCE_YEAR;
+  if (year) p.set("year", String(year));
+  if (filters?.dre)               p.set("dre", filters.dre);
+  if (filters?.municipio)         p.set("municipio", filters.municipio);
+  if (filters?.zona)              p.set("zona", filters.zona);
+  if (filters?.regiao_integracao) p.set("regiao_integracao", filters.regiao_integracao);
+
+  return p.toString();
+}
+
+// Extrai o filename do header Content-Disposition, tolerando os formatos
+// `filename*=UTF-8''...` (RFC 5987) e `filename="..."`. Usa o fallback quando o
+// header não vem ou não pôde ser interpretado.
+function filenameFromDisposition(header: string | null, fallback: string): string {
+  if (!header) return fallback;
+
+  const star = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(header);
+  if (star?.[1]) {
+    try {
+      return decodeURIComponent(star[1].trim().replace(/^"|"$/g, ""));
+    } catch {
+      // ignora e tenta o formato simples abaixo
+    }
+  }
+
+  const plain = /filename="?([^";]+)"?/i.exec(header);
+  if (plain?.[1]) return plain[1].trim();
+
+  return fallback;
+}
+
+export function ReportButton({
+  reportId,
+  token,
+  filters,
+  onUnauth,
+  label = "Gerar relatório",
+  className = "",
+}: ReportButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleDownload() {
+    if (loading) return; // evita duplo clique
+    setLoading(true);
+    setError("");
+
+    try {
+      const qs = buildReportQuery(filters);
+      const res = await fetch(`${API}/v1/admin/reports/${reportId}?${qs}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (res.status === 401) {
+        onUnauth();
+        return;
+      }
+
+      if (!res.ok) {
+        let msg = "Não foi possível gerar o relatório.";
+        try {
+          const body = await res.json();
+          if (body && typeof body.message === "string" && body.message.trim()) {
+            msg = body.message;
+          }
+        } catch {
+          // corpo não-JSON: mantém a mensagem amigável padrão
+        }
+        setError(msg);
+        return;
+      }
+
+      const blob = await res.blob();
+      const year = filters?.ano ?? DASHBOARD_REFERENCE_YEAR;
+      const fallbackName = `${reportId}-${year}.xlsx`;
+      const filename = filenameFromDisposition(
+        res.headers.get("Content-Disposition"),
+        fallbackName,
+      );
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError("Não foi possível gerar o relatório.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className={`flex flex-col items-end gap-1 ${className}`}>
+      <button
+        type="button"
+        onClick={handleDownload}
+        disabled={loading}
+        aria-busy={loading}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {loading ? (
+          <Loader2 size={14} className="animate-spin" />
+        ) : (
+          <Download size={14} />
+        )}
+        {loading ? "Gerando..." : label}
+      </button>
+      {error && (
+        <span className="text-[11px] text-rose-600 text-right max-w-xs" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/admin/shared/constants.ts
+++ b/web/src/components/admin/shared/constants.ts
@@ -5,6 +5,10 @@
 export const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 export const TOKEN_KEY = "censo_admin_token";
 
+// Temporário: o dashboard atual está fixado no ciclo do Censo Escolar 2026.
+// Usado como fallback de `year` quando nenhum ano é escolhido nos filtros globais.
+export const DASHBOARD_REFERENCE_YEAR = 2026;
+
 export const ZONA_COLORS: Record<string, string> = {
   "Urbana": "var(--zona-urbana)",
   "Rural": "var(--zona-rural)",


### PR DESCRIPTION
## Resumo

Adiciona botões de geração de relatórios gerenciais XLSX nas abas administrativas do dashboard.

## Escopo

* Cria componente reutilizável `ReportButton`;
* Integra os relatórios backend já validados;
* Envia filtros globais para o endpoint de relatórios;
* Baixa XLSX via `blob`;
* Usa o filename do `Content-Disposition`, quando disponível;
* Possui fallback de filename;
* Trata loading, erro e autenticação expirada;
* Evita duplo clique durante a geração.

## Relatórios integrados

* `saude-operacional-escolas`
* `infraestrutura-seguranca-escolas`
* `merenda-escolar-condicoes`
* `censo-preenchimento-escolas`

## Abas integradas

* Saúde Operacional;
* Infraestrutura e Segurança;
* Merenda Escolar;
* Preenchimento por DRE.

## Observação sobre Registros do Censo

A aba `Registros do Censo` ainda não recebe diretamente `token`, `onUnauth` e `filters`. Por isso, nesta primeira versão, o relatório `censo-preenchimento-escolas` foi integrado na aba `Preenchimento por DRE`, que já possui esses dados e tem aderência funcional ao relatório de acompanhamento do preenchimento.

## Filtros enviados

O botão envia:

* `format=xlsx`;
* `year`;
* `dre`, quando preenchido;
* `municipio`, quando preenchido;
* `zona`, quando preenchido;
* `regiao_integracao`, quando preenchido.

O ano usa `filters.ano` ou o fallback `DASHBOARD_REFERENCE_YEAR = 2026`.

## Validação

Executado:

* `npm run build` — sucesso;
* `npm run lint` — há erros pré-existentes na base, não introduzidos por este PR.

Também foi confirmado que os erros de lint já existem na base `develop`.

## Fora de escopo

* Novos relatórios backend;
* PDF;
* Alteração dos cálculos;
* Alteração dos endpoints analíticos;
* Alteração dos filtros globais;
* Redesenho geral das abas;
* Integração do botão na aba `Registros do Censo`.