### PR TITLE
feat(analytics): filtros compartilhados de Escola/INEP (#159)

### DIFF
--- a/api/cmd/api/analytics.go
+++ b/api/cmd/api/analytics.go
@@ -538,7 +538,7 @@ func (app *application) AdminAnalyticsCaracterizacaoInfraEducacional(w http.Resp
 				 ELSE 0
 			END::float8                                                        AS pct_plena
 		FROM por_escola
-	`, f.Args()...).Scan(
+	`, f.LegacyArgs()...).Scan(
 		&totalEscolas,
 		&out.CoberturaEssenciais.MediaAmbientesEssenciais,
 		&out.CoberturaEssenciais.PctCoberturaPlena,
@@ -563,7 +563,7 @@ func (app *application) AdminAnalyticsCaracterizacaoInfraEducacional(w http.Resp
 		  AND ($5 = '' OR a.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $5))
 		GROUP BY TRIM(a.ambiente)
 		ORDER BY escolas DESC, label
-	`, f.Args()...)
+	`, f.LegacyArgs()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro na presença de ambientes: %v", err), http.StatusInternalServerError)
 		return
@@ -601,7 +601,7 @@ func (app *application) AdminAnalyticsCaracterizacaoInfraEducacional(w http.Resp
 			COUNT(*)      AS escolas
 		FROM por_escola
 		GROUP BY 1
-	`, f.Args()...)
+	`, f.LegacyArgs()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro nas faixas de cobertura: %v", err), http.StatusInternalServerError)
 		return
@@ -642,7 +642,7 @@ func (app *application) AdminAnalyticsCaracterizacaoInfraEducacional(w http.Resp
 		FROM por_escola
 		GROUP BY porte_nome
 		ORDER BY ord
-	`, f.Args()...)
+	`, f.LegacyArgs()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro na média por porte: %v", err), http.StatusInternalServerError)
 		return
@@ -821,7 +821,7 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 		CROSS JOIN total t
 		GROUP BY ex.etapa, t.n
 		ORDER BY escolas DESC, label
-	`, f.Args()...)
+	`, f.LegacyArgs()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro em etapas_ofertadas: %v", err), http.StatusInternalServerError)
 		return
@@ -879,7 +879,7 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 		CROSS JOIN total t
 		GROUP BY ex.modalidade, t.n
 		ORDER BY escolas DESC, label
-	`, f.Args()...)
+	`, f.LegacyArgs()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro em modalidades_ofertadas: %v", err), http.StatusInternalServerError)
 		return
@@ -944,7 +944,7 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 		CROSS JOIN total t
 		GROUP BY ex.turno, t.n
 		ORDER BY escolas DESC, label
-	`, f.Args()...)
+	`, f.LegacyArgs()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro em turnos: %v", err), http.StatusInternalServerError)
 		return
@@ -1006,7 +1006,7 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 		 AND e.year      = $1
 		GROUP BY e.porte_escola_nome
 		ORDER BY ord
-	`, f.Args()...)
+	`, f.LegacyArgs()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro em media_turnos_por_porte: %v", err), http.StatusInternalServerError)
 		return

--- a/api/cmd/api/analytics_filtros.go
+++ b/api/cmd/api/analytics_filtros.go
@@ -19,9 +19,13 @@ type AnalyticsFilters struct {
 	Municipio        string
 	Zona             string
 	RegiaoIntegracao string
+	SchoolID         int
+	CodigoINEP       string
 }
 
 func parseAnalyticsFilters(r *http.Request) AnalyticsFilters {
+	// TODO(#157): constrain f.DRE from the authenticated AdminAccessScope here
+	// (or immediately after this call), never from a query-string authorization claim.
 	return parseAnalyticsFiltersFromValues(r.URL.Query(), time.Now())
 }
 
@@ -36,16 +40,21 @@ func parseAnalyticsFiltersFromValues(q url.Values, now time.Time) AnalyticsFilte
 		Municipio:        strings.TrimSpace(q.Get("municipio")),
 		Zona:             strings.TrimSpace(q.Get("zona")),
 		RegiaoIntegracao: strings.TrimSpace(q.Get("regiao_integracao")),
+		CodigoINEP:       strings.TrimSpace(q.Get("codigo_inep")),
 	}
 	if y, err := strconv.Atoi(strings.TrimSpace(q.Get("year"))); err == nil && y > 0 {
 		f.Year = y
+	}
+	if schoolID, err := strconv.Atoi(strings.TrimSpace(q.Get("school_id"))); err == nil && schoolID > 0 {
+		f.SchoolID = schoolID
 	}
 	return f
 }
 
 // WhereSQL returns a parameterized WHERE fragment (no table alias prefix).
-// $1=year, $2=dre, $3=municipio, $4=zona, $5=regiao_integracao.
-// Empty string params disable the corresponding filter.
+// $1=year, $2=dre, $3=municipio, $4=zona, $5=regiao_integracao,
+// $6=school_id and $7=codigo_inep. Empty strings and school_id zero disable
+// the corresponding optional filters.
 // Pair with Args() to get the matching positional arguments.
 func (f AnalyticsFilters) WhereSQL() string {
 	return `status = 'completed'
@@ -58,12 +67,21 @@ func (f AnalyticsFilters) WhereSQL() string {
         SELECT UPPER(TRIM(municipio))
         FROM reg_integracao
         WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
-      ))`
+      ))
+      AND ($6 = 0 OR school_id = $6)
+      AND ($7 = '' OR UPPER(TRIM(codigo_inep)) = UPPER(TRIM($7)))`
 }
 
-// Args returns the five positional arguments that match WhereSQL in order.
+// Args returns the positional arguments that match WhereSQL in order.
 func (f AnalyticsFilters) Args() []any {
-	return []any{f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao}
+	return []any{f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP}
+}
+
+// LegacyArgs preserves the original five-argument contract for bespoke
+// analytics queries that do not use WhereSQL. Those endpoints intentionally
+// remain outside the shared filter infrastructure.
+func (f AnalyticsFilters) LegacyArgs() []any {
+	return f.Args()[:5]
 }
 
 func queryStringSlice(app *application, ctx context.Context, query string, args ...any) ([]string, error) {
@@ -99,6 +117,30 @@ type FiltrosOpcoes struct {
 	Municipios        []string            `json:"municipios"`
 	Zonas             []string            `json:"zonas"`
 	Escolas           []FiltrosEscolaItem `json:"escolas"`
+	CodigosINEP       []string            `json:"codigos_inep"`
+}
+
+// filtrosOpcoesSchoolsWhere returns a parameterized predicate over schools.
+// except excludes the option currently being populated from its own cascade.
+func filtrosOpcoesSchoolsWhere(f AnalyticsFilters, alias, except string) (string, []any) {
+	conditions := make([]string, 0, 6)
+	args := make([]any, 0, 6)
+	add := func(key, condition string, arg any) {
+		if key == except {
+			return
+		}
+		args = append(args, arg)
+		conditions = append(conditions, fmt.Sprintf(condition, len(args), len(args)))
+	}
+
+	add("dre", "($%d = '' OR UPPER(TRIM("+alias+".dre)) = UPPER(TRIM($%d)))", f.DRE)
+	add("municipio", "($%d = '' OR UPPER(TRIM("+alias+".municipio)) = UPPER(TRIM($%d)))", f.Municipio)
+	add("zona", "($%d = '' OR UPPER(TRIM("+alias+".zona)) = UPPER(TRIM($%d)))", f.Zona)
+	add("regiao_integracao", "($%d = '' OR UPPER(TRIM("+alias+".municipio)) IN (SELECT UPPER(TRIM(municipio)) FROM reg_integracao WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($%d))))", f.RegiaoIntegracao)
+	add("school_id", "($%d = 0 OR "+alias+".id = $%d)", f.SchoolID)
+	add("codigo_inep", "($%d = '' OR UPPER(TRIM("+alias+".codigo_inep)) = UPPER(TRIM($%d)))", f.CodigoINEP)
+
+	return strings.Join(conditions, "\n\t  AND "), args
 }
 
 // AdminAnalyticsFiltrosOpcoes retorna as listas para popular os selects
@@ -127,63 +169,60 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 	}
 
 	// Regiões: filtradas por dre, municipio, zona (não pela própria regiao)
+	regioesWhere, regioesArgs := filtrosOpcoesSchoolsWhere(f, "s", "regiao_integracao")
 	regioes, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT r.regiao_de_integracao
 		FROM reg_integracao r
-		JOIN schools s ON s.municipio = r.municipio
-		WHERE ($1 = '' OR s.dre = $1)
-		  AND ($2 = '' OR s.municipio = $2)
-		  AND ($3 = '' OR s.zona = $3)
+		JOIN schools s ON UPPER(TRIM(s.municipio)) = UPPER(TRIM(r.municipio))
+		WHERE `+regioesWhere+`
 		ORDER BY 1
-	`, f.DRE, f.Municipio, f.Zona)
+	`, regioesArgs...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("regioes_integracao: %w", err), http.StatusInternalServerError)
 		return
 	}
 
 	// DREs: filtradas por municipio, zona, regiao (não pela própria dre)
+	dresWhere, dresArgs := filtrosOpcoesSchoolsWhere(f, "s", "dre")
 	dres, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre
 		FROM schools s
-		WHERE ($1 = '' OR s.municipio = $1)
-		  AND ($2 = '' OR s.zona = $2)
-		  AND ($3 = '' OR s.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $3))
+		WHERE `+dresWhere+`
 		ORDER BY 1
-	`, f.Municipio, f.Zona, f.RegiaoIntegracao)
+	`, dresArgs...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("dres: %w", err), http.StatusInternalServerError)
 		return
 	}
 
 	// Municípios: filtrados por dre, zona, regiao (não pelo próprio municipio)
+	municipiosWhere, municipiosArgs := filtrosOpcoesSchoolsWhere(f, "s", "municipio")
 	municipios, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio
 		FROM schools s
-		WHERE ($1 = '' OR s.dre = $1)
-		  AND ($2 = '' OR s.zona = $2)
-		  AND ($3 = '' OR s.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $3))
+		WHERE `+municipiosWhere+`
 		ORDER BY 1
-	`, f.DRE, f.Zona, f.RegiaoIntegracao)
+	`, municipiosArgs...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("municipios: %w", err), http.StatusInternalServerError)
 		return
 	}
 
 	// Zonas: filtradas por dre, municipio, regiao (não pela própria zona)
+	zonasWhere, zonasArgs := filtrosOpcoesSchoolsWhere(f, "s", "zona")
 	zonas, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT s.zona
 		FROM schools s
 		WHERE s.zona IS NOT NULL AND TRIM(s.zona) <> ''
-		  AND ($1 = '' OR s.dre = $1)
-		  AND ($2 = '' OR s.municipio = $2)
-		  AND ($3 = '' OR s.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $3))
+		  AND `+zonasWhere+`
 		ORDER BY 1
-	`, f.DRE, f.Municipio, f.RegiaoIntegracao)
+	`, zonasArgs...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("zonas: %w", err), http.StatusInternalServerError)
 		return
 	}
 
+	escolasWhere, escolasArgs := filtrosOpcoesSchoolsWhere(f, "s", "school_id")
 	rows, err := app.models.Schools.DB.QueryContext(ctx, `
 		SELECT
 			id,
