### PR TITLE
feat: apply DRE scope to core analytics

### DIFF
--- a/api/cmd/api/analytics.go
+++ b/api/cmd/api/analytics.go
@@ -133,42 +133,45 @@ type ZonaStat struct {
 func (app *application) AdminAnalyticsOverview(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	db := app.models.Schools.DB
+	f := parseAnalyticsFilters(r)
 
-	out := AnalyticsOverview{
-		PorZona: []ZonaStat{},
-	}
+	out := AnalyticsOverview{PorZona: []ZonaStat{}}
 
-	// 1) Contagens operacionais e quantitativos de alunos (1 query).
-	//    - COUNT DISTINCT school_id em completed/drafts: evita contar
-	//      a mesma escola múltiplas vezes quando houver censos de mais
-	//      de um ano.
-	//    - SUM/AVG filtram pelo ano corrente para evitar inflação
-	//      acumulada entre ciclos anuais.
-	//    - COALESCE garante 0 quando não há linhas completed no ano.
+	// Scope schools before any aggregate so a DRE profile cannot observe totals
+	// from another DRE. School/INEP filters are applied to the same base relation.
 	err := db.QueryRowContext(ctx, `
+		WITH scoped_schools AS (
+			SELECT s.id
+			FROM schools s
+			WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+			  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+			  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+			  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+			        SELECT UPPER(TRIM(municipio))
+			        FROM reg_integracao
+			        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+			      ))
+			  AND ($6 = 0 OR s.id = $6)
+			  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
+		),
+		base AS (
+			SELECT v.*
+			FROM vw_censo_base v
+			JOIN scoped_schools ss ON ss.id = v.school_id
+			WHERE v.year = $1
+		)
 		SELECT
-			(SELECT COUNT(*) FROM schools)                                                       AS total_schools,
-			COUNT(*) FILTER (WHERE census_id IS NOT NULL)                                        AS total_censuses,
-			COUNT(DISTINCT school_id) FILTER (WHERE status = 'completed')                        AS completed,
-			COUNT(DISTINCT school_id) FILTER (WHERE status = 'draft')                            AS drafts,
-			COALESCE(SUM(total_alunos)
-				FILTER (
-					WHERE status = 'completed'
-					  AND year = EXTRACT(YEAR FROM CURRENT_DATE)::int
-				), 0)::float8                                                                    AS total_alunos,
-			COALESCE(SUM(alunos_pcd)
-				FILTER (
-					WHERE status = 'completed'
-					  AND year = EXTRACT(YEAR FROM CURRENT_DATE)::int
-				), 0)::float8                                                                    AS alunos_pcd,
-			COALESCE(AVG(total_alunos)
-				FILTER (
-					WHERE status = 'completed'
-					  AND total_alunos IS NOT NULL
-					  AND year = EXTRACT(YEAR FROM CURRENT_DATE)::int
-				), 0)::float8                                                                    AS media_alunos
-		FROM vw_censo_base
-	`).Scan(
+			(SELECT COUNT(*) FROM scoped_schools)                                      AS total_schools,
+			COUNT(*) FILTER (WHERE census_id IS NOT NULL)                              AS total_censuses,
+			COUNT(DISTINCT school_id) FILTER (WHERE status = 'completed')              AS completed,
+			COUNT(DISTINCT school_id) FILTER (WHERE status = 'draft')                  AS drafts,
+			COALESCE(SUM(total_alunos) FILTER (WHERE status = 'completed'), 0)::float8 AS total_alunos,
+			COALESCE(SUM(alunos_pcd) FILTER (WHERE status = 'completed'), 0)::float8   AS alunos_pcd,
+			COALESCE(AVG(total_alunos) FILTER (
+				WHERE status = 'completed' AND total_alunos IS NOT NULL
+			), 0)::float8 AS media_alunos
+		FROM base
+	`, f.Args()...).Scan(
 		&out.TotalSchools,
 		&out.TotalCensuses,
 		&out.Completed,
@@ -182,15 +185,24 @@ func (app *application) AdminAnalyticsOverview(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// 2) Distribuição por zona — escolas DISTINTAS por zona.
 	rows, err := db.QueryContext(ctx, `
 		SELECT
-			COALESCE(NULLIF(zona, ''), 'Não informado') AS zona,
-			COUNT(DISTINCT school_id)                   AS total
-		FROM vw_censo_base
+			COALESCE(NULLIF(TRIM(s.zona), ''), 'Não informado') AS zona,
+			COUNT(*) AS total
+		FROM schools s
+		WHERE ($1 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($1)))
+		  AND ($2 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($2)))
+		  AND ($3 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($3)))
+		  AND ($4 = '' OR UPPER(TRIM(s.municipio)) IN (
+		        SELECT UPPER(TRIM(municipio))
+		        FROM reg_integracao
+		        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($4))
+		      ))
+		  AND ($5 = 0 OR s.id = $5)
+		  AND ($6 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($6)))
 		GROUP BY 1
 		ORDER BY 2 DESC, 1
