### PR TITLE
fix: finalizar escopo DRE nos filtros analíticos (#159)

### DIFF
--- a/api/cmd/api/analytics_filtros.go
+++ b/api/cmd/api/analytics_filtros.go
@@ -224,7 +224,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 
 	escolasWhere, escolasArgs := filtrosOpcoesSchoolsWhere(f, "s", "school_id")
 	rows, err := app.models.Schools.DB.QueryContext(ctx, `
-		SELECT
+		SELECT DISTINCT
 			id,
 			codigo_inep,
 			COALESCE(NULLIF(TRIM(nome_escola), ''), 'Sem nome') AS nome_escola,

--- a/api/cmd/api/analytics_filtros.go
+++ b/api/cmd/api/analytics_filtros.go
@@ -24,9 +24,11 @@ type AnalyticsFilters struct {
 }
 
 func parseAnalyticsFilters(r *http.Request) AnalyticsFilters {
-	// TODO(#157): constrain f.DRE from the authenticated AdminAccessScope here
-	// (or immediately after this call), never from a query-string authorization claim.
-	return parseAnalyticsFiltersFromValues(r.URL.Query(), time.Now())
+	f := parseAnalyticsFiltersFromValues(r.URL.Query(), time.Now())
+	if scope, ok := GetAdminAccessScope(r.Context()); ok && scope.Role == RoleDRE {
+		f.DRE = strings.TrimSpace(scope.DRE)
+	}
+	return f
 }
 
 // parseAnalyticsFiltersFromValues is the testable core of parseAnalyticsFilters.
@@ -123,6 +125,13 @@ type FiltrosOpcoes struct {
 // filtrosOpcoesSchoolsWhere returns a parameterized predicate over schools.
 // except excludes the option currently being populated from its own cascade.
 func filtrosOpcoesSchoolsWhere(f AnalyticsFilters, alias, except string) (string, []any) {
+	return filtrosOpcoesSchoolsWhereWithAuthorization(f, alias, except, "")
+}
+
+// filtrosOpcoesSchoolsWhereWithAuthorization applies the mandatory territorial
+// scope independently from the select cascade. A DRE user's authorization
+// must survive even when the DRE select is the option being populated.
+func filtrosOpcoesSchoolsWhereWithAuthorization(f AnalyticsFilters, alias, except, authorizedDRE string) (string, []any) {
 	conditions := make([]string, 0, 6)
 	args := make([]any, 0, 6)
 	add := func(key, condition string, arg any) {
@@ -133,7 +142,12 @@ func filtrosOpcoesSchoolsWhere(f AnalyticsFilters, alias, except string) (string
 		conditions = append(conditions, fmt.Sprintf(condition, len(args), len(args)))
 	}
 
-	add("dre", "($%d = '' OR UPPER(TRIM("+alias+".dre)) = UPPER(TRIM($%d)))", f.DRE)
+	if strings.TrimSpace(authorizedDRE) != "" {
+		args = append(args, strings.TrimSpace(authorizedDRE))
+		conditions = append(conditions, "UPPER(TRIM("+alias+".dre)) = UPPER(TRIM($"+strconv.Itoa(len(args))+"))")
+	} else {
+		add("dre", "($%d = '' OR UPPER(TRIM("+alias+".dre)) = UPPER(TRIM($%d)))", f.DRE)
+	}
 	add("municipio", "($%d = '' OR UPPER(TRIM("+alias+".municipio)) = UPPER(TRIM($%d)))", f.Municipio)
 	add("zona", "($%d = '' OR UPPER(TRIM("+alias+".zona)) = UPPER(TRIM($%d)))", f.Zona)
 	add("regiao_integracao", "($%d = '' OR UPPER(TRIM("+alias+".municipio)) IN (SELECT UPPER(TRIM(municipio)) FROM reg_integracao WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($%d))))", f.RegiaoIntegracao)
@@ -149,13 +163,26 @@ func filtrosOpcoesSchoolsWhere(f AnalyticsFilters, alias, except string) (string
 func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	f := parseAnalyticsFilters(r)
+	authorizedDRE := ""
+	if scope, ok := GetAdminAccessScope(ctx); ok && scope.Role == RoleDRE {
+		authorizedDRE = strings.TrimSpace(scope.DRE)
+	}
 
-	anos, err := queryStringSlice(app, ctx, `
-		SELECT DISTINCT year::text
-		FROM census_responses
-		WHERE status = 'completed'
-		ORDER BY year::text DESC
-	`)
+	anosQuery := `
+		SELECT DISTINCT cr.year::text
+		FROM census_responses cr
+		JOIN schools s ON s.id = cr.school_id
+		WHERE cr.status = 'completed'
+	`
+	var anosArgs []any
+	if authorizedDRE != "" {
+		anosQuery += ` AND UPPER(TRIM(s.dre)) = UPPER(TRIM($1))`
+		anosArgs = append(anosArgs, authorizedDRE)
+	}
+	anosQuery += `
+		ORDER BY cr.year::text DESC
+	`
+	anos, err := queryStringSlice(app, ctx, anosQuery, anosArgs...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("anos: %w", err), http.StatusInternalServerError)
 		return
@@ -169,7 +196,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 	}
 
 	// Regiões: filtradas por dre, municipio, zona (não pela própria regiao)
-	regioesWhere, regioesArgs := filtrosOpcoesSchoolsWhere(f, "s", "regiao_integracao")
+	regioesWhere, regioesArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "regiao_integracao", authorizedDRE)
 	regioes, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT r.regiao_de_integracao
 		FROM reg_integracao r
@@ -183,7 +210,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 	}
 
 	// DREs: filtradas por municipio, zona, regiao (não pela própria dre)
-	dresWhere, dresArgs := filtrosOpcoesSchoolsWhere(f, "s", "dre")
+	dresWhere, dresArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "dre", authorizedDRE)
 	dres, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre
 		FROM schools s
@@ -196,7 +223,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 	}
 
 	// Municípios: filtrados por dre, zona, regiao (não pelo próprio municipio)
-	municipiosWhere, municipiosArgs := filtrosOpcoesSchoolsWhere(f, "s", "municipio")
+	municipiosWhere, municipiosArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "municipio", authorizedDRE)
 	municipios, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio
 		FROM schools s
@@ -209,7 +236,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 	}
 
 	// Zonas: filtradas por dre, municipio, regiao (não pela própria zona)
-	zonasWhere, zonasArgs := filtrosOpcoesSchoolsWhere(f, "s", "zona")
+	zonasWhere, zonasArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "zona", authorizedDRE)
 	zonas, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT s.zona
 		FROM schools s
@@ -222,7 +249,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 		return
 	}
 
-	escolasWhere, escolasArgs := filtrosOpcoesSchoolsWhere(f, "s", "school_id")
+	escolasWhere, escolasArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "school_id", authorizedDRE)
 	rows, err := app.models.Schools.DB.QueryContext(ctx, `
 		SELECT DISTINCT
 			id,
@@ -262,7 +289,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 		return
 	}
 
-	codigosWhere, codigosArgs := filtrosOpcoesSchoolsWhere(f, "s", "codigo_inep")
+	codigosWhere, codigosArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "codigo_inep", authorizedDRE)
 	codigosINEP, err := queryStringSlice(app, ctx, `
 		SELECT DISTINCT TRIM(s.codigo_inep)
 		FROM schools s

--- a/api/cmd/api/analytics_filtros_test.go
+++ b/api/cmd/api/analytics_filtros_test.go
@@ -1,11 +1,40 @@
 package main
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 )
+
+func requestWithAnalyticsScope(scope AdminAccessScope, query string) *http.Request {
+	r := httptest.NewRequest("GET", "/admin/analytics/filtros/opcoes?"+query, nil)
+	return r.WithContext(context.WithValue(r.Context(), contextKeyAdminScope, scope))
+}
+
+func TestParseAnalyticsFilters_AdminScopeKeepsQueryDRE(t *testing.T) {
+	f := parseAnalyticsFilters(requestWithAnalyticsScope(AdminAccessScope{Role: RoleAdmin}, "dre=DRE_B"))
+	if f.DRE != "DRE_B" {
+		t.Fatalf("expected query DRE, got %q", f.DRE)
+	}
+}
+
+func TestParseAnalyticsFilters_DREScopeOverridesQueryAndTrims(t *testing.T) {
+	f := parseAnalyticsFilters(requestWithAnalyticsScope(AdminAccessScope{Role: RoleDRE, DRE: "  DRE_A  "}, "dre=DRE_B"))
+	if f.DRE != "DRE_A" {
+		t.Fatalf("expected authorized DRE, got %q", f.DRE)
+	}
+}
+
+func TestParseAnalyticsFilters_WithoutScopeKeepsCompatibility(t *testing.T) {
+	r := httptest.NewRequest("GET", "/admin/analytics?dre=DRE_B", nil)
+	if f := parseAnalyticsFilters(r); f.DRE != "DRE_B" {
+		t.Fatalf("expected query DRE, got %q", f.DRE)
+	}
+}
 
 var fixedNow = time.Date(2025, time.March, 15, 10, 0, 0, 0, time.UTC)
 
@@ -185,5 +214,16 @@ func TestFiltrosOpcoesSchoolsWhere_INEPOptionsUseSchoolID(t *testing.T) {
 	}
 	if len(args) != 5 || args[4] != 42 {
 		t.Fatalf("unexpected INEP option args: %#v", args)
+	}
+}
+
+func TestFiltrosOpcoesSchoolsWhere_AuthorizedDRESurvivesExcept(t *testing.T) {
+	f := AnalyticsFilters{DRE: "DRE_A"}
+	where, args := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "dre", " DRE_A ")
+	if !strings.Contains(where, "s.dre") || len(args) != 6 || args[0] != "DRE_A" {
+		t.Fatalf("authorized DRE was removed from cascade: where=%s args=%#v", where, args)
+	}
+	if strings.Contains(where, "($1 = '' OR") {
+		t.Fatalf("authorization must be mandatory: %s", where)
 	}
 }

--- a/api/cmd/api/analytics_filtros_test.go
+++ b/api/cmd/api/analytics_filtros_test.go
@@ -69,6 +69,27 @@ func TestParseAnalyticsFilters_SchoolID(t *testing.T) {
 	}
 }
 
+func TestParseAnalyticsFilters_InvalidSchoolIDMeansNoFilter(t *testing.T) {
+	for _, raw := range []string{"", "   ", "abc", "0", "-1", "1.5"} {
+		f := parseAnalyticsFiltersFromValues(url.Values{"school_id": {raw}}, fixedNow)
+		if f.SchoolID != 0 {
+			t.Fatalf("school_id %q: expected no filter, got %d", raw, f.SchoolID)
+		}
+	}
+}
+
+func TestParseAnalyticsFilters_SchoolAndINEPWithOtherFilters(t *testing.T) {
+	f := parseAnalyticsFiltersFromValues(url.Values{
+		"school_id": {"42"}, "codigo_inep": {" 15000001 "},
+		"dre": {"DRE A"}, "municipio": {"Cidade A"}, "zona": {"Urbana"},
+		"regiao_integracao": {"RI A"},
+	}, fixedNow)
+	if f.SchoolID != 42 || f.CodigoINEP != "15000001" || f.DRE != "DRE A" ||
+		f.Municipio != "Cidade A" || f.Zona != "Urbana" || f.RegiaoIntegracao != "RI A" {
+		t.Fatalf("combined filters were not preserved: %+v", f)
+	}
+}
+
 func TestParseAnalyticsFilters_CodigoINEP(t *testing.T) {
 	f := parseAnalyticsFiltersFromValues(url.Values{"codigo_inep": {" 15000001 "}}, fixedNow)
 	if f.CodigoINEP != "15000001" {
@@ -124,6 +145,9 @@ func TestAnalyticsFilters_WhereSQL(t *testing.T) {
 		if !strings.Contains(sql, frag) {
 			t.Fatalf("WhereSQL missing %q\n--- got ---\n%s", frag, sql)
 		}
+	}
+	if strings.Contains(sql, "15000001") || strings.Contains(sql, "DRE") || strings.Contains(sql, "42") {
+		t.Fatalf("WhereSQL must not interpolate request values: %s", sql)
 	}
 }
 


### PR DESCRIPTION
## Resumo

Finaliza a #159 após a entrega da #157, aplicando o `AdminAccessScope` aos filtros analíticos compartilhados e garantindo isolamento territorial real para usuários `role=dre`.

### Implementado
- `parseAnalyticsFilters` passa a usar `GetAdminAccessScope(r.Context())`;
- para `RoleDRE`, a DRE efetiva sempre vem do scope autenticado, ignorando tentativa de override via `?dre=`;
- separa a restrição obrigatória de autorização da lógica de cascata dos selects;
- impede que `except="dre"` remova o escopo autorizado;
- restringe DREs, municípios, zonas, regiões, escolas, códigos INEP e anos ao escopo autorizado;
- mantém comportamento amplo do admin e compatibilidade sem scope;
- preserva SQL parametrizado e os filtros `school_id`/`codigo_inep` já implementados.

## Segurança

Um usuário DRE não consegue enumerar dados de outra DRE usando `?dre=`, `school_id` ou `codigo_inep` externos.

## Validação

- `go test ./...` ✅
- `go vet ./...` ✅
- `git diff --check` ✅
- branch rebaseada sobre a `develop` atual sem conflitos;
- diff restrito à implementação/testes da #159.

Closes #159