### PR TITLE
feat: enforce DRE scope on advanced analytics and reports

### DIFF
--- a/api/cmd/api/advanced_dre_scope_test.go
+++ b/api/cmd/api/advanced_dre_scope_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func advancedDRERequest(path string) *http.Request {
+	req := httptest.NewRequest("GET", path, nil)
+	ctx := context.WithValue(req.Context(), contextKeyAdminScope, AdminAccessScope{
+		Username: "dre-a",
+		Role:     RoleDRE,
+		DRE:      "DRE_A",
+	})
+	return req.WithContext(ctx)
+}
+
+func TestAdvancedScopeOverridesHostileDREAcrossSensitiveHandlers(t *testing.T) {
+	req := advancedDRERequest("/v1/admin/analytics/x?dre=DRE_B&municipio=Belem&school_id=202&codigo_inep=15000202")
+
+	health := saudeOperacionalFiltersFromRequest(req)
+	if health.DRE != "DRE_A" || health.SchoolID != 202 || health.CodigoINEP != "15000202" {
+		t.Fatalf("health scope mismatch: %+v", health)
+	}
+
+	ideb := applyIdebAccessScope(req, idebFilters{})
+	if ideb.DRE != "DRE_A" || !ideb.RequireLinkedSchool || ideb.SchoolID != 202 || ideb.CodigoINEP != "15000202" {
+		t.Fatalf("IDEB scope mismatch: %+v", ideb)
+	}
+
+	prodep := applyProdepAccessScope(req, prodepFilters{})
+	if prodep.DRE != "DRE_A" || !prodep.RequireLinkedDRE || prodep.SchoolID != 202 || prodep.CodigoINEP != "15000202" {
+		t.Fatalf("PRODEP scope mismatch: %+v", prodep)
+	}
+
+	preenchimento := preenchimentoDreFiltersFromRequest(req, time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC))
+	if preenchimento.DRE != "DRE_A" || preenchimento.SchoolID != 202 || preenchimento.CodigoINEP != "15000202" {
+		t.Fatalf("preenchimento scope mismatch: %+v", preenchimento)
+	}
+
+	report := parseReportFiltersRequest(req)
+	if report.DRE != "DRE_A" || report.SchoolID != 202 || report.CodigoINEP != "15000202" {
+		t.Fatalf("report scope mismatch: %+v", report)
+	}
+}
+
+func TestAdvancedScopeIDEBFailsClosedForDREUnlinkedRows(t *testing.T) {
+	required := []string{
+		"$13 = false OR ir.school_id IS NOT NULL",
+		"$11 = 0 OR ir.school_id = $11",
+		"COALESCE(ir.codigo_inep, '')",
+		"COALESCE(s.codigo_inep, '')",
+	}
+	for _, part := range required {
+		if !strings.Contains(idebFromWhere, part) {
+			t.Fatalf("IDEB security predicate missing: %q", part)
+		}
+	}
+
+	adminReq := httptest.NewRequest("GET", "/v1/admin/analytics/x?codigo_inep=15000123", nil)
+	admin := applyIdebAccessScope(adminReq, idebFilters{})
+	if admin.RequireLinkedSchool {
+		t.Fatal("admin must retain broad IDEB visibility, including quality/unmatched rows")
+	}
+}
+
+func TestAdvancedScopePRODEPFailsClosedWithoutReliableDRELink(t *testing.T) {
+	required := []string{
+		"$8 = false OR ($3 <> '' AND EXISTS",
+		"scope_s.id = prodep_repasses.school_id",
+		"scope_s.id = prodep_repasses.school_id_sede",
+		"$9 = 0 OR prodep_repasses.school_id = $9",
+		"codigo_inep_prodep",
+	}
+	for _, part := range required {
+		if !strings.Contains(prodepWhereSQL, part) {
+			t.Fatalf("PRODEP security predicate missing: %q", part)
+		}
+	}
+}
+
+func TestAdvancedScopeSensitiveQueriesFilterBeforeAggregation(t *testing.T) {
+	queries := map[string]string{
+		"saude":                    saudeOperacionalSelectSQL,
+		"governanca_institucional": governancaInstitucionalScopedWhereSQL,
+		"indice_governanca":        indiceGovernancaSelectSQL,
+		"preenchimento":            preenchimentoDreScopedSelectSQL,
+	}
+	for name, query := range queries {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(query, "codigo_inep") {
+				t.Fatalf("%s lacks INEP scope", name)
+			}
+		})
+	}
+	if !strings.Contains(saudeOperacionalSelectSQL, "$6 = 0 OR s.id = $6") || !strings.Contains(saudeOperacionalSelectSQL, "$7") {
+		t.Fatal("health dataset is not scoped by school/INEP")
+	}
+	if !strings.Contains(indiceGovernancaSelectSQL, "$5 = 0 OR s.id = $5") || !strings.Contains(indiceGovernancaSelectSQL, "$6") {
+		t.Fatal("governance index is not scoped before summary")
+	}
+}
+
+func TestAdvancedScopeEveryCurrentXLSXSchoolQueryIsScoped(t *testing.T) {
+	queries := map[string]string{
+		"censo-preenchimento": censoPreenchimentoSelectSQL,
+		"infraestrutura":      infraestruturaSelectSQL,
+		"merenda":             merendaSelectSQL,
+		"financeiro":          financeiroGovernancaSelectSQL,
+	}
+	for name, query := range queries {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(query, "$6 = 0 OR s.id = $6") {
+				t.Fatalf("%s report lacks school_id predicate", name)
+			}
+			if !strings.Contains(query, "codigo_inep") || !strings.Contains(query, "$7") {
+				t.Fatalf("%s report lacks codigo_inep predicate", name)
+			}
+		})
+	}
+}
+
+func TestAdvancedScopeReportRequestCannotOverrideTokenDRE(t *testing.T) {
+	req := advancedDRERequest("/v1/admin/reports/saude-operacional-escolas?dre=DRE_B&school_id=99&codigo_inep=X")
+	f := parseReportFiltersRequest(req)
+	if f.DRE != "DRE_A" {
+		t.Fatalf("report honored hostile DRE query: %q", f.DRE)
+	}
+	args := f.scopedArgs()
+	if len(args) != 7 || args[1] != "DRE_A" || args[5] != 99 || args[6] != "X" {
+		t.Fatalf("unexpected scoped report args: %#v", args)
+	}
+}