-	`)
+	`, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro ao agrupar por zona: %v", err), http.StatusInternalServerError)
 		return
@@ -465,6 +477,8 @@ WITH escolas AS (
       AND ($3 = '' OR e.municipio = $3)
       AND ($4 = '' OR e.zona = $4)
       AND ($5 = '' OR e.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $5))
+      AND ($6 = 0 OR e.school_id = $6)
+      AND ($7 = '' OR UPPER(TRIM(COALESCE(e.codigo_inep, ''))) = UPPER(TRIM($7)))
     GROUP BY e.school_id
 ),
 essenciais(nome) AS (
@@ -538,7 +552,7 @@ func (app *application) AdminAnalyticsCaracterizacaoInfraEducacional(w http.Resp
 				 ELSE 0
 			END::float8                                                        AS pct_plena
 		FROM por_escola
-	`, f.LegacyArgs()...).Scan(
+	`, f.Args()...).Scan(
 		&totalEscolas,
 		&out.CoberturaEssenciais.MediaAmbientesEssenciais,
 		&out.CoberturaEssenciais.PctCoberturaPlena,
@@ -561,9 +575,11 @@ func (app *application) AdminAnalyticsCaracterizacaoInfraEducacional(w http.Resp
 		  AND ($3 = '' OR a.municipio = $3)
 		  AND ($4 = '' OR a.zona = $4)
 		  AND ($5 = '' OR a.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $5))
+		  AND ($6 = 0 OR a.school_id = $6)
+		  AND ($7 = '' OR EXISTS (SELECT 1 FROM schools s_scope WHERE s_scope.id = a.school_id AND UPPER(TRIM(COALESCE(s_scope.codigo_inep, ''))) = UPPER(TRIM($7))))
 		GROUP BY TRIM(a.ambiente)
 		ORDER BY escolas DESC, label
-	`, f.LegacyArgs()...)
+	`, f.Args()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro na presença de ambientes: %v", err), http.StatusInternalServerError)
 		return
@@ -601,7 +617,7 @@ func (app *application) AdminAnalyticsCaracterizacaoInfraEducacional(w http.Resp
 			COUNT(*)      AS escolas
 		FROM por_escola
 		GROUP BY 1
-	`, f.LegacyArgs()...)
+	`, f.Args()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro nas faixas de cobertura: %v", err), http.StatusInternalServerError)
 		return
@@ -642,7 +658,7 @@ func (app *application) AdminAnalyticsCaracterizacaoInfraEducacional(w http.Resp
 		FROM por_escola
 		GROUP BY porte_nome
 		ORDER BY ord
-	`, f.LegacyArgs()...)
+	`, f.Args()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro na média por porte: %v", err), http.StatusInternalServerError)
 		return
@@ -794,6 +810,8 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 			  AND ($3 = '' OR s.municipio = $3)
 			  AND ($4 = '' OR s.zona = $4)
 			  AND ($5 = '' OR s.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $5))
+			  AND ($6 = 0 OR s.id = $6)
+			  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 		),
 		total AS (
 			SELECT COUNT(DISTINCT school_id)::numeric AS n FROM completed
@@ -821,7 +839,7 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 		CROSS JOIN total t
 		GROUP BY ex.etapa, t.n
 		ORDER BY escolas DESC, label
-	`, f.LegacyArgs()...)
+	`, f.Args()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro em etapas_ofertadas: %v", err), http.StatusInternalServerError)
 		return
@@ -852,6 +870,8 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 			  AND ($3 = '' OR s.municipio = $3)
 			  AND ($4 = '' OR s.zona = $4)
 			  AND ($5 = '' OR s.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $5))
+			  AND ($6 = 0 OR s.id = $6)
+			  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 		),
 		total AS (
 			SELECT COUNT(DISTINCT school_id)::numeric AS n FROM completed
@@ -879,7 +899,7 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 		CROSS JOIN total t
 		GROUP BY ex.modalidade, t.n
 		ORDER BY escolas DESC, label
-	`, f.LegacyArgs()...)
+	`, f.Args()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro em modalidades_ofertadas: %v", err), http.StatusInternalServerError)
 		return
@@ -910,6 +930,8 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 			  AND ($3 = '' OR s.municipio = $3)
 			  AND ($4 = '' OR s.zona = $4)
 			  AND ($5 = '' OR s.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $5))
+			  AND ($6 = 0 OR s.id = $6)
+			  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 		),
 		total AS (
 			SELECT COUNT(*)::numeric AS n FROM completed
@@ -944,7 +966,7 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 		CROSS JOIN total t
 		GROUP BY ex.turno, t.n
 		ORDER BY escolas DESC, label
-	`, f.LegacyArgs()...)
+	`, f.Args()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro em turnos: %v", err), http.StatusInternalServerError)
 		return
@@ -976,6 +998,8 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 			  AND ($3 = '' OR s.municipio = $3)
 			  AND ($4 = '' OR s.zona = $4)
 			  AND ($5 = '' OR s.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $5))
