### PR TITLE
fix(modo-apresentacao): nao deixar zoom residual ao fechar via Esc

### DIFF
--- a/web/src/components/admin/PresentationMode.tsx
+++ b/web/src/components/admin/PresentationMode.tsx
@@ -340,6 +340,11 @@ export default function PresentationMode({ onClose, onNavigateTab }: Presentatio
 
   const applySlideZoom = useCallback((element: HTMLElement) => {
     const measure = () => {
+      // Se o slide já não está mais ativo (modo apresentação fechado entre
+      // o agendamento do rAF e sua execução — caso típico ao sair via Esc,
+      // que dispara resize antes do fullscreenchange) abortamos para não
+      // re-aplicar zoom sobre um conteúdo que já voltou ao tamanho normal.
+      if (!element.classList.contains("ca-pres-slide-active")) return;
       const available = window.innerHeight - PRES_PAGE_PADDING;
       const natural = element.scrollHeight;
       if (natural > 0 && available > 0) {


### PR DESCRIPTION
Quando o usuario apertava Esc, o navegador disparava 'resize' SINCRONAMENTE ao sair do fullscreen, antes do nosso fullscreenchange/onClose. O handler de resize agendava um requestAnimationFrame para remedir e re-aplicar zoom. O rAF executava DEPOIS do cleanup que ja havia limpado o zoom — e como 'measure' nao verificava se o slide ainda estava ativo, recalculava o zoom baseado em window.innerHeight ja fora do fullscreen (menor) e escrevia element.style.zoom novamente, deixando fontes e graficos permanentemente reduzidos no dashboard normal.

Pelo botao Fechar isso nao acontecia porque o cleanup roda ANTES do exitFullscreen (e portanto antes do resize), entao o listener de resize ja estava removido quando o evento dispara.

Fix: adicionar a mesma checagem que o re-measure de 800ms ja tem, abortando o measure se o elemento perdeu a classe ca-pres-slide-active.