--- a/api/cmd/api/analytics_financeiro_governanca.go
+++ b/api/cmd/api/analytics_financeiro_governanca.go
@@ -62,6 +62,9 @@ type prodepFilters struct {
 	RI                    string // '' = todas (case-insensitive sobre ri_prodep)
 	MatchStatus           string // '' = todos
 	StatusPrestacaoContas string // '' = todos
+	SchoolID              int
+	CodigoINEP            string
+	RequireLinkedDRE      bool
 }
 
 // args devolve os argumentos posicionais na ordem esperada por prodepWhereSQL.
@@ -74,6 +77,9 @@ func (f prodepFilters) args() []any {
 		f.RI,
 		f.MatchStatus,
 		f.StatusPrestacaoContas,
+		f.RequireLinkedDRE,
+		f.SchoolID,
+		f.CodigoINEP,
 	}
 }
 
@@ -125,6 +131,14 @@ var prodepWhereSQL = `
 	  AND ($5 = '' OR ` + sqlNormalizeProdep("COALESCE(ri_prodep, '')", "RI") + ` = ` + sqlNormalizeProdep("$5::text", "RI") + `)
 	  AND ($6 = '' OR match_status = $6)
 	  AND ($7 = '' OR COALESCE(status_prestacao_contas, '') = $7)
+	  AND ($8 = false OR ($3 <> '' AND EXISTS (
+	        SELECT 1
+	        FROM schools scope_s
+	        WHERE (scope_s.id = prodep_repasses.school_id OR scope_s.id = prodep_repasses.school_id_sede)
+	          AND UPPER(TRIM(scope_s.dre)) = UPPER(TRIM($3))
+	      )))
+	  AND ($9 = 0 OR prodep_repasses.school_id = $9 OR prodep_repasses.school_id_sede = $9)
+	  AND ($10 = '' OR UPPER(TRIM(COALESCE(codigo_inep_prodep, ''))) = UPPER(TRIM($10)))
 `
 
 type ProdepResumo struct {
@@ -270,6 +284,26 @@ func parseProdepFilters(q map[string][]string) (prodepFilters, error) {
 	return f, nil
 }
 
+// applyProdepAccessScope combina os filtros específicos do PRODEP com o escopo
+// compartilhado. Um usuário DRE só pode consumir linhas que tenham vínculo
+// operacional verificável (school_id ou school_id_sede) com sua DRE. Entradas
+// apenas saneadas por fonte auxiliar permanecem visíveis para admin, mas são
+// deliberadamente ocultadas do perfil DRE quando não há vínculo confiável.
+func applyProdepAccessScope(r *http.Request, f prodepFilters) prodepFilters {
+	shared := parseAnalyticsFilters(r)
+	f.DRE = shared.DRE
+	f.Municipio = shared.Municipio
+	f.SchoolID = shared.SchoolID
+	f.CodigoINEP = shared.CodigoINEP
+	if strings.TrimSpace(shared.RegiaoIntegracao) != "" {
+		f.RI = shared.RegiaoIntegracao
+	}
+	if scope, ok := GetAdminAccessScope(r.Context()); ok && scope.Role == RoleDRE {
+		f.RequireLinkedDRE = true
+	}
+	return f
+}
+
 // AdminAnalyticsFinanceiroGovernancaProdep responde GET
 // /v1/admin/analytics/financeiro-governanca/prodep.
 //
@@ -285,6 +319,7 @@ func (app *application) AdminAnalyticsFinanceiroGovernancaProdep(w http.Response
 		app.errorJSON(w, err, http.StatusBadRequest)
 		return
 	}
+	filters = applyProdepAccessScope(r, filters)
 	args := filters.args()
 
 	out := ProdepFinanceiroPayload{
@@ -479,15 +514,15 @@ func (app *application) AdminAnalyticsFinanceiroGovernancaProdep(w http.Response
 		MatchStatus:           []string{"matched_by_inep_schools", "matched_by_base_dige", "prodep_only_validado", "anexo_vinculado_sede"},
 		StatusPrestacaoContas: []string{"ok", "sem_recurso", "nao_prestou_contas"},
 	}
-	if out.FiltrosDisponiveis.DREs, err = app.queryProdepDistinct(ctx, db, "dre_prodep"); err != nil {
+	if out.FiltrosDisponiveis.DREs, err = app.queryProdepDistinct(ctx, db, "dre_prodep", args); err != nil {
 		app.errorJSON(w, fmt.Errorf("filtros dres prodep: %v", err), http.StatusInternalServerError)
 		return
 	}
-	if out.FiltrosDisponiveis.Municipios, err = app.queryProdepDistinct(ctx, db, "municipio_resolvido"); err != nil {
+	if out.FiltrosDisponiveis.Municipios, err = app.queryProdepDistinct(ctx, db, "municipio_resolvido", args); err != nil {
 		app.errorJSON(w, fmt.Errorf("filtros municipios prodep: %v", err), http.StatusInternalServerError)
 		return
 	}
-	if out.FiltrosDisponiveis.RIs, err = app.queryProdepDistinct(ctx, db, "ri_prodep"); err != nil {
+	if out.FiltrosDisponiveis.RIs, err = app.queryProdepDistinct(ctx, db, "ri_prodep", args); err != nil {
 		app.errorJSON(w, fmt.Errorf("filtros ris prodep: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -584,6 +619,7 @@ func (app *application) queryProdepDistinct(
 	ctx context.Context,
 	db *sql.DB,
 	col string,
+	args []any,
 ) ([]string, error) {
 	switch col {
 	case "dre_prodep", "municipio_resolvido", "ri_prodep":
@@ -593,13 +629,12 @@ func (app *application) queryProdepDistinct(
 
 	query := fmt.Sprintf(`
 		SELECT DISTINCT TRIM(%s)
-		FROM prodep_repasses
-		WHERE usar_na_carga = true
+		FROM prodep_repasses`+prodepWhereSQL+`
 		  AND %s IS NOT NULL
 		  AND TRIM(%s) <> ''
 		ORDER BY 1`, col, col, col)
 
-	rows, err := db.QueryContext(ctx, query)
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/api/cmd/api/analytics_governanca_institucional.go
+++ b/api/cmd/api/analytics_governanca_institucional.go
@@ -64,6 +64,20 @@ const governancaInstitucionalWhereSQL = `
 	  AND ($3 = '' OR UPPER(TRIM(zona)) = UPPER(TRIM($3)))
 `
 
+// governancaInstitucionalScopedWhereSQL é a variante usada pelo handler HTTP:
+// além dos filtros territoriais, aplica o recorte obrigatório do perfil DRE e
+// os filtros Escola/INEP antes dos COUNTs.
+const governancaInstitucionalScopedWhereSQL = `
+	WHERE ($1 = '' OR UPPER(TRIM(dre)) = UPPER(TRIM($1)))
+	  AND ($2 = '' OR UPPER(TRIM(municipio)) = UPPER(TRIM($2)))
+	  AND ($3 = '' OR UPPER(TRIM(zona)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(municipio)) IN (
+	        SELECT UPPER(TRIM(municipio)) FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($4))))
+	  AND ($5 = 0 OR school_id = $5)
+	  AND ($6 = '' OR UPPER(TRIM(COALESCE(codigo_inep, ''))) = UPPER(TRIM($6)))
+`
+
 // GovernancaIndicador é a tripla total/denominador/percentual de cada card.
 type GovernancaIndicador struct {
 	Total       int64   `json:"total"`
@@ -123,8 +137,15 @@ func (app *application) AdminAnalyticsFinanceiroGovernancaInstitucional(w http.R
 	ctx := r.Context()
 	db := app.models.Schools.DB
 
-	filters := parseGovernancaInstitucionalFilters(r.URL.Query())
-	args := filters.args()
+	shared := parseAnalyticsFilters(r)
+	args := []any{
+		shared.DRE,
+		shared.Municipio,
+		shared.Zona,
+		shared.RegiaoIntegracao,
+		shared.SchoolID,
+		shared.CodigoINEP,
+	}
 
 	var (
 		totalEscolas        int64
@@ -145,7 +166,7 @@ func (app *application) AdminAnalyticsFinanceiroGovernancaInstitucional(w http.R
 			COUNT(*) FILTER (WHERE is_conselho_parcialmente_ativo)::bigint,
 			COUNT(*) FILTER (WHERE is_governanca_completa)::bigint,
 			COUNT(*) FILTER (WHERE is_governanca_critica)::bigint
-		FROM vw_censo_governanca_institucional`+governancaInstitucionalWhereSQL,
+		FROM vw_censo_governanca_institucional`+governancaInstitucionalScopedWhereSQL,
 		args...,
 	).Scan(
 		&totalEscolas,

--- a/api/cmd/api/analytics_indice_governanca.go
+++ b/api/cmd/api/analytics_indice_governanca.go
@@ -72,12 +72,18 @@ const indiceGovernancaSelectSQL = `
 	WHERE ($1 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($1)))
 	  AND ($2 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($2)))
 	  AND ($3 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio)) FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($4))))
+	  AND ($5 = 0 OR s.id = $5)
+	  AND ($6 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($6)))
 `
 
 func (app *application) AdminAnalyticsGovernancaIndiceEscolas(w http.ResponseWriter, r *http.Request) {
-	filters := parseGovernancaInstitucionalFilters(r.URL.Query())
+	filters := parseAnalyticsFilters(r)
 
-	rows, err := app.models.Schools.DB.QueryContext(r.Context(), indiceGovernancaSelectSQL, filters.args()...)
+	rows, err := app.models.Schools.DB.QueryContext(r.Context(), indiceGovernancaSelectSQL,
+		filters.DRE, filters.Municipio, filters.Zona, filters.RegiaoIntegracao, filters.SchoolID, filters.CodigoINEP)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("erro ao consultar indice de governanca: %w", err), http.StatusInternalServerError)
 		return

--- a/api/cmd/api/analytics_infra_merenda_servicos.go
+++ b/api/cmd/api/analytics_infra_merenda_servicos.go
@@ -1404,14 +1404,7 @@ func infraEscolaSortVal(r InfraEscolaRow, key string) string {
 	}
 }
 
-var infraestruturaAnalyticsSelectSQL = strings.Replace(
-	infraestruturaSelectSQL,
-	"\n\tORDER BY",
-	"\n\t  AND ($6 = 0 OR s.id = $6)"+
-		"\n\t  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))"+
-		"\n\tORDER BY",
-	1,
-)
+var infraestruturaAnalyticsSelectSQL = infraestruturaSelectSQL
 
 // AdminAnalyticsInfraEscolas retorna a listagem escola-a-escola de infraestrutura e
 // segurança com busca textual, ordenação e paginação server-side.

--- a/api/cmd/api/analytics_perfil_alunos_ideb.go
+++ b/api/cmd/api/analytics_perfil_alunos_ideb.go
@@ -89,32 +89,38 @@ var (
 // idebFilters reúne os filtros opcionais do endpoint. Ano default = 2023; strings
 // vazias significam "filtro desativado"; SomenteComIdeb=false significa "todos".
 type idebFilters struct {
-	Ano               int
-	Etapa             string
-	DRE               string
-	Municipio         string
-	Zona              string
-	RegiaoIntegracao  string
-	StatusIdeb        string
-	DetalheStatusIdeb string
-	StatusVinculo     string
-	SomenteComIdeb    bool
+	Ano                 int
+	Etapa               string
+	DRE                 string
+	Municipio           string
+	Zona                string
+	RegiaoIntegracao    string
+	StatusIdeb          string
+	DetalheStatusIdeb   string
+	StatusVinculo       string
+	SomenteComIdeb      bool
+	SchoolID            int
+	CodigoINEP          string
+	RequireLinkedSchool bool
 }
 
 // args devolve os argumentos posicionais na ordem esperada por idebFromWhere
 // ($1..$10).
 func (f idebFilters) args() []any {
 	return []any{
-		f.Ano,               // $1
-		f.Etapa,             // $2
-		f.DRE,               // $3
-		f.Municipio,         // $4
-		f.Zona,              // $5
-		f.RegiaoIntegracao,  // $6
-		f.StatusIdeb,        // $7
-		f.DetalheStatusIdeb, // $8
-		f.StatusVinculo,     // $9
-		f.SomenteComIdeb,    // $10
+		f.Ano,                 // $1
+		f.Etapa,               // $2
+		f.DRE,                 // $3
+		f.Municipio,           // $4
+		f.Zona,                // $5
+		f.RegiaoIntegracao,    // $6
+		f.StatusIdeb,          // $7
+		f.DetalheStatusIdeb,   // $8
+		f.StatusVinculo,       // $9
+		f.SomenteComIdeb,      // $10
+		f.SchoolID,            // $11
+		f.CodigoINEP,          // $12
+		f.RequireLinkedSchool, // $13
 	}
 }
 
@@ -167,6 +173,24 @@ func parseIdebFilters(q url.Values) (idebFilters, error) {
 	return f, nil
 }
 
+// applyIdebAccessScope aplica os filtros compartilhados depois da validação dos
+// filtros específicos do IDEB. Para perfil DRE, registros sem vínculo confiável
+// em schools são excluídos explicitamente; admin preserva a visão ampla e os
+// indicadores de qualidade sobre registros sem match.
+func applyIdebAccessScope(r *http.Request, f idebFilters) idebFilters {
+	shared := parseAnalyticsFilters(r)
+	f.DRE = shared.DRE
+	f.Municipio = shared.Municipio
+	f.Zona = shared.Zona
+	f.RegiaoIntegracao = shared.RegiaoIntegracao
+	f.SchoolID = shared.SchoolID
+	f.CodigoINEP = shared.CodigoINEP
+	if scope, ok := GetAdminAccessScope(r.Context()); ok && scope.Role == RoleDRE {
+		f.RequireLinkedSchool = true
+	}
+	return f
+}
+
 // idebFromWhere é o trecho FROM + LEFT JOIN + WHERE comum a todas as agregações.
 // Os filtros territoriais (dre/municipio/zona/regiao_integracao) atuam sobre a
 // tabela schools via LEFT JOIN: quando presentes, registros com school_id NULL
@@ -189,6 +213,12 @@ const idebFromWhere = `
 	  AND ($8 = '' OR ir.detalhe_status_ideb = $8)
 	  AND ($9 = '' OR ir.status_vinculo = $9)
 	  AND ($10 = false OR ir.ideb IS NOT NULL)
+	  AND ($11 = 0 OR ir.school_id = $11)
+	  AND ($12 = '' OR (
+	        ($13 = false AND UPPER(TRIM(COALESCE(ir.codigo_inep, ''))) = UPPER(TRIM($12)))
+	        OR ($13 = true AND UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($12)))
+	      ))
+	  AND ($13 = false OR ir.school_id IS NOT NULL)
 `
 
 // ---------------------------------------------------------------------------
@@ -391,6 +421,7 @@ func (app *application) AdminAnalyticsPerfilAlunosResultadosIDEB(w http.Response
 		app.errorJSON(w, err, http.StatusBadRequest)
 		return
 	}
+	f = applyIdebAccessScope(r, f)
 
 	out := IdebAnalytics{
 		PorEtapa:           []IdebPorEtapa{},

--- a/api/cmd/api/analytics_perfil_alunos_ideb_test.go
+++ b/api/cmd/api/analytics_perfil_alunos_ideb_test.go
@@ -92,12 +92,13 @@ func TestIdebArgsOrder(t *testing.T) {
 		Ano: 2023, Etapa: "anos_finais", DRE: "d", Municipio: "m", Zona: "z",
 		RegiaoIntegracao: "ri", StatusIdeb: "com_ideb", DetalheStatusIdeb: "outro",
 		StatusVinculo: "match_inep", SomenteComIdeb: true,
+		SchoolID: 42, CodigoINEP: "15000123", RequireLinkedSchool: true,
 	}
 	args := f.args()
-	if len(args) != 10 {
-		t.Fatalf("esperava 10 args, obtive %d", len(args))
+	if len(args) != 13 {
+		t.Fatalf("esperava 13 args, obtive %d", len(args))
 	}
-	if args[0] != 2023 || args[1] != "anos_finais" || args[9] != true {
+	if args[0] != 2023 || args[1] != "anos_finais" || args[9] != true || args[10] != 42 || args[11] != "15000123" || args[12] != true {
 		t.Fatalf("ordem dos args inesperada: %+v", args)
 	}
 }

--- a/api/cmd/api/analytics_preenchimento.go
+++ b/api/cmd/api/analytics_preenchimento.go
@@ -43,6 +43,8 @@ type preenchimentoDreFilters struct {
 	Municipio        string
 	Zona             string
 	RegiaoIntegracao string
+	SchoolID         int
+	CodigoINEP       string
 }
 
 // parsePreenchimentoDreFilters lê os filtros globais da query string. Espaços em
@@ -116,6 +118,39 @@ func buildPreenchimentoDreQuery(f preenchimentoDreFilters) (string, []any) {
 	}
 }
 
+var preenchimentoDreScopedSelectSQL = strings.Replace(
+	preenchimentoDreSelectSQL,
+	"\n\tGROUP BY",
+	"\n\t  AND ($6 = 0 OR s.id = $6)"+
+		"\n\t  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))"+
+		"\n\tGROUP BY",
+	1,
+)
+
+func preenchimentoDreFiltersFromRequest(r *http.Request, now time.Time) preenchimentoDreFilters {
+	f := parsePreenchimentoDreFilters(r.URL.Query(), now)
+	shared := parseAnalyticsFilters(r)
+	f.DRE = shared.DRE
+	f.Municipio = shared.Municipio
+	f.Zona = shared.Zona
+	f.RegiaoIntegracao = shared.RegiaoIntegracao
+	f.SchoolID = shared.SchoolID
+	f.CodigoINEP = shared.CodigoINEP
+	return f
+}
+
+func buildPreenchimentoDreScopedQuery(f preenchimentoDreFilters) (string, []any) {
+	return preenchimentoDreScopedSelectSQL, []any{
+		f.Year,
+		f.DRE,
+		f.Municipio,
+		f.Zona,
+		f.RegiaoIntegracao,
+		f.SchoolID,
+		f.CodigoINEP,
+	}
+}
+
 // completionPercentage devolve o percentual inteiro de conclusão (completed /
 // total * 100), arredondado, espelhando o que a UI atual já faz com Math.round.
 // Retorna 0 quando não há escolas no recorte.
@@ -147,8 +182,8 @@ func buildPreenchimentoDreRow(dre string, total, completed, draft int) Preenchim
 // por DRE, respeitando os filtros globais (year, dre, municipio, zona,
 // regiao_integracao). Recorte vazio devolve payload válido com totais zerados.
 func (app *application) AdminAnalyticsPreenchimentoDre(w http.ResponseWriter, r *http.Request) {
-	filters := parsePreenchimentoDreFilters(r.URL.Query(), time.Now())
-	query, args := buildPreenchimentoDreQuery(filters)
+	filters := preenchimentoDreFiltersFromRequest(r, time.Now())
+	query, args := buildPreenchimentoDreScopedQuery(filters)
 
 	rows, err := app.models.Schools.DB.QueryContext(r.Context(), query, args...)
 	if err != nil {

--- a/api/cmd/api/analytics_saude_operacional.go
+++ b/api/cmd/api/analytics_saude_operacional.go
@@ -1108,6 +1108,8 @@ type saudeOperacionalFilters struct {
 	Municipio        string
 	Zona             string
 	RegiaoIntegracao string
+	SchoolID         int
+	CodigoINEP       string
 }
 
 // parseSaudeOperacionalFilters lê os filtros globais da query string. Espaços em
@@ -1119,6 +1121,22 @@ func parseSaudeOperacionalFilters(q url.Values) saudeOperacionalFilters {
 		Municipio:        strings.TrimSpace(q.Get("municipio")),
 		Zona:             strings.TrimSpace(q.Get("zona")),
 		RegiaoIntegracao: strings.TrimSpace(q.Get("regiao_integracao")),
+	}
+}
+
+// saudeOperacionalFiltersFromRequest reaproveita o parser compartilhado para
+// aplicar o escopo de autorização DRE antes de carregar o dataset. School/INEP
+// também entram na consulta base, portanto totais, resumo, ordenação e paginação
+// nunca são calculados sobre linhas fora do recorte.
+func saudeOperacionalFiltersFromRequest(r *http.Request) saudeOperacionalFilters {
+	shared := parseAnalyticsFilters(r)
+	return saudeOperacionalFilters{
+		DRE:              shared.DRE,
+		Municipio:        shared.Municipio,
+		Zona:             shared.Zona,
+		RegiaoIntegracao: shared.RegiaoIntegracao,
+		SchoolID:         shared.SchoolID,
+		CodigoINEP:       shared.CodigoINEP,
 	}
 }
 
@@ -1217,6 +1235,8 @@ const saudeOperacionalSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY s.nome_escola, s.id
 `
 
@@ -1230,6 +1250,8 @@ func buildSaudeOperacionalQuery(year int, f saudeOperacionalFilters) (string, []
 		f.Municipio,
 		f.Zona,
 		f.RegiaoIntegracao,
+		f.SchoolID,
+		f.CodigoINEP,
 	}
 }
 
@@ -1380,7 +1402,7 @@ func (app *application) AdminAnalyticsSaudeOperacionalEscolas(w http.ResponseWri
 		return
 	}
 
-	filters := parseSaudeOperacionalFilters(q)
+	filters := saudeOperacionalFiltersFromRequest(r)
 
 	localFilters, err := parseSaudeOperacionalLocalFilters(q)
 	if err != nil {

--- a/api/cmd/api/analytics_saude_operacional_test.go
+++ b/api/cmd/api/analytics_saude_operacional_test.go
@@ -907,31 +907,31 @@ func TestSaudeOperacionalBuildQueryArgs(t *testing.T) {
 		{
 			name: "sem filtros",
 			year: 2026,
-			want: []any{2026, "", "", "", ""},
+			want: []any{2026, "", "", "", "", 0, ""},
 		},
 		{
 			name:    "dre filtra o universo",
 			year:    2026,
 			filters: saudeOperacionalFilters{DRE: "CASTANHAL"},
-			want:    []any{2026, "CASTANHAL", "", "", ""},
+			want:    []any{2026, "CASTANHAL", "", "", "", 0, ""},
 		},
 		{
 			name:    "municipio filtra o universo",
 			year:    2026,
 			filters: saudeOperacionalFilters{Municipio: "BELEM"},
-			want:    []any{2026, "", "BELEM", "", ""},
+			want:    []any{2026, "", "BELEM", "", "", 0, ""},
 		},
 		{
 			name:    "zona filtra o universo",
 			year:    2026,
 			filters: saudeOperacionalFilters{Zona: "Urbana"},
-			want:    []any{2026, "", "", "Urbana", ""},
+			want:    []any{2026, "", "", "Urbana", "", 0, ""},
 		},
 		{
 			name:    "regiao_integracao filtra o universo",
 			year:    2026,
 			filters: saudeOperacionalFilters{RegiaoIntegracao: "GUAJARA"},
-			want:    []any{2026, "", "", "", "GUAJARA"},
+			want:    []any{2026, "", "", "", "GUAJARA", 0, ""},
 		},
 		{
 			name: "multiplos filtros combinados por AND",
@@ -942,7 +942,7 @@ func TestSaudeOperacionalBuildQueryArgs(t *testing.T) {
 				Zona:             "Urbana",
 				RegiaoIntegracao: "GUAJARA",
 			},
-			want: []any{2025, "BELEM", "BELEM", "Urbana", "GUAJARA"},
+			want: []any{2025, "BELEM", "BELEM", "Urbana", "GUAJARA", 0, ""},
 		},
 	}
 

--- a/api/cmd/api/reports.go
+++ b/api/cmd/api/reports.go
@@ -43,6 +43,8 @@ type reportFilters struct {
 	Municipio        string
 	Zona             string
 	RegiaoIntegracao string
+	SchoolID         int
+	CodigoINEP       string
 }
 
 // parseReportFilters lê os filtros da query string, removendo espaços. Um
@@ -66,6 +68,28 @@ func parseReportFilters(q url.Values) reportFilters {
 // $5=regiao_integracao.
 func (f reportFilters) args() []any {
 	return []any{f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao}
+}
+
+// scopedArgs amplia o contrato dos relatórios escola-a-escola com os filtros
+// de identidade. O método args legado é mantido para helpers/testes que ainda
+// exercitam o contrato histórico de cinco argumentos.
+func (f reportFilters) scopedArgs() []any {
+	return []any{f.Year, f.DRE, f.Municipio, f.Zona, f.RegiaoIntegracao, f.SchoolID, f.CodigoINEP}
+}
+
+// parseReportFiltersRequest aplica o escopo autenticado antes do dispatch para
+// qualquer builder XLSX. Assim nenhum builder pode confiar no `dre` enviado pelo
+// navegador quando o token pertence a um perfil DRE.
+func parseReportFiltersRequest(r *http.Request) reportFilters {
+	f := parseReportFilters(r.URL.Query())
+	shared := parseAnalyticsFilters(r)
+	f.DRE = shared.DRE
+	f.Municipio = shared.Municipio
+	f.Zona = shared.Zona
+	f.RegiaoIntegracao = shared.RegiaoIntegracao
+	f.SchoolID = shared.SchoolID
+	f.CodigoINEP = shared.CodigoINEP
+	return f
 }
 
 // describe monta a linha 2 do XLSX ("Filtros aplicados — ..."). Sempre
@@ -271,7 +295,7 @@ func (app *application) AdminGetReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filters := parseReportFilters(r.URL.Query())
+	filters := parseReportFiltersRequest(r)
 
 	var (
 		rd  reportData
@@ -394,6 +418,8 @@ const censoPreenchimentoSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY
 		CASE
 			WHEN cr.status IS NULL THEN 1
@@ -415,7 +441,7 @@ const reportDateLayout = "02/01/2006 15:04"
 // e monta o reportData (sem paginar). Datas chegam formatadas em pt-BR; o
 // ano vem como inteiro quando há resposta, ou célula vazia quando pendente.
 func (app *application) buildCensoPreenchimentoReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
-	rows, err := app.models.Schools.DB.QueryContext(ctx, censoPreenchimentoSelectSQL, f.args()...)
+	rows, err := app.models.Schools.DB.QueryContext(ctx, censoPreenchimentoSelectSQL, f.scopedArgs()...)
 	if err != nil {
 		return reportData{}, fmt.Errorf("consultar preenchimento: %w", err)
 	}

--- a/api/cmd/api/reports_financeiro_governanca.go
+++ b/api/cmd/api/reports_financeiro_governanca.go
@@ -75,6 +75,8 @@ const financeiroGovernancaSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY
 		UPPER(TRIM(s.dre)),
 		UPPER(TRIM(s.municipio)),
@@ -83,7 +85,7 @@ const financeiroGovernancaSelectSQL = `
 `
 
 func (app *application) buildFinanceiroGovernancaReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
-	dbRows, err := app.models.Schools.DB.QueryContext(ctx, financeiroGovernancaSelectSQL, f.args()...)
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, financeiroGovernancaSelectSQL, f.scopedArgs()...)
 	if err != nil {
 		return reportData{}, fmt.Errorf("consultar financeiro governanca: %w", err)
 	}

--- a/api/cmd/api/reports_infraestrutura.go
+++ b/api/cmd/api/reports_infraestrutura.go
@@ -264,6 +264,8 @@ const infraestruturaSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY
 		UPPER(TRIM(s.dre)),
 		UPPER(TRIM(s.municipio)),
@@ -275,7 +277,7 @@ const infraestruturaSelectSQL = `
 // Operacional de cada escola, ordena por prioridade operacional e projeta as
 // colunas do XLSX. Não pagina.
 func (app *application) buildInfraestruturaReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
-	dbRows, err := app.models.Schools.DB.QueryContext(ctx, infraestruturaSelectSQL, f.args()...)
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, infraestruturaSelectSQL, f.scopedArgs()...)
 	if err != nil {
 		return reportData{}, fmt.Errorf("consultar infraestrutura: %w", err)
 	}

--- a/api/cmd/api/reports_merenda.go
+++ b/api/cmd/api/reports_merenda.go
@@ -207,6 +207,8 @@ const merendaSelectSQL = `
 	        FROM reg_integracao
 	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
 	      ))
+	  AND ($6 = 0 OR s.id = $6)
+	  AND ($7 = '' OR UPPER(TRIM(COALESCE(s.codigo_inep, ''))) = UPPER(TRIM($7)))
 	ORDER BY
 		UPPER(TRIM(s.dre)),
 		UPPER(TRIM(s.municipio)),
@@ -218,7 +220,7 @@ const merendaSelectSQL = `
 // cada escola, ordena por prioridade operacional e projeta as colunas do XLSX.
 // Não pagina.
 func (app *application) buildMerendaReportData(ctx context.Context, def ReportDefinition, f reportFilters) (reportData, error) {
-	dbRows, err := app.models.Schools.DB.QueryContext(ctx, merendaSelectSQL, f.args()...)
+	dbRows, err := app.models.Schools.DB.QueryContext(ctx, merendaSelectSQL, f.scopedArgs()...)
 	if err != nil {
 		return reportData{}, fmt.Errorf("consultar merenda: %w", err)
 	}

--- a/api/cmd/api/reports_saude_operacional.go
+++ b/api/cmd/api/reports_saude_operacional.go
@@ -210,6 +210,8 @@ func (app *application) buildSaudeOperacionalReportData(ctx context.Context, def
 		Municipio:        f.Municipio,
 		Zona:             f.Zona,
 		RegiaoIntegracao: f.RegiaoIntegracao,
+		SchoolID:         f.SchoolID,
+		CodigoINEP:       f.CodigoINEP,
 	}
 
 	escolas, _, err := app.buildSaudeOperacionalDataset(ctx, f.Year, soFilters)


### PR DESCRIPTION
## Summary
- aplica o escopo autorizado de DRE antes de cálculos, rankings, paginação e geração de dados em Saúde Operacional, IDEB, Financeiro/Governança e Preenchimento por DRE
- impede que `?dre=` enviado pelo cliente sobrescreva o recorte territorial de um perfil DRE
- adiciona `school_id` e `codigo_inep` aos recortes sensíveis e aos relatórios XLSX atuais
- aplica fail-closed no IDEB para perfil DRE quando o registro não possui vínculo confiável com `schools`
- aplica fail-closed no PRODEP para perfil DRE: a linha só entra quando existe vínculo operacional verificável por `school_id` ou `school_id_sede` dentro da DRE autorizada; registros sem vínculo permanecem disponíveis apenas para a visão administrativa ampla
- restringe também as opções de filtro do PRODEP ao mesmo recorte, evitando vazamento indireto de outras DREs
- mantém a visão ampla de admin e os contratos legados necessários aos testes existentes
- adiciona regressões específicas contra tentativa de trocar a DRE via query string e contra vazamentos em IDEB, PRODEP e XLSX

## Validation
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- auditoria estrutural das invariantes de segurança
- diff final revisado: 1 commit sobre `develop`, sem alterações em frontend, migrations, `main.go` ou `admin.go`

Closes #161