+			  AND ($6 = 0 OR s.id = $6)
+			  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 		),
 		turnos_por_escola AS (
 			SELECT c.school_id,
@@ -1006,7 +1030,7 @@ func (app *application) AdminAnalyticsCaracterizacaoOfertaFuncionamento(w http.R
 		 AND e.year      = $1
 		GROUP BY e.porte_escola_nome
 		ORDER BY ord
-	`, f.LegacyArgs()...)
+	`, f.Args()...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro em media_turnos_por_porte: %v", err), http.StatusInternalServerError)
 		return
@@ -1108,6 +1132,8 @@ const caracterizacaoEscolasSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY UPPER(TRIM(s.dre)), UPPER(TRIM(s.municipio)), UPPER(TRIM(s.nome_escola)), s.codigo_inep
 `
 
@@ -1148,7 +1174,7 @@ func (app *application) AdminAnalyticsCaracterizacaoEscolas(w http.ResponseWrite
 
 	ctx := r.Context()
 	dbRows, err := app.models.Schools.DB.QueryContext(ctx, caracterizacaoEscolasSelectSQL,
-		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao)
+		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("caracterizacao escolas: %w", err), http.StatusInternalServerError)
 		return

--- a/api/cmd/api/analytics_core_scope_test.go
+++ b/api/cmd/api/analytics_core_scope_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCoreAnalyticsDREScopeOverridesQueryAndKeepsSchoolFilters(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/admin/analytics/overview?dre=DRE_B&school_id=42&codigo_inep=15000123", nil)
+	ctx := context.WithValue(req.Context(), contextKeyAdminScope, AdminAccessScope{
+		Username: "dre-a",
+		Role:     RoleDRE,
+		DRE:      "DRE_A",
+	})
+	f := parseAnalyticsFilters(req.WithContext(ctx))
+	if f.DRE != "DRE_A" {
+		t.Fatalf("DRE scope not enforced: got %q", f.DRE)
+	}
+	if f.SchoolID != 42 {
+		t.Fatalf("school_id not preserved: got %d", f.SchoolID)
+	}
+	if f.CodigoINEP != "15000123" {
+		t.Fatalf("codigo_inep not preserved: got %q", f.CodigoINEP)
+	}
+}
+
+func TestCoreAnalyticsSchoolTablesApplySchoolAndINEP(t *testing.T) {
+	queries := map[string]string{
+		"caracterizacaoEscolasSelectSQL": caracterizacaoEscolasSelectSQL,
+		"merendaEscolasSelectSQL":        merendaEscolasSelectSQL,
+		"pessoalEscolasSelectSQL":        pessoalEscolasSelectSQL,
+		"servicosEscolasSelectSQL":       servicosEscolasSelectSQL,
+		"tecnologiaEscolasSelectSQL":     tecnologiaEscolasSelectSQL,
+	}
+	for name, query := range queries {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(query, "$6 = 0 OR s.id = $6") {
+				t.Fatalf("school_id predicate missing from %s", name)
+			}
+			if !strings.Contains(query, "codigo_inep") || !strings.Contains(query, "$7") {
+				t.Fatalf("codigo_inep predicate missing from %s", name)
+			}
+		})
+	}
+}
+
+func TestInfraestruturaAnalyticsSelectSQLAppliesSchoolAndINEP(t *testing.T) {
+	if !strings.Contains(infraestruturaAnalyticsSelectSQL, "$6 = 0 OR s.id = $6") {
+		t.Fatal("school_id predicate missing from infraestrutura analytics query")
+	}
+	if !strings.Contains(infraestruturaAnalyticsSelectSQL, "codigo_inep") || !strings.Contains(infraestruturaAnalyticsSelectSQL, "$7") {
+		t.Fatal("codigo_inep predicate missing from infraestrutura analytics query")
+	}
+}

--- a/api/cmd/api/analytics_infra_merenda_servicos.go
+++ b/api/cmd/api/analytics_infra_merenda_servicos.go
@@ -347,7 +347,7 @@ func (app *application) AdminAnalyticsInfraCondicoes(w http.ResponseWriter, r *h
 				 ELSE 0
 			END::float8
 		FROM por_escola
-	`, f.LegacyArgs()...).Scan(&out.PctCoberturaPlena)
+	`, f.Args()...).Scan(&out.PctCoberturaPlena)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("pct_cobertura_plena: %v", err), http.StatusInternalServerError)
 		return
@@ -1404,6 +1404,15 @@ func infraEscolaSortVal(r InfraEscolaRow, key string) string {
 	}
 }
 
+var infraestruturaAnalyticsSelectSQL = strings.Replace(
+	infraestruturaSelectSQL,
+	"\n\tORDER BY",
+	"\n\t  AND ($6 = 0 OR s.id = $6)"+
+		"\n\t  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))"+
+		"\n\tORDER BY",
+	1,
+)
+
 // AdminAnalyticsInfraEscolas retorna a listagem escola-a-escola de infraestrutura e
 // segurança com busca textual, ordenação e paginação server-side.
 // Parâmetros: year, dre, municipio, zona, regiao_integracao, q, page, page_size, sort, direction.
@@ -1420,8 +1429,8 @@ func (app *application) AdminAnalyticsInfraEscolas(w http.ResponseWriter, r *htt
 	direction := parseEscolasDirection(q.Get("direction"))
 
 	ctx := r.Context()
-	dbRows, err := app.models.Schools.DB.QueryContext(ctx, infraestruturaSelectSQL,
-		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao)
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, infraestruturaAnalyticsSelectSQL,
+		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("infra escolas: %w", err), http.StatusInternalServerError)
 		return
@@ -1584,6 +1593,8 @@ const merendaEscolasSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY UPPER(TRIM(s.dre)), UPPER(TRIM(s.municipio)), UPPER(TRIM(s.nome_escola)), s.codigo_inep
 `
 
@@ -1626,7 +1637,7 @@ func (app *application) AdminAnalyticsMerendaEscolas(w http.ResponseWriter, r *h
 
 	ctx := r.Context()
 	dbRows, err := app.models.Schools.DB.QueryContext(ctx, merendaEscolasSelectSQL,
-		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao)
+		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("merenda escolas: %w", err), http.StatusInternalServerError)
 		return
@@ -1764,6 +1775,8 @@ const servicosEscolasSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY UPPER(TRIM(s.dre)), UPPER(TRIM(s.municipio)), UPPER(TRIM(s.nome_escola)), s.codigo_inep
 `
 
@@ -1807,7 +1820,7 @@ func (app *application) AdminAnalyticsServicosTerceirizadosEscolas(w http.Respon
 
 	ctx := r.Context()
 	dbRows, err := app.models.Schools.DB.QueryContext(ctx, servicosEscolasSelectSQL,
-		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao)
+		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("servicos escolas: %w", err), http.StatusInternalServerError)
 		return

--- a/api/cmd/api/analytics_pessoal_tecnologia.go
+++ b/api/cmd/api/analytics_pessoal_tecnologia.go
@@ -49,6 +49,15 @@ func (app *application) AdminAnalyticsPessoalEstrutura(w http.ResponseWriter, r 
 		}
 	}
 
+	sharedFilters := parseAnalyticsFilters(r)
+	year = sharedFilters.Year
+	dre = sharedFilters.DRE
+	municipio = sharedFilters.Municipio
+	zona = sharedFilters.Zona
+	regiaoIntegracao = sharedFilters.RegiaoIntegracao
+	schoolID := sharedFilters.SchoolID
+	codigoINEP := sharedFilters.CodigoINEP
+
 	out := PessoalEstrutura{
 		ComposicaoGestao: []CategoricStat{},
 	}
@@ -65,6 +74,8 @@ func (app *application) AdminAnalyticsPessoalEstrutura(w http.ResponseWriter, r 
 		  AND ($4 = '' OR v.zona = $4)
 		  AND ($5 = '' OR e.porte_escola_nome = $5)
 		  AND ($6 = '' OR v.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $6))
+		  AND ($7 = 0 OR e.school_id = $7)
+		  AND ($8 = '' OR UPPER(TRIM(COALESCE(e.codigo_inep, ''))) = UPPER(TRIM($8)))
 	`
 
 	// 1) Composição da Gestão (% de Sim por cargo)
@@ -83,7 +94,7 @@ func (app *application) AdminAnalyticsPessoalEstrutura(w http.ResponseWriter, r 
 		FROM base CROSS JOIN tot_escolas
 		GROUP BY cargo, ordem, tot_escolas.n
 		ORDER BY ordem
-	`, baseQuery), year, dre, municipio, zona, porte, regiaoIntegracao)
+	`, baseQuery), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("composicao_gestao: %v", err), http.StatusInternalServerError)
 		return
