### PR TITLE
feat(admin): adicionar botões de relatórios gerenciais

### DIFF
--- a/api/cmd/api/middleware.go
+++ b/api/cmd/api/middleware.go
@@ -45,6 +45,7 @@ func (app *application) enableCORS(next http.Handler) http.Handler {
 
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-API-Key, Cache-Control, Pragma")
+		w.Header().Set("Access-Control-Expose-Headers", "Content-Disposition")
 
 		// Previne MIME sniffing e clickjacking.
 		// X-XSS-Protection foi removido por estar obsoleto (pode introduzir

--- a/web/src/components/admin/AbaInfraestruturaSeguranca.tsx
+++ b/web/src/components/admin/AbaInfraestruturaSeguranca.tsx
@@ -15,6 +15,7 @@ import type {
   InfraCondicoes, InfraSeguranca, InfraEnergia, DashboardFilters,
 } from "./shared/types";
 import { buildPostgresSourceLabel } from "./shared/sourceLabel";
+import { ReportButton } from "./shared/ReportButton";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -134,10 +135,18 @@ export function AbaInfraestruturaSeguranca({
 
   return (
     <div className="space-y-6">
-      {/* Badge de fonte */}
-      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
-        <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
+      {/* Badge de fonte + ação de relatório */}
+      <div data-pres-hide="true" className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs text-emerald-700">
+          <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
+          <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
+        </div>
+        <ReportButton
+          reportId="infraestrutura-seguranca-escolas"
+          token={token}
+          filters={filters}
+          onUnauth={onUnauth}
+        />
       </div>
 
       {/* Banners de erro parcial */}

--- a/web/src/components/admin/AbaMerenda.tsx
+++ b/web/src/components/admin/AbaMerenda.tsx
@@ -17,6 +17,7 @@ import type {
   MerendaCondicoesSanitarias, DashboardFilters,
 } from "./shared/types";
 import { buildPostgresSourceLabel } from "./shared/sourceLabel";
+import { ReportButton } from "./shared/ReportButton";
 
 function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";
@@ -327,10 +328,18 @@ export function AbaMerenda({ token, onUnauth, filters }: AbaMerendaProps) {
 
   return (
     <div className="space-y-6">
-      {/* Badge de fonte */}
-      <div data-pres-hide="true" className="flex items-center gap-2 text-xs text-emerald-700">
-        <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-        <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
+      {/* Badge de fonte + ação de relatório */}
+      <div data-pres-hide="true" className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs text-emerald-700">
+          <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
+          <span>Fonte: {buildPostgresSourceLabel(filters)}</span>
+        </div>
+        <ReportButton
+          reportId="merenda-escolar-condicoes"
+          token={token}
+          filters={filters}
+          onUnauth={onUnauth}
+        />
       </div>
 
       {/* Banners de erro parcial */}

--- a/web/src/components/admin/AbaPorDre.tsx
+++ b/web/src/components/admin/AbaPorDre.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { AlertCircle, Loader2, MapPinned } from "lucide-react";
 import { apiFetch } from "./shared/api";
 import { C } from "./shared/constants";
+import { ReportButton } from "./shared/ReportButton";
 import type { DashboardFilters, PreenchimentoDrePayload } from "./shared/types";
 
 const ENDPOINT_BASE = "/v1/admin/analytics/preenchimento/dre";
@@ -125,6 +126,14 @@ export function AbaPorDre({
           <p className="text-[11px] text-slate-400 mt-1.5">
             Município, Região de Integração e Zona reduzem o conjunto de escolas antes do agrupamento por DRE.
           </p>
+        </div>
+        <div className="ml-auto shrink-0">
+          <ReportButton
+            reportId="censo-preenchimento-escolas"
+            token={token}
+            filters={filters}
+            onUnauth={onUnauth}
+          />
         </div>
       </div>
 

--- a/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
+++ b/web/src/components/admin/AbaSaudeOperacionalEscolas.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { apiFetch, sanitize } from "./shared/api";
 import { C } from "./shared/constants";
+import { ReportButton } from "./shared/ReportButton";
 import SaudeOperacionalMetodologiaInfo from "./SaudeOperacionalMetodologiaInfo";
 import type {
   SaudeOperacionalEscola,
@@ -410,6 +411,14 @@ export function AbaSaudeOperacionalEscolas({
               {payload.total_escolas.toLocaleString("pt-BR")} escolas cadastradas
             </span>
             <SaudeOperacionalMetodologiaInfo />
+          </div>
+          <div className="mt-3 flex lg:justify-end">
+            <ReportButton
+              reportId="saude-operacional-escolas"
+              token={token}
+              filters={filters}
+              onUnauth={onUnauth}
+            />
           </div>
           <p className="mt-2 text-xs text-slate-500 lg:text-right">
             Escolas sem censo concluído no ano aparecem como pendentes de censo.

--- a/web/src/components/admin/shared/ReportButton.tsx
+++ b/web/src/components/admin/shared/ReportButton.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+// Botão reutilizável de geração de relatórios gerenciais XLSX.
+// Consome a rota genérica protegida GET /v1/admin/reports/{reportId}, já existente
+// e validada no backend. Repassa os filtros globais ativos do dashboard, baixa o
+// arquivo respeitando o filename do header Content-Disposition e trata loading,
+// autenticação expirada (401) e erros amigáveis sem quebrar a UI.
+
+import React, { useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { API, DASHBOARD_REFERENCE_YEAR } from "./constants";
+import type { DashboardFilters } from "./types";
+
+type ReportButtonProps = {
+  reportId: string;
+  token: string;
+  filters?: DashboardFilters;
+  onUnauth: () => void;
+  label?: string;
+  className?: string;
+};
+
+// Monta a query string do relatório: format=xlsx + ano de referência + filtros
+// globais ativos. Filtros vazios não são enviados.
+function buildReportQuery(filters?: DashboardFilters): string {
+  const p = new URLSearchParams();
+  p.set("format", "xlsx");
+
+  const year = filters?.ano ?? DASHBOARD_REFERENCE_YEAR;
+  if (year) p.set("year", String(year));
+  if (filters?.dre)               p.set("dre", filters.dre);
+  if (filters?.municipio)         p.set("municipio", filters.municipio);
+  if (filters?.zona)              p.set("zona", filters.zona);
+  if (filters?.regiao_integracao) p.set("regiao_integracao", filters.regiao_integracao);
+
+  return p.toString();
+}
+
+// Extrai o filename do header Content-Disposition, tolerando os formatos
+// `filename*=UTF-8''...` (RFC 5987) e `filename="..."`. Usa o fallback quando o
+// header não vem ou não pôde ser interpretado.
+function filenameFromDisposition(header: string | null, fallback: string): string {
+  if (!header) return fallback;
+
+  const star = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(header);
+  if (star?.[1]) {
+    try {
+      return decodeURIComponent(star[1].trim().replace(/^"|"$/g, ""));
+    } catch {
+      // ignora e tenta o formato simples abaixo
+    }
+  }
+
+  const plain = /filename="?([^";]+)"?/i.exec(header);
+  if (plain?.[1]) return plain[1].trim();
+
+  return fallback;
+}
+
+export function ReportButton({
+  reportId,
+  token,
+  filters,
+  onUnauth,
+  label = "Gerar relatório",
+  className = "",
+}: ReportButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleDownload() {
+    if (loading) return; // evita duplo clique
+    setLoading(true);
+    setError("");
+
+    try {
+      const qs = buildReportQuery(filters);
+      const res = await fetch(`${API}/v1/admin/reports/${reportId}?${qs}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (res.status === 401) {
+        onUnauth();
+        return;
+      }
+
+      if (!res.ok) {
+        let msg = "Não foi possível gerar o relatório.";
+        try {
+          const body = await res.json();
+          if (body && typeof body.message === "string" && body.message.trim()) {
+            msg = body.message;
+          }
+        } catch {
+          // corpo não-JSON: mantém a mensagem amigável padrão
+        }
+        setError(msg);
+        return;
+      }
+
+      const blob = await res.blob();
+      const year = filters?.ano ?? DASHBOARD_REFERENCE_YEAR;
+      const fallbackName = `${reportId}-${year}.xlsx`;
+      const filename = filenameFromDisposition(
+        res.headers.get("Content-Disposition"),
+        fallbackName,
+      );
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError("Não foi possível gerar o relatório.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className={`flex flex-col items-end gap-1 ${className}`}>
+      <button
+        type="button"
+        onClick={handleDownload}
+        disabled={loading}
+        aria-busy={loading}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {loading ? (
+          <Loader2 size={14} className="animate-spin" />
+        ) : (
+          <Download size={14} />
+        )}
+        {loading ? "Gerando..." : label}
+      </button>
+      {error && (
+        <span className="text-[11px] text-rose-600 text-right max-w-xs" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/admin/shared/constants.ts
+++ b/web/src/components/admin/shared/constants.ts
@@ -5,6 +5,10 @@
 export const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 export const TOKEN_KEY = "censo_admin_token";
 
+// Temporário: o dashboard atual está fixado no ciclo do Censo Escolar 2026.
+// Usado como fallback de `year` quando nenhum ano é escolhido nos filtros globais.
+export const DASHBOARD_REFERENCE_YEAR = 2026;
+
 export const ZONA_COLORS: Record<string, string> = {
   "Urbana": "var(--zona-urbana)",
   "Rural": "var(--zona-rural)",


### PR DESCRIPTION
## Resumo

Adiciona botões de geração de relatórios gerenciais XLSX nas abas administrativas do dashboard.

## Escopo

- Cria componente reutilizável `ReportButton`;
- Integra relatórios backend já validados;
- Envia filtros globais para o endpoint de relatórios;
- Baixa XLSX via `blob`;
- Usa o filename do `Content-Disposition`, quando disponível;
- Possui fallback de filename;
- Trata loading, erro e autenticação expirada;
- Evita duplo clique durante a geração;
- Expõe `Content-Disposition` no CORS para permitir leitura do filename pelo navegador.

## Relatórios integrados

- `saude-operacional-escolas`
- `infraestrutura-seguranca-escolas`
- `merenda-escolar-condicoes`
- `censo-preenchimento-escolas`

## Abas integradas

- Saúde Operacional;
- Infraestrutura e Segurança;
- Merenda Escolar;
- Preenchimento por DRE.

## Observação sobre Registros do Censo

A aba `Registros do Censo` ainda não recebe diretamente `token`, `onUnauth` e `filters`. Por isso, nesta primeira versão, o relatório `censo-preenchimento-escolas` foi integrado na aba `Preenchimento por DRE`, que já possui esses dados e tem aderência funcional ao relatório de acompanhamento do preenchimento.

## Validação

- `go test -count=1 ./...` — sucesso;
- `go vet ./...` — sucesso;
- `go build ./cmd/api/...` — sucesso;
- `npm run build` — sucesso;
- `npm run lint` — falhou com 11 erros e 12 avisos pré-existentes na base, principalmente `react-hooks/set-state-in-effect`; os erros estão em arquivos não tocados ou em trechos fora dos hunks deste PR.

## Fora de escopo

- Novos relatórios backend;
- PDF;
- Alteração dos cálculos;
- Alteração dos endpoints analíticos;
- Alteração dos filtros globais;
- Redesenho geral das abas;
- Integração do botão diretamente na aba `Registros do Censo`.