@@ -192,9 +231,10 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 			COALESCE(NULLIF(TRIM(municipio), ''), 'Não informado') AS municipio,
 			COALESCE(NULLIF(TRIM(dre), ''), 'Não informado') AS dre,
 			zona
-		FROM schools
+		FROM schools s
+		WHERE `+escolasWhere+`
 		ORDER BY nome_escola
-	`)
+	`, escolasArgs...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("escolas: %w", err), http.StatusInternalServerError)
 		return
@@ -222,6 +262,19 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 		return
 	}
 
+	codigosWhere, codigosArgs := filtrosOpcoesSchoolsWhere(f, "s", "codigo_inep")
+	codigosINEP, err := queryStringSlice(app, ctx, `
+		SELECT DISTINCT TRIM(s.codigo_inep)
+		FROM schools s
+		WHERE s.codigo_inep IS NOT NULL AND TRIM(s.codigo_inep) <> ''
+		  AND `+codigosWhere+`
+		ORDER BY 1
+	`, codigosArgs...)
+	if err != nil {
+		app.errorJSON(w, fmt.Errorf("codigos_inep: %w", err), http.StatusInternalServerError)
+		return
+	}
+
 	out := FiltrosOpcoes{
 		Anos:              anosInt,
 		RegioesIntegracao: regioes,
@@ -229,6 +282,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 		Municipios:        municipios,
 		Zonas:             zonas,
 		Escolas:           escolas,
+		CodigosINEP:       codigosINEP,
 	}
 
 	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: out})