@@ -119,7 +130,9 @@ func (app *application) AdminAnalyticsPessoalEstrutura(w http.ResponseWriter, r 
 		  AND ($4 = '' OR b.zona = $4)
 		  AND ($5 = '' OR e.porte_escola_nome = $5)
 		  AND ($6 = '' OR b.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $6))
-	`, year, dre, municipio, zona, porte, regiaoIntegracao).Scan(&out.TotalCoordenadoresPedagog)
+		  AND ($7 = 0 OR e.school_id = $7)
+		  AND ($8 = '' OR UPPER(TRIM(COALESCE(e.codigo_inep, ''))) = UPPER(TRIM($8)))
+	`, year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP).Scan(&out.TotalCoordenadoresPedagog)
 
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("total_coordenadores: %v", err), http.StatusInternalServerError)
@@ -152,6 +165,15 @@ func (app *application) AdminAnalyticsPessoalCoordenacao(w http.ResponseWriter, 
 		}
 	}
 
+	sharedFilters := parseAnalyticsFilters(r)
+	year = sharedFilters.Year
+	dre = sharedFilters.DRE
+	municipio = sharedFilters.Municipio
+	zona = sharedFilters.Zona
+	regiaoIntegracao = sharedFilters.RegiaoIntegracao
+	schoolID := sharedFilters.SchoolID
+	codigoINEP := sharedFilters.CodigoINEP
+
 	out := PessoalCoordenacao{
 		PorArea: []CategoricStat{},
 	}
