### PR TITLE
hotfix: encerrar período de preenchimento do Censo Operacional

### DIFF
--- a/api/cmd/api/census_period.go
+++ b/api/cmd/api/census_period.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const censusPeriodClosedCode = "census_period_closed"
+
+var errCensusPeriodClosed = errors.New("O período de preenchimento do Censo Operacional foi encerrado.")
+
+func censusSubmissionsEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("CENSUS_SUBMISSIONS_ENABLED")), "true")
+}
+
+func (app *application) requireCensusSubmissions(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if censusSubmissionsEnabled() {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		app.writeJSON(w, http.StatusForbidden, jsonResponse{
+			Error:   true,
+			Code:    censusPeriodClosedCode,
+			Message: errCensusPeriodClosed.Error(),
+		})
+	})
+}
+
+func (app *application) CensusStatus(w http.ResponseWriter, r *http.Request) {
+	app.writeJSON(w, http.StatusOK, jsonResponse{
+		Error: false,
+		Data:  map[string]bool{"submissions_enabled": censusSubmissionsEnabled()},
+	})
+}

--- a/api/cmd/api/census_period_test.go
+++ b/api/cmd/api/census_period_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCensusSubmissionsEnabledIsFailClosed(t *testing.T) {
+	t.Setenv("CENSUS_SUBMISSIONS_ENABLED", "")
+	if censusSubmissionsEnabled() {
+		t.Fatal("empty configuration must close submissions")
+	}
+
+	t.Setenv("CENSUS_SUBMISSIONS_ENABLED", "false")
+	if censusSubmissionsEnabled() {
+		t.Fatal("false configuration must close submissions")
+	}
+
+	t.Setenv("CENSUS_SUBMISSIONS_ENABLED", "true")
+	if !censusSubmissionsEnabled() {
+		t.Fatal("true configuration must enable submissions")
+	}
+}
+
+func TestRequireCensusSubmissionsBlocksWritesWhenClosed(t *testing.T) {
+	for _, value := range []string{"", "false"} {
+		t.Run("closed_"+value, func(t *testing.T) {
+			t.Setenv("CENSUS_SUBMISSIONS_ENABLED", value)
+			called := false
+			next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+			app := &application{}
+			req := httptest.NewRequest(http.MethodPost, "/v1/census", nil)
+			res := httptest.NewRecorder()
+
+			app.requireCensusSubmissions(next).ServeHTTP(res, req)
+
+			if called {
+				t.Fatal("closed period must not invoke the write handler")
+			}
+			if res.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d", res.Code, http.StatusForbidden)
+			}
+			var payload jsonResponse
+			if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if payload.Code != censusPeriodClosedCode {
+				t.Fatalf("code = %q, want %q", payload.Code, censusPeriodClosedCode)
+			}
+			if payload.Message != errCensusPeriodClosed.Error() {
+				t.Fatalf("message = %q, want %q", payload.Message, errCensusPeriodClosed.Error())
+			}
+		})
+	}
+}
+
+func TestRequireCensusSubmissionsAllowsWritesWhenEnabled(t *testing.T) {
+	t.Setenv("CENSUS_SUBMISSIONS_ENABLED", "true")
+	called := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+	app := &application{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/census", nil)
+	res := httptest.NewRecorder()
+
+	app.requireCensusSubmissions(next).ServeHTTP(res, req)
+
+	if !called {
+		t.Fatal("enabled period must invoke the write handler")
+	}
+}

--- a/api/cmd/api/helpers.go
+++ b/api/cmd/api/helpers.go
@@ -7,6 +7,7 @@ import (
 
 type jsonResponse struct {
 	Error   bool        `json:"error"`
+	Code    string      `json:"code,omitempty"`
 	Message string      `json:"message,omitempty"`
 	Data    interface{} `json:"data,omitempty"`
 }

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -309,6 +309,7 @@ func (app *application) routes() http.Handler {
 
 	mux.Route("/v1", func(r chi.Router) {
 		r.Get("/health", app.HealthCheck)
+		r.Get("/census/status", app.CensusStatus)
 
 		// Endpoints públicos do formulário. Ficam atrás do gate opcional de
 		// X-API-Key (requirePublicAPIKey): inerte até PUBLIC_API_KEY ser
@@ -317,10 +318,10 @@ func (app *application) routes() http.Handler {
 			pub.Use(app.requirePublicAPIKey)
 			pub.Get("/locations", app.GetLocations)
 			pub.Get("/schools", app.GetSchools)
-			pub.Post("/schools", app.CreateSchool)
+			pub.With(app.requireCensusSubmissions).Post("/schools", app.CreateSchool)
 			pub.Get("/census", app.GetCenso)
-			pub.Post("/census", app.CreateOrUpdateCenso)
-			pub.Post("/upload", app.uploadPhoto)
+			pub.With(app.requireCensusSubmissions).Post("/census", app.CreateOrUpdateCenso)
+			pub.With(app.requireCensusSubmissions).Post("/upload", app.uploadPhoto)
 		})
 
 		// Admin: login público + rotas protegidas por JWT

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -33,6 +33,15 @@ export default function CensusPage() {
   const [isCompleted, setIsCompleted] = useState(false);
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [submissionsEnabled, setSubmissionsEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+    fetch(`${baseUrl}/v1/census/status`)
+      .then((response) => response.ok ? response.json() : Promise.reject())
+      .then((payload) => setSubmissionsEnabled(payload.data?.submissions_enabled === true))
+      .catch(() => setSubmissionsEnabled(false));
+  }, []);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -278,7 +287,18 @@ export default function CensusPage() {
     }
   };
 
-  if (!isInitialized) return null;
+  if (!isInitialized || submissionsEnabled === null) return null;
+
+  if (!submissionsEnabled) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+        <Card className="w-full max-w-md text-center p-8 shadow-md border-slate-200 bg-white">
+          <h1 className="text-2xl font-bold text-slate-900 mb-3">Período de preenchimento encerrado.</h1>
+          <p className="text-slate-600">O prazo para envio das informações do Censo Operacional foi finalizado.</p>
+        </Card>
+      </div>
+    );
+  }
 
   if (isCompleted) {
     return (


### PR DESCRIPTION
## Hotfix de produção

Leva para `main` exclusivamente a implementação da #169 para encerrar o período de preenchimento do Censo Operacional, sem promover a `develop` inteira.

### Incluído
- `CENSUS_SUBMISSIONS_ENABLED` como controle fail-closed;
- `GET /v1/census/status`;
- bloqueio server-side de `POST /v1/census`, `POST /v1/upload` e `POST /v1/schools`;
- retorno `403` com `code: census_period_closed` quando fechado;
- frontend deixa de renderizar o formulário e mostra a mensagem de período encerrado;
- testes do gate de submissão.

### Segurança do hotfix
- branch criada diretamente a partir da `main`;
- 1 commit à frente e 0 atrás;
- exatamente 5 arquivos alterados;
- nenhuma implementação de `AdminAccessScope`, perfil DRE, analytics, reports ou migrations incluída.

Este hotfix replica somente a implementação já validada da #169, evitando levar para produção as tarefas DRE ainda incompletas.