### PR TITLE
feat(analytics): usar DREs oficiais nos filtros globais

### DIFF
--- a/api/cmd/api/analytics_filtros.go
+++ b/api/cmd/api/analytics_filtros.go
@@ -157,6 +157,43 @@ func filtrosOpcoesSchoolsWhereWithAuthorization(f AnalyticsFilters, alias, excep
 	return strings.Join(conditions, "\n\t  AND "), args
 }
 
+// filtrosOpcoesDREsQuery returns the master-DRE query for filter options.
+// The DRE option itself is excluded from its cascade, while the remaining
+// school filters retain the current cascade behavior. Without those filters,
+// no schools lookup is made so active DREs without schools remain visible.
+func filtrosOpcoesDREsQuery(f AnalyticsFilters, authorizedDRE string) (string, []any) {
+	query := `
+		SELECT TRIM(d.nome)
+		FROM dres d
+		WHERE d.ativa = TRUE
+		  AND NULLIF(TRIM(d.nome), '') IS NOT NULL
+	`
+	args := make([]any, 0, 6)
+	if authorizedDRE = strings.TrimSpace(authorizedDRE); authorizedDRE != "" {
+		args = append(args, authorizedDRE)
+		query += "\t  AND UPPER(TRIM(d.nome)) = UPPER(TRIM($" + strconv.Itoa(len(args)) + "))\n"
+	}
+
+	if f.Municipio != "" || f.Zona != "" || f.RegiaoIntegracao != "" || f.SchoolID != 0 || f.CodigoINEP != "" {
+		schoolsWhere, schoolsArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "dre", authorizedDRE)
+		offset := len(args)
+		args = append(args, schoolsArgs...)
+		for i := len(schoolsArgs); i > 0; i-- {
+			schoolsWhere = strings.ReplaceAll(schoolsWhere, "$"+strconv.Itoa(i), "$"+strconv.Itoa(offset+i))
+		}
+		query += `	  AND EXISTS (
+			SELECT 1
+			FROM schools s
+			WHERE ` + schoolsWhere + `
+			  AND UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome))
+		)
+`
+	}
+
+	query += "\t\tORDER BY UPPER(TRIM(d.nome)), TRIM(d.nome)\n"
+	return query, args
+}
+
 // AdminAnalyticsFiltrosOpcoes retorna as listas para popular os selects
 // dos filtros globais do dashboard. Aceita os mesmos query params dos filtros
 // analíticos e aplica cascata: cada lista é filtrada pelos demais filtros ativos.
@@ -210,13 +247,8 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 	}
 
 	// DREs: filtradas por municipio, zona, regiao (não pela própria dre)
-	dresWhere, dresArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "dre", authorizedDRE)
-	dres, err := queryStringSlice(app, ctx, `
-		SELECT DISTINCT COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado') AS dre
-		FROM schools s
-		WHERE `+dresWhere+`
-		ORDER BY 1
-	`, dresArgs...)
+	dresQuery, dresArgs := filtrosOpcoesDREsQuery(f, authorizedDRE)
+	dres, err := queryStringSlice(app, ctx, dresQuery, dresArgs...)
 	if err != nil {
 		app.errorJSON(w, fmt.Errorf("dres: %w", err), http.StatusInternalServerError)
 		return

--- a/api/cmd/api/analytics_filtros_test.go
+++ b/api/cmd/api/analytics_filtros_test.go
@@ -227,3 +227,59 @@ func TestFiltrosOpcoesSchoolsWhere_AuthorizedDRESurvivesExcept(t *testing.T) {
 		t.Fatalf("authorization must be mandatory: %s", where)
 	}
 }
+
+func TestFiltrosOpcoesDREsQuery_UsesActiveMasterDREs(t *testing.T) {
+	query, args := filtrosOpcoesDREsQuery(AnalyticsFilters{}, "")
+	for _, part := range []string{
+		"FROM dres d",
+		"d.ativa = TRUE",
+		"TRIM(d.nome)",
+		"ORDER BY UPPER(TRIM(d.nome)), TRIM(d.nome)",
+	} {
+		if !strings.Contains(query, part) {
+			t.Fatalf("master DRE query missing %q:\n%s", part, query)
+		}
+	}
+	if strings.Contains(query, "FROM schools s") {
+		t.Fatalf("unfiltered master DRE query must include DREs without schools:\n%s", query)
+	}
+	if len(args) != 0 {
+		t.Fatalf("unexpected arguments: %#v", args)
+	}
+}
+
+func TestFiltrosOpcoesDREsQuery_CascadesOtherSchoolFilters(t *testing.T) {
+	query, args := filtrosOpcoesDREsQuery(AnalyticsFilters{Municipio: "Belem"}, "")
+	if !strings.Contains(query, "EXISTS (") || !strings.Contains(query, "FROM schools s") {
+		t.Fatalf("DRE query must cascade municipio through schools:\n%s", query)
+	}
+	if !strings.Contains(query, "UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome))") {
+		t.Fatalf("DRE query must match school DREs to master DRE names:\n%s", query)
+	}
+	if len(args) != 5 || args[0] != "Belem" {
+		t.Fatalf("unexpected cascade arguments: %#v", args)
+	}
+}
+
+func TestFiltrosOpcoesDREsQuery_DREAuthorizationIsMandatory(t *testing.T) {
+	query, args := filtrosOpcoesDREsQuery(AnalyticsFilters{DRE: "DRE_B"}, " DRE_A ")
+	if !strings.Contains(query, "UPPER(TRIM(d.nome)) = UPPER(TRIM($1))") {
+		t.Fatalf("DRE scope must constrain master DREs:\n%s", query)
+	}
+	if len(args) != 1 || args[0] != "DRE_A" {
+		t.Fatalf("unexpected authorization arguments: %#v", args)
+	}
+	if strings.Contains(query, "DRE_B") {
+		t.Fatalf("query must not trust requested DRE value:\n%s", query)
+	}
+}
+
+func TestFiltrosOpcoesDREsQuery_RebindsCascadeArgumentsAfterAuthorization(t *testing.T) {
+	query, args := filtrosOpcoesDREsQuery(AnalyticsFilters{Municipio: "Belem"}, "DRE_A")
+	if !strings.Contains(query, "d.nome)) = UPPER(TRIM($1))") || !strings.Contains(query, "s.dre)) = UPPER(TRIM($2))") {
+		t.Fatalf("authorization arguments were not rebound correctly:\n%s", query)
+	}
+	if len(args) != 7 || args[0] != "DRE_A" || args[1] != "DRE_A" || args[2] != "Belem" {
+		t.Fatalf("unexpected authorization cascade arguments: %#v", args)
+	}
+}


### PR DESCRIPTION
## Objetivo

Implementa a issue #187, atualizando `GET /v1/admin/analytics/filtros/opcoes` para usar a entidade mestre `dres` como fonte oficial das DREs.

## Alterações

- lista de DREs passa a vir de `dres.nome`;
- somente DREs ativas são retornadas;
- ordenação alfabética determinística;
- DRE ativa sem escolas pode aparecer no filtro;
- preservado o escopo de autorização para usuários `role=dre`;
- preservado o comportamento dos demais filtros em cascata;
- adicionados/ajustados testes específicos da #187.

## Validação

- ED-01 / #183 já integrada em `develop`;
- branch atualizada com a migration `0019_create_dres_master.sql`;
- `go test ./...` passou;
- `go build ./...` passou;
- `git diff --check` passou;
- Vercel Preview verde;
- PR mergeable e sem divergência de `develop`.

Closes #187