@@ -167,6 +189,8 @@ func (app *application) AdminAnalyticsPessoalCoordenacao(w http.ResponseWriter, 
 		  AND ($4 = '' OR v.zona = $4)
 		  AND ($5 = '' OR e.porte_escola_nome = $5)
 		  AND ($6 = '' OR v.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $6))
+		  AND ($7 = 0 OR e.school_id = $7)
+		  AND ($8 = '' OR UPPER(TRIM(COALESCE(e.codigo_inep, ''))) = UPPER(TRIM($8)))
 	`
 
 	// 1) Distribuição por Área (% de Sim por área)
@@ -185,7 +209,7 @@ func (app *application) AdminAnalyticsPessoalCoordenacao(w http.ResponseWriter, 
 		FROM base CROSS JOIN tot_escolas
 		GROUP BY area, ordem, tot_escolas.n
 		ORDER BY ordem
-	`, baseQuery), year, dre, municipio, zona, porte, regiaoIntegracao)
+	`, baseQuery), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("por_area: %v", err), http.StatusInternalServerError)
 		return
@@ -210,7 +234,7 @@ func (app *application) AdminAnalyticsPessoalCoordenacao(w http.ResponseWriter, 
 		)
 		SELECT COALESCE(ROUND(AVG(qtd_areas), 2), 0)::float8
 		FROM base
-	`, baseQuery), year, dre, municipio, zona, porte, regiaoIntegracao).Scan(&out.CoberturaMedia)
+	`, baseQuery), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP).Scan(&out.CoberturaMedia)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("cobertura_media: %v", err), http.StatusInternalServerError)
 		return
@@ -268,6 +292,15 @@ func (app *application) AdminAnalyticsPessoalQuadro(w http.ResponseWriter, r *ht
 		}
 	}
 
+	sharedFilters := parseAnalyticsFilters(r)
+	year = sharedFilters.Year
+	dre = sharedFilters.DRE
+	municipio = sharedFilters.Municipio
+	zona = sharedFilters.Zona
+	regiaoIntegracao = sharedFilters.RegiaoIntegracao
+	schoolID := sharedFilters.SchoolID
+	codigoINEP := sharedFilters.CodigoINEP
+
 	out := QuadroPessoal{PorDRE: []QuadroPessoalDRE{}}
 
 	const baseWhere = `