--- a/api/cmd/api/analytics_filtros_test.go
+++ b/api/cmd/api/analytics_filtros_test.go
@@ -42,6 +42,7 @@ func TestParseAnalyticsFilters_TextualFiltersTrimmed(t *testing.T) {
 		"municipio":         {"  Belém "},
 		"zona":              {" Urbana "},
 		"regiao_integracao": {"  Metropolitana "},
+		"codigo_inep":       {"  15000001  "},
 	}
 	f := parseAnalyticsFiltersFromValues(q, fixedNow)
 	if f.DRE != "DRE Belém" {
@@ -56,12 +57,29 @@ func TestParseAnalyticsFilters_TextualFiltersTrimmed(t *testing.T) {
 	if f.RegiaoIntegracao != "Metropolitana" {
 		t.Fatalf("regiao_integracao not trimmed: %q", f.RegiaoIntegracao)
 	}
+	if f.CodigoINEP != "15000001" {
+		t.Fatalf("codigo_inep not trimmed: %q", f.CodigoINEP)
+	}
+}
+
+func TestParseAnalyticsFilters_SchoolID(t *testing.T) {
+	f := parseAnalyticsFiltersFromValues(url.Values{"school_id": {" 42 "}}, fixedNow)
+	if f.SchoolID != 42 {
+		t.Fatalf("expected school_id 42, got %d", f.SchoolID)
+	}
+}
+
+func TestParseAnalyticsFilters_CodigoINEP(t *testing.T) {
+	f := parseAnalyticsFiltersFromValues(url.Values{"codigo_inep": {" 15000001 "}}, fixedNow)
+	if f.CodigoINEP != "15000001" {
+		t.Fatalf("expected codigo_inep to be trimmed, got %q", f.CodigoINEP)
+	}
 }
 
 func TestParseAnalyticsFilters_AbsentFiltersEmpty(t *testing.T) {
 	q := url.Values{}
 	f := parseAnalyticsFiltersFromValues(q, fixedNow)
-	if f.DRE != "" || f.Municipio != "" || f.Zona != "" || f.RegiaoIntegracao != "" {
+	if f.DRE != "" || f.Municipio != "" || f.Zona != "" || f.RegiaoIntegracao != "" || f.SchoolID != 0 || f.CodigoINEP != "" {
 		t.Fatalf("expected empty textual filters, got %+v", f)
 	}
 }
@@ -73,12 +91,14 @@ func TestAnalyticsFilters_ArgsOrder(t *testing.T) {
 		Municipio:        "m",
 		Zona:             "z",
 		RegiaoIntegracao: "r",
+		SchoolID:         99,
+		CodigoINEP:       "15000001",
 	}
 	args := f.Args()
-	if len(args) != 5 {
-		t.Fatalf("expected 5 args, got %d", len(args))
+	if len(args) != 7 {
+		t.Fatalf("expected 7 args, got %d", len(args))
 	}
-	want := []any{2024, "d", "m", "z", "r"}
+	want := []any{2024, "d", "m", "z", "r", 99, "15000001"}
 	for i := range want {
 		if args[i] != want[i] {
 			t.Fatalf("arg %d: expected %v, got %v", i, want[i], args[i])
@@ -97,10 +117,49 @@ func TestAnalyticsFilters_WhereSQL(t *testing.T) {
 		"UPPER(TRIM(zona)) = UPPER(TRIM($4))",
 		"UPPER(TRIM(municipio)) IN",
 		"UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))",
+		"($6 = 0 OR school_id = $6)",
+		"UPPER(TRIM(codigo_inep)) = UPPER(TRIM($7))",
 	}
 	for _, frag := range mustContain {
 		if !strings.Contains(sql, frag) {
 			t.Fatalf("WhereSQL missing %q\n--- got ---\n%s", frag, sql)
 		}
+	}
+}
+
+func TestFiltrosOpcoesSchoolsWhere_CascadesSchoolAndINEP(t *testing.T) {
+	f := AnalyticsFilters{
+		DRE: "DRE A", Municipio: "Cidade A", Zona: "Urbana",
+		RegiaoIntegracao: "RI A", SchoolID: 42, CodigoINEP: "15000001",
+	}
+	where, args := filtrosOpcoesSchoolsWhere(f, "s", "school_id")
+	if strings.Contains(where, "s.id = $") {
+		t.Fatalf("school list must exclude its own school_id filter: %s", where)
+	}
+	if !strings.Contains(where, "s.codigo_inep") {
+		t.Fatalf("school list must retain codigo_inep cascade: %s", where)
+	}
+	want := []any{"DRE A", "Cidade A", "Urbana", "RI A", "15000001"}
+	if len(args) != len(want) {
+		t.Fatalf("expected %d cascade args, got %d: %#v", len(want), len(args), args)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("arg %d: expected %v, got %v", i, want[i], args[i])
+		}
+	}
+}
+
+func TestFiltrosOpcoesSchoolsWhere_INEPOptionsUseSchoolID(t *testing.T) {
+	f := AnalyticsFilters{SchoolID: 42, CodigoINEP: "15000001"}
+	where, args := filtrosOpcoesSchoolsWhere(f, "s", "codigo_inep")
+	if !strings.Contains(where, "s.id = $5") {
+		t.Fatalf("INEP options must retain school_id cascade: %s", where)
+	}
+	if strings.Contains(where, "s.codigo_inep") {
+		t.Fatalf("INEP options must exclude their own filter: %s", where)
+	}
+	if len(args) != 5 || args[4] != 42 {
+		t.Fatalf("unexpected INEP option args: %#v", args)
 	}
 }

--- a/api/cmd/api/analytics_infra_merenda_servicos.go
+++ b/api/cmd/api/analytics_infra_merenda_servicos.go
@@ -347,7 +347,7 @@ func (app *application) AdminAnalyticsInfraCondicoes(w http.ResponseWriter, r *h
 				 ELSE 0
 			END::float8
 		FROM por_escola
-	`, f.Args()...).Scan(&out.PctCoberturaPlena)
+	`, f.LegacyArgs()...).Scan(&out.PctCoberturaPlena)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("pct_cobertura_plena: %v", err), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Resumo

Implementa a #159 — LUCAS-01 — Filtros compartilhados + filtros/opcoes + Escola/INEP.

- adiciona `SchoolID` e `CodigoINEP` em `AnalyticsFilters`;
- aceita `school_id` e `codigo_inep` no parser;
- estende `WhereSQL()`/`Args()` mantendo SQL parametrizado;
- adiciona Escola/INEP e cascata em `/admin/analytics/filtros/opcoes`;
- preserva compatibilidade das queries legadas de 5 parâmetros via `LegacyArgs()`;
- adiciona/atualiza testes de parse, SQL, argumentos e cascata.

## Validação

- `git diff --check` ✅
- `go test ./...` ✅

## Dependência

A integração definitiva de `role=dre -> f.DRE = scope.DRE` permanece pendente da #157 (`AdminAccessScope`). Nenhuma implementação provisória de autorização foi criada nesta PR.

Esta branch deve ser rebaseada/ajustada após a entrega da #157 antes do aceite final da frente de escopo DRE.

Closes #159