### PR TITLE
feat(auth): apply DRE access scope authorization to legacy administrative endpoints

### DIFF
--- a/api/cmd/api/admin.go
+++ b/api/cmd/api/admin.go
@@ -691,7 +691,7 @@ func (app *application) AdminGetCensus(w http.ResponseWriter, r *http.Request) {
 
 	p := parseCensusListParams(r.URL.Query())
 	if scope.Role == RoleDRE {
-		p.DRE = scope.DRE
+		p.DRE = strings.TrimSpace(scope.DRE)
 	}
 
 	whereArgs := p.whereArgs()
@@ -822,7 +822,7 @@ func (app *application) AdminGetCensusByID(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if scope.Role == RoleDRE && !strings.EqualFold(strings.TrimSpace(c.Dre), strings.TrimSpace(scope.DRE)) {
+	if !scope.IsAuthorizedForDRE(c.Dre) {
 		app.errorJSON(w, fmt.Errorf("acesso não permitido para esta DRE"), http.StatusForbidden)
 		return
 	}

--- a/api/cmd/api/admin_census_test.go
+++ b/api/cmd/api/admin_census_test.go
@@ -69,6 +69,34 @@ func TestCensusListParamsParsing(t *testing.T) {
 	}
 }
 
+func TestCensusListParamsDREScopeEnforcement(t *testing.T) {
+	q := url.Values{
+		"dre": {"DRE CASTANHAL"},
+	}
+
+	t.Run("admin scope keeps requested DRE", func(t *testing.T) {
+		p := parseCensusListParams(q)
+		adminScope := AdminAccessScope{Role: RoleAdmin}
+		if adminScope.Role == RoleDRE {
+			p.DRE = strings.TrimSpace(adminScope.DRE)
+		}
+		if p.DRE != "DRE CASTANHAL" {
+			t.Fatalf("expected DRE CASTANHAL, got %q", p.DRE)
+		}
+	})
+
+	t.Run("dre scope forces user DRE and overrides query param", func(t *testing.T) {
+		p := parseCensusListParams(q)
+		dreScope := AdminAccessScope{Role: RoleDRE, DRE: " DRE BELEM "}
+		if dreScope.Role == RoleDRE {
+			p.DRE = strings.TrimSpace(dreScope.DRE)
+		}
+		if p.DRE != "DRE BELEM" {
+			t.Fatalf("expected forced DRE BELEM, got %q", p.DRE)
+		}
+	})
+}
+
 // Cenário 16 da task: limit inválido volta para 10; só {10,50,100,1000} valem.
 func TestCensusListParamsLimitFallback(t *testing.T) {
 	for _, valid := range []int{10, 50, 100, 1000} {

--- a/api/cmd/api/admin_scope.go
+++ b/api/cmd/api/admin_scope.go
@@ -1,6 +1,9 @@
 package main
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // AdminAccessScope representa a identidade e o escopo territorial/organizacional
 // do usuário autenticado no painel administrativo.
@@ -26,4 +29,19 @@ const (
 func GetAdminAccessScope(ctx context.Context) (AdminAccessScope, bool) {
 	scope, ok := ctx.Value(contextKeyAdminScope).(AdminAccessScope)
 	return scope, ok
+}
+
+// IsAuthorizedForDRE verifica se o escopo de acesso do usuário permite visualizar dados
+// da DRE informada. O perfil "admin" possui acesso ilimitado; o perfil "dre" só acessa
+// sua própria DRE (compara sem diferenciar maiúsculas/minúsculas nem espaços extras).
+func (scope AdminAccessScope) IsAuthorizedForDRE(targetDRE string) bool {
+	if scope.Role == RoleAdmin {
+		return true
+	}
+	if scope.Role == RoleDRE {
+		userDRE := strings.TrimSpace(scope.DRE)
+		target := strings.TrimSpace(targetDRE)
+		return userDRE != "" && strings.EqualFold(userDRE, target)
+	}
+	return false
 }

--- a/api/cmd/api/admin_scope_test.go
+++ b/api/cmd/api/admin_scope_test.go
@@ -29,3 +29,58 @@ func TestGetAdminAccessScope(t *testing.T) {
 		}
 	})
 }
+
+func TestIsAuthorizedForDRE(t *testing.T) {
+	adminScope := AdminAccessScope{Username: "admin", Role: RoleAdmin, DRE: ""}
+	dreBelemScope := AdminAccessScope{Username: "user_belem", Role: RoleDRE, DRE: "DRE BELEM"}
+	dreSpacedScope := AdminAccessScope{Username: "user_belem", Role: RoleDRE, DRE: "  DRE BELEM  "}
+	unknownRoleScope := AdminAccessScope{Username: "other", Role: "guest", DRE: "DRE BELEM"}
+
+	t.Run("admin role has global access", func(t *testing.T) {
+		if !adminScope.IsAuthorizedForDRE("DRE BELEM") {
+			t.Errorf("admin should be authorized for DRE BELEM")
+		}
+		if !adminScope.IsAuthorizedForDRE("DRE CASTANHAL") {
+			t.Errorf("admin should be authorized for DRE CASTANHAL")
+		}
+		if !adminScope.IsAuthorizedForDRE("") {
+			t.Errorf("admin should be authorized even if target DRE is empty")
+		}
+	})
+
+	t.Run("dre role authorized for same DRE", func(t *testing.T) {
+		if !dreBelemScope.IsAuthorizedForDRE("DRE BELEM") {
+			t.Errorf("DRE BELEM scope should access DRE BELEM")
+		}
+	})
+
+	t.Run("dre role case insensitive and whitespace tolerant", func(t *testing.T) {
+		if !dreBelemScope.IsAuthorizedForDRE("dre belem") {
+			t.Errorf("DRE BELEM scope should access lowercase dre belem")
+		}
+		if !dreBelemScope.IsAuthorizedForDRE("  DRE BELEM  ") {
+			t.Errorf("DRE BELEM scope should access target with extra spaces")
+		}
+		if !dreSpacedScope.IsAuthorizedForDRE("DRE BELEM") {
+			t.Errorf("DRE scope with spaces should access clean target DRE")
+		}
+	})
+
+	t.Run("dre role forbidden for different DRE (BOLA)", func(t *testing.T) {
+		if dreBelemScope.IsAuthorizedForDRE("DRE CASTANHAL") {
+			t.Errorf("DRE BELEM scope must NOT access DRE CASTANHAL")
+		}
+		if dreBelemScope.IsAuthorizedForDRE("DRE MARABA") {
+			t.Errorf("DRE BELEM scope must NOT access DRE MARABA")
+		}
+		if dreBelemScope.IsAuthorizedForDRE("") {
+			t.Errorf("DRE BELEM scope must NOT access empty target DRE")
+		}
+	})
+
+	t.Run("unknown role has no access", func(t *testing.T) {
+		if unknownRoleScope.IsAuthorizedForDRE("DRE BELEM") {
+			t.Errorf("unknown role must NOT be authorized for any DRE")
+		}
+	})
+}


### PR DESCRIPTION
- Enforce DRE scope on /admin/dashboard and /admin/census
- Add object-level authorization (BOLA) on /admin/census/{id} via IsAuthorizedForDRE
- Restrict global actions (/admin/sync-sheets, /admin/sheet-metrics, /admin/indicadores-metrics) to admin role
- Add unit tests for IsAuthorizedForDRE and DRE scope param override