@@ -280,6 +313,8 @@ func (app *application) AdminAnalyticsPessoalQuadro(w http.ResponseWriter, r *ht
 		  AND ($4 = '' OR v.zona = $4)
 		  AND ($5 = '' OR e.porte_escola_nome = $5)
 		  AND ($6 = '' OR v.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $6))
+		  AND ($7 = 0 OR e.school_id = $7)
+		  AND ($8 = '' OR UPPER(TRIM(COALESCE(e.codigo_inep, ''))) = UPPER(TRIM($8)))
 	`
 
 	// 1) Totais e médias globais
@@ -294,7 +329,7 @@ func (app *application) AdminAnalyticsPessoalQuadro(w http.ResponseWriter, r *ht
 			COALESCE(ROUND(AVG(qtd_servidores_administrativos), 2), 0)::float8,
 			COALESCE(ROUND(AVG(qtd_professor_readaptado), 2), 0)::float8
 		%s
-	`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao).Scan(
+	`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP).Scan(
 		&out.TotalEfetivos,
 		&out.TotalTemporarios,
 		&out.TotalAdministrativos,
@@ -320,7 +355,7 @@ func (app *application) AdminAnalyticsPessoalQuadro(w http.ResponseWriter, r *ht
 		GROUP BY v.dre
 		ORDER BY SUM(total_professores) DESC
 		LIMIT 20
-	`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao)
+	`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("quadro_pessoal por_dre: %v", err), http.StatusInternalServerError)
 		return
@@ -399,6 +434,15 @@ func (app *application) AdminAnalyticsTecnologiaInfra(w http.ResponseWriter, r *
 		}
 	}
 
+	sharedFilters := parseAnalyticsFilters(r)
+	year = sharedFilters.Year
+	dre = sharedFilters.DRE
+	municipio = sharedFilters.Municipio
+	zona = sharedFilters.Zona
+	regiaoIntegracao = sharedFilters.RegiaoIntegracao
+	schoolID := sharedFilters.SchoolID
+	codigoINEP := sharedFilters.CodigoINEP
+
 	out := TecnologiaInfra{
 		DisponibilidadeInternet:    []CategoricStat{},
 		PorProvedor:                []CategoricStat{},
@@ -417,6 +461,8 @@ func (app *application) AdminAnalyticsTecnologiaInfra(w http.ResponseWriter, r *
 		  AND ($4 = '' OR v.zona = $4)
 		  AND ($5 = '' OR e.porte_escola_nome = $5)
 		  AND ($6 = '' OR v.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $6))
+		  AND ($7 = 0 OR e.school_id = $7)
+		  AND ($8 = '' OR UPPER(TRIM(COALESCE(e.codigo_inep, ''))) = UPPER(TRIM($8)))
 	`
 
 	// 1) Totais de internet e equipamentos (inclui total absoluto de inoperantes)
@@ -434,7 +480,7 @@ func (app *application) AdminAnalyticsTecnologiaInfra(w http.ResponseWriter, r *
 			COALESCE(SUM(qtd_computadores_inoperantes), 0)::float8,
 			COALESCE(ROUND(100.0 * COUNT(DISTINCT school_id) FILTER (WHERE computadores_atendem = 'Sim') / NULLIF(MAX(tot.n), 0), 1), 0)::float8
 		FROM base CROSS JOIN tot
-	`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao).Scan(
+	`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP).Scan(
 		&out.EscolasComInternet,
 		&out.PercentualInternet,
 		&out.TotalDesktopsAdm,
@@ -465,7 +511,7 @@ func (app *application) AdminAnalyticsTecnologiaInfra(w http.ResponseWriter, r *
 				COUNT(DISTINCT school_id) FILTER (WHERE NOT internet_disponivel)::int,
 				COALESCE(ROUND(100.0 * COUNT(DISTINCT school_id) FILTER (WHERE NOT internet_disponivel) / NULLIF(MAX(tot.n), 0), 1), 0)::float8
 			FROM base CROSS JOIN tot
-		`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao).Scan(&simEsc, &simPct, &naoEsc, &naoPct); e != nil {
+		`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP).Scan(&simEsc, &simPct, &naoEsc, &naoPct); e != nil {
 			app.errorJSON(w, fmt.Errorf("disponibilidade_internet: %v", e), http.StatusInternalServerError)
 			return
 		}
@@ -491,7 +537,7 @@ func (app *application) AdminAnalyticsTecnologiaInfra(w http.ResponseWriter, r *
 				COALESCE(ROUND(AVG(COALESCE(qtd_desktop_adm, 0)), 2), 0)::float8,
 				COALESCE(ROUND(AVG(COALESCE(qtd_notebooks, 0)), 2), 0)::float8
 			FROM base
-		`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao).Scan(&medChromebooks, &medDesktopAlunos, &medDesktopAdm, &medNotebooks); e != nil {
+		`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP).Scan(&medChromebooks, &medDesktopAlunos, &medDesktopAdm, &medNotebooks); e != nil {
 			app.errorJSON(w, fmt.Errorf("media_equipamentos: %v", e), http.StatusInternalServerError)
 			return
 		}
@@ -516,7 +562,7 @@ func (app *application) AdminAnalyticsTecnologiaInfra(w http.ResponseWriter, r *
 			WHERE %s IS NOT NULL
 			GROUP BY %s, tot.n
 			ORDER BY escolas DESC
-		`, baseWhere, campo, campo, campo), year, dre, municipio, zona, porte, regiaoIntegracao)
+		`, baseWhere, campo, campo, campo), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP)
 		if err != nil {
 			return nil, err
 		}
@@ -561,7 +607,7 @@ func (app *application) AdminAnalyticsTecnologiaInfra(w http.ResponseWriter, r *
 			FROM base CROSS JOIN tot
 			GROUP BY COALESCE(computadores_atendem, 'Não informado'), tot.n
 			ORDER BY escolas DESC
-		`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao)
+		`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP)
 		if err != nil {
 			app.errorJSON(w, fmt.Errorf("computadores_atendem_demanda: %v", err), http.StatusInternalServerError)
 			return
@@ -602,6 +648,15 @@ func (app *application) AdminAnalyticsTecnologiaUso(w http.ResponseWriter, r *ht
 		}
 	}
 
+	sharedFilters := parseAnalyticsFilters(r)
+	year = sharedFilters.Year
+	dre = sharedFilters.DRE
+	municipio = sharedFilters.Municipio
+	zona = sharedFilters.Zona
+	regiaoIntegracao = sharedFilters.RegiaoIntegracao
+	schoolID := sharedFilters.SchoolID
+	codigoINEP := sharedFilters.CodigoINEP
+
 	out := TecnologiaUso{
 		PossuiProjetorDist:     []CategoricStat{},
 		PossuiLousaDigitalDist: []CategoricStat{},
@@ -617,6 +672,8 @@ func (app *application) AdminAnalyticsTecnologiaUso(w http.ResponseWriter, r *ht
 		  AND ($4 = '' OR v.zona = $4)
 		  AND ($5 = '' OR e.porte_escola_nome = $5)
 		  AND ($6 = '' OR v.municipio IN (SELECT municipio FROM reg_integracao WHERE regiao_de_integracao = $6))
+		  AND ($7 = 0 OR e.school_id = $7)
+		  AND ($8 = '' OR UPPER(TRIM(COALESCE(e.codigo_inep, ''))) = UPPER(TRIM($8)))
 	`
 
 	// 1) KPIs de projetor/lousa e média de projetores por escola.
@@ -633,7 +690,7 @@ func (app *application) AdminAnalyticsTecnologiaUso(w http.ResponseWriter, r *ht
 			COUNT(DISTINCT school_id) FILTER (WHERE possui_lousa_digital)::bigint,
 			COALESCE(ROUND(100.0 * COUNT(DISTINCT school_id) FILTER (WHERE possui_lousa_digital) / NULLIF(MAX(tot.n), 0), 1), 0)::float8
 		FROM base CROSS JOIN tot
-	`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao).Scan(
+	`, baseWhere), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP).Scan(
 		&out.EscolasComProjetor,
 		&out.PercentualComProjetor,
 		&out.TotalProjetores,
@@ -660,7 +717,7 @@ func (app *application) AdminAnalyticsTecnologiaUso(w http.ResponseWriter, r *ht
 				COUNT(DISTINCT school_id) FILTER (WHERE NOT %s)::int,
 				COALESCE(ROUND(100.0 * COUNT(DISTINCT school_id) FILTER (WHERE NOT %s) / NULLIF(MAX(tot.n), 0), 1), 0)::float8
 			FROM base CROSS JOIN tot
-		`, baseWhere, campo, campo, campo, campo), year, dre, municipio, zona, porte, regiaoIntegracao).Scan(&simEsc, &simPct, &naoEsc, &naoPct); e != nil {
+		`, baseWhere, campo, campo, campo, campo), year, dre, municipio, zona, porte, regiaoIntegracao, schoolID, codigoINEP).Scan(&simEsc, &simPct, &naoEsc, &naoPct); e != nil {
 			return nil, e
 		}
 		return []CategoricStat{
@@ -747,6 +804,8 @@ const pessoalEscolasSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY UPPER(TRIM(s.dre)), UPPER(TRIM(s.municipio)), UPPER(TRIM(s.nome_escola)), s.codigo_inep
 `
 
@@ -787,7 +846,7 @@ func (app *application) AdminAnalyticsPessoalEscolas(w http.ResponseWriter, r *h
 
 	ctx := r.Context()
 	dbRows, err := app.models.Schools.DB.QueryContext(ctx, pessoalEscolasSelectSQL,
-		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao)
+		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("pessoal escolas: %w", err), http.StatusInternalServerError)
 		return
@@ -928,6 +987,8 @@ const tecnologiaEscolasSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY UPPER(TRIM(s.dre)), UPPER(TRIM(s.municipio)), UPPER(TRIM(s.nome_escola)), s.codigo_inep
 `
 
@@ -970,7 +1031,7 @@ func (app *application) AdminAnalyticsTecnologiaEscolas(w http.ResponseWriter, r
 
 	ctx := r.Context()
 	dbRows, err := app.models.Schools.DB.QueryContext(ctx, tecnologiaEscolasSelectSQL,
-		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao)
+		f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("tecnologia escolas: %w", err), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary
- aplica o escopo DRE antes dos cálculos do overview e da Caracterização
- propaga `school_id` e `codigo_inep` pelos analytics principais de Pessoal, Tecnologia, Infraestrutura, Merenda e Serviços Terceirizados
- restringe também as tabelas escola-a-escola ao recorte autorizado
- mantém o contrato dos relatórios fora deste PR, preservando o escopo da #161
- adiciona testes de regressão para override de DRE e filtros Escola/INEP

## Validation
- `go test ./...`
- `git diff --check`

Closes #160