### PR TITLE
feat(web): criar modal de cadastro de DRE (PEDRO-02 / #180)

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -745,7 +745,7 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
 
             {profile?.role === "admin" && visited.has("gestao") && (
               <div style={{ display: tab === "gestao" ? undefined : "none" }}>
-                <AbaGestaoDres />
+                <AbaGestaoDres token={token} onUnauth={logout} />
               </div>
             )}
           </div>

--- a/web/src/components/admin/AbaGestaoDres.tsx
+++ b/web/src/components/admin/AbaGestaoDres.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import React from "react";
-import { UserCog } from "lucide-react";
+import React, { useState } from "react";
+import { Plus, UserCog } from "lucide-react";
 import { EmptyStatePlaceholder } from "./shared/EmptyStatePlaceholder";
+import { NovaDreModal } from "./shared/NovaDreModal";
+import { AdminToast, type AdminToastData } from "./shared/AdminToast";
+import { clearApiCache } from "./shared/api";
+import { C } from "./shared/constants";
 
 const SECOES_PREVISTAS = [
   "Listagem de acessos DRE",
@@ -11,15 +15,61 @@ const SECOES_PREVISTAS = [
   "Ativação e desativação de acessos",
 ];
 
-export function AbaGestaoDres() {
+interface AbaGestaoDresProps {
+  token: string;
+  onUnauth: () => void;
+}
+
+export function AbaGestaoDres({ token, onUnauth }: AbaGestaoDresProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [toast, setToast] = useState<AdminToastData | null>(null);
+
+  // Após criar: limpa o cache de GETs para filtros/opções refletirem a nova DRE.
+  const handleCreated = () => {
+    setModalOpen(false);
+    clearApiCache();
+    setToast({ type: "success", message: "DRE cadastrada com sucesso." });
+  };
+
   return (
     <div className="space-y-6 animate-fade-in-up">
+      <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm">
+        <div className="px-6 py-4 border-b border-slate-200 flex items-center gap-2" style={{ background: C.primaryLight }}>
+          <UserCog size={16} className="shrink-0" strokeWidth={2} />
+          <h2 className="font-semibold text-slate-800 text-sm">Gestão de DREs e Acessos</h2>
+        </div>
+        <div className="px-6 py-5 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <p className="text-sm text-slate-600 max-w-xl">
+            Cadastre novas Diretorias Regionais de Educação e gerencie os acessos dos usuários DRE do painel.
+          </p>
+          <button
+            onClick={() => setModalOpen(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white shrink-0 self-start sm:self-auto"
+            style={{ background: C.primary }}
+          >
+            <Plus size={16} />
+            Nova DRE
+          </button>
+        </div>
+      </div>
+
       <EmptyStatePlaceholder
-        title="Gestão de DREs e Acessos"
+        title="Demais funcionalidades"
         icon={UserCog}
-        description="Espaço reservado para a administração dos acessos das Diretorias Regionais de Educação. Quando integrada ao backend, esta aba permitirá criar, consultar e manter os usuários DRE do painel, substituindo o fluxo atual via linha de comando (cmd/admin-user)."
+        description="Espaço reservado para a administração dos acessos das Diretorias Regionais de Educação. Quando integrada ao backend, esta aba permitirá consultar e manter os usuários DRE do painel, substituindo o fluxo atual via linha de comando (cmd/admin-user)."
         sections={SECOES_PREVISTAS}
       />
+
+      {modalOpen && (
+        <NovaDreModal
+          token={token}
+          onClose={() => setModalOpen(false)}
+          onSuccess={handleCreated}
+          onUnauth={onUnauth}
+        />
+      )}
+
+      <AdminToast toast={toast} onDismiss={() => setToast(null)} />
     </div>
   );
 }

--- a/web/src/components/admin/shared/AdminToast.tsx
+++ b/web/src/components/admin/shared/AdminToast.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import { CheckCircle2, AlertCircle, X } from "lucide-react";
+import { C } from "./constants";
+
+// Toast leve do painel admin — feedback pós-ação (ex.: DRE criada).
+// Controlado por estado do componente pai; auto-dismiss em 4s.
+export interface AdminToastData {
+  type: "success" | "error";
+  message: string;
+}
+
+export function AdminToast({
+  toast,
+  onDismiss,
+}: {
+  toast: AdminToastData | null;
+  onDismiss: () => void;
+}) {
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(onDismiss, 4000);
+    return () => clearTimeout(t);
+  }, [toast, onDismiss]);
+
+  if (!toast) return null;
+
+  const ok = toast.type === "success";
+
+  return (
+    <div className="fixed bottom-5 right-5 z-[110] animate-fade-in-up max-w-[calc(100vw-2.5rem)]">
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-lg"
+      >
+        {ok ? (
+          <CheckCircle2 size={18} style={{ color: C.success }} className="shrink-0" />
+        ) : (
+          <AlertCircle size={18} style={{ color: C.danger }} className="shrink-0" />
+        )}
+        <span className="text-sm font-medium text-slate-800">{toast.message}</span>
+        <button
+          onClick={onDismiss}
+          aria-label="Fechar notificação"
+          className="ml-1 text-slate-400 hover:text-slate-600 shrink-0"
+        >
+          <X size={15} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/admin/shared/NovaDreModal.tsx
+++ b/web/src/components/admin/shared/NovaDreModal.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Landmark, X, Loader2, AlertCircle } from "lucide-react";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { novaDreSchema, type NovaDreFormValues } from "@/schemas/admin/nova-dre";
+import { apiFetch, createDre } from "./api";
+import { C } from "./constants";
+import type { FiltrosOpcoes } from "./types";
+
+// Modal de cadastro de nova DRE — aba "Gestão de DREs e Acessos".
+// Montado/desmontado pelo pai quando aberto/fechado (padrão JsonModal).
+// Endpoint de criação ainda sem contrato final do backend: ver createDre() em shared/api.ts.
+interface NovaDreModalProps {
+  token: string;
+  onClose: () => void;
+  onSuccess: () => void;
+  onUnauth: () => void;
+}
+
+const INPUT_CLASS = "bg-white border-slate-200 text-slate-800 placeholder:text-slate-400";
+const SELECT_CLASS = `h-9 w-full rounded-md border px-3 text-sm shadow-xs focus:outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 ${INPUT_CLASS}`;
+
+export function NovaDreModal({ token, onClose, onSuccess, onUnauth }: NovaDreModalProps) {
+  const [apiError, setApiError] = useState("");
+  const [municipios, setMunicipios] = useState<string[]>([]);
+  const [municipiosErro, setMunicipiosErro] = useState(false);
+
+  // Fonte dos polos ainda não exposta pelo backend — select obrigatório
+  // permanece vazio até que a lista seja disponibilizada.
+  const polos: string[] = [];
+
+  const form = useForm<NovaDreFormValues>({
+    resolver: zodResolver(novaDreSchema) as unknown as Resolver<NovaDreFormValues>,
+    defaultValues: {
+      nome: "",
+      sigla: "",
+      municipio_sede: "",
+      polo: "",
+      responsavel_nome: "",
+      responsavel_email: "",
+      responsavel_telefone: "",
+    },
+    mode: "onTouched",
+  });
+
+  const submitting = form.formState.isSubmitting;
+
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch<FiltrosOpcoes>("/v1/admin/analytics/filtros/opcoes", token)
+      .then((d) => { if (!cancelled) setMunicipios(d.municipios ?? []); })
+      .catch(() => { if (!cancelled) setMunicipiosErro(true); });
+    return () => { cancelled = true; };
+  }, [token]);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    const fn = (e: KeyboardEvent) => { if (e.key === "Escape" && !submitting) onClose(); };
+    window.addEventListener("keydown", fn);
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", fn);
+    };
+  }, [submitting, onClose]);
+
+  const onSubmit = async (values: NovaDreFormValues) => {
+    setApiError("");
+    try {
+      await createDre(token, values);
+      onSuccess();
+    } catch (e) {
+      const msg = (e as Error).message ?? "";
+      if (msg === "UNAUTHORIZED") {
+        onUnauth();
+        return;
+      }
+      setApiError(msg || "Não foi possível cadastrar a DRE. Tente novamente.");
+    }
+  };
+
+  const maskTelefone = (raw: string) => {
+    let v = raw.replace(/\D/g, "");
+    if (v.length > 11) v = v.substring(0, 11);
+    v = v.replace(/^(\d{2})(\d)/, "($1) $2");
+    v = v.replace(/(\d)(\d{4})$/, "$1-$2");
+    return v;
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm animate-fade-in"
+      onClick={submitting ? undefined : onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="nova-dre-title"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white rounded-2xl shadow-2xl border border-slate-200 w-full max-w-xl max-h-[90vh] flex flex-col overflow-hidden animate-scale-in"
+      >
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-slate-200 flex items-center justify-between" style={{ background: C.primaryLight }}>
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-lg flex items-center justify-center text-white shrink-0" style={{ background: C.primary }}>
+              <Landmark size={19} />
+            </div>
+            <div>
+              <h2 id="nova-dre-title" className="font-bold text-slate-800">Cadastrar nova DRE</h2>
+              <p className="text-xs text-slate-600">Diretoria Regional de Educação</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            aria-label="Fechar modal"
+            className="w-9 h-9 rounded-lg hover:bg-black/10 flex items-center justify-center text-slate-700 disabled:opacity-40"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Formulário */}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col min-h-0">
+            <div className="px-6 py-5 overflow-y-auto flex-1">
+              {apiError && (
+                <div role="alert" className="mb-4 flex items-start gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2.5">
+                  <AlertCircle size={16} style={{ color: C.danger }} className="mt-0.5 shrink-0" />
+                  <span className="text-sm" style={{ color: C.danger }}>{apiError}</span>
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-4">
+                <FormField
+                  control={form.control}
+                  name="nome"
+                  render={({ field }) => (
+                    <FormItem className="sm:col-span-2">
+                      <FormLabel>Nome da DRE *</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="Ex.: Diretoria Regional de Educação de Belém"
+                          autoFocus
+                          disabled={submitting}
+                          className={INPUT_CLASS}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="sigla"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Sigla *</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="Ex.: DREBELEM"
+                          maxLength={12}
+                          disabled={submitting}
+                          className={INPUT_CLASS}
+                          {...field}
+                          value={field.value ?? ""}
+                          onChange={(e) => {
+                            field.onChange(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 12));
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="municipio_sede"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Município Sede *</FormLabel>
+                      <FormControl>
+                        <select
+                          value={field.value ?? ""}
+                          onChange={(e) => field.onChange(e.target.value)}
+                          disabled={submitting}
+                          className={SELECT_CLASS}
+                        >
+                          <option value="" disabled>Selecione...</option>
+                          {municipios.map((m) => (
+                            <option key={m} value={m}>{m}</option>
+                          ))}
+                        </select>
+                      </FormControl>
+                      {municipiosErro && (
+                        <FormDescription>Não foi possível carregar os municípios.</FormDescription>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="polo"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Polo *</FormLabel>
+                      <FormControl>
+                        <select
+                          value={field.value ?? ""}
+                          onChange={(e) => field.onChange(e.target.value)}
+                          disabled={submitting}
+                          className={SELECT_CLASS}
+                        >
+                          <option value="" disabled>Selecione...</option>
+                          {polos.map((p) => (
+                            <option key={p} value={p}>{p}</option>
+                          ))}
+                        </select>
+                      </FormControl>
+                      {polos.length === 0 && (
+                        <FormDescription>Nenhuma opção disponível no momento.</FormDescription>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="responsavel_nome"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nome do Responsável *</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="Nome completo"
+                          disabled={submitting}
+                          className={INPUT_CLASS}
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="responsavel_email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>E-mail *</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="email"
+                          placeholder="responsavel@educ.pa.gov.br"
+                          disabled={submitting}
+                          className={INPUT_CLASS}
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="responsavel_telefone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Telefone *</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="tel"
+                          placeholder="(91) 90000-0000"
+                          maxLength={15}
+                          inputMode="tel"
+                          disabled={submitting}
+                          className={INPUT_CLASS}
+                          {...field}
+                          value={field.value ?? ""}
+                          onChange={(e) => field.onChange(maskTelefone(e.target.value))}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="px-6 py-4 border-t border-slate-200 bg-white flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={submitting}
+                className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium bg-white border border-slate-200 hover:bg-slate-50 disabled:opacity-50 text-slate-700"
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white disabled:opacity-60"
+                style={{ background: C.primary }}
+              >
+                {submitting && <Loader2 size={15} className="animate-spin" />}
+                {submitting ? "Cadastrando…" : "Cadastrar DRE"}
+              </button>
+            </div>
+          </form>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/admin/shared/api.ts
+++ b/web/src/components/admin/shared/api.ts
@@ -97,9 +97,21 @@ export async function prefetchDashboard(token: string, role?: string): Promise<v
   await Promise.race([fetches, timeout]);
 }
 
+// ── Escrita: Gestão de DREs ─────────────────────────────────────────────────
+
+// Criação de nova DRE — POST /v1/admin/dres.
+// Contrato provisório assumido enquanto o backend não define o endpoint final;
+// path e payload estão concentrados aqui para ajuste em ponto único.
+export async function createDre(token: string, payload: DreCreatePayload): Promise<DreRecord> {
+  return apiFetch<DreRecord>("/v1/admin/dres", token, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
 // ── Filtros e Labels ────────────────────────────────────────────────────────
 
-import type { DashboardFilters, AdminProfile } from "./types";
+import type { DashboardFilters, AdminProfile, DreCreatePayload, DreRecord } from "./types";
 
 export function buildFilterParams(filters?: DashboardFilters): string {
   if (!filters) return "";

--- a/web/src/components/admin/shared/types.ts
+++ b/web/src/components/admin/shared/types.ts
@@ -711,3 +711,24 @@ export interface CaracterizacaoEscolaRow extends EscolasBaseRow {
   etapas_texto: string;
   modalidades_texto: string;
 }
+
+// ── Gestão de DREs ──────────────────────────────────────────────────────────
+// Payload de criação de nova DRE (modal da aba "Gestão de DREs e Acessos").
+// Contrato provisório — aguardando definição final do endpoint pelo backend.
+export interface DreCreatePayload {
+  nome:               string;
+  sigla:              string;
+  municipio_sede:     string;
+  polo:               string;
+  responsavel_nome:   string;
+  responsavel_email:  string;
+  responsavel_telefone: string;
+}
+
+// Registro de DRE retornado pelo backend após a criação (campos mínimos
+// esperados; o contrato final pode trazer campos adicionais).
+export interface DreRecord {
+  id:    number | string;
+  nome:  string;
+  sigla: string;
+}

--- a/web/src/schemas/admin/nova-dre.ts
+++ b/web/src/schemas/admin/nova-dre.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// Validação do modal de cadastro de nova DRE (aba "Gestão de DREs e Acessos").
+// Todos os campos são obrigatórios; telefone e sigla recebem máscara/normalização
+// no input — aqui validamos o resultado final.
+
+const apenasDigitos = (v: string) => v.replace(/\D/g, "");
+
+export const novaDreSchema = z.object({
+  nome: z
+    .string()
+    .trim()
+    .min(3, "O nome deve ter pelo menos 3 caracteres"),
+
+  // Normalizada para uppercase no onChange do input.
+  sigla: z
+    .string()
+    .trim()
+    .regex(/^[A-Z0-9]{2,12}$/, "Sigla inválida. Use de 2 a 12 letras ou números"),
+
+  municipio_sede: z
+    .string()
+    .min(1, "Selecione o município sede"),
+
+  polo: z
+    .string()
+    .min(1, "Selecione o polo"),
+
+  responsavel_nome: z
+    .string()
+    .trim()
+    .min(3, "Informe o nome do responsável"),
+
+  responsavel_email: z
+    .string()
+    .trim()
+    .regex(/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/, "E-mail inválido"),
+
+  // Máscara aplicada no input: (XX) XXXXX-XXXX ou (XX) XXXX-XXXX.
+  responsavel_telefone: z
+    .string()
+    .refine((v) => {
+      const d = apenasDigitos(v);
+      return d.length === 10 || d.length === 11;
+    }, { message: "Telefone inválido. Use DDD + número, ex.: (91) 90000-0000" }),
+});
+
+export type NovaDreFormValues = z.infer<typeof novaDreSchema>;


### PR DESCRIPTION
## Objetivo
Implementa a task **PEDRO-02 — Formulário/Modal Criar Nova DRE** (#180) na aba **Gestão de DREs e Acessos**.

## Alterações
- adiciona modal de cadastro com validação via Zod;
- integra `POST /v1/admin/dres` ao contrato atual do backend;
- mapeia corretamente responsável para `gestor_nome`, `email` e `telefone`;
- torna `Polo` preenchível e validado, sem depender de uma lista inexistente no backend;
- mantém Município com sugestões da API, mas permite digitação manual se a lista falhar;
- trata loading, erros, 401 e feedback de sucesso;
- limpa o cache administrativo após criação;
- atualiza a branch com a `develop` atual, incluindo o CRUD administrativo e seus testes.

## Correções aplicadas na revisão
- removido bloqueio que tornava impossível selecionar Polo;
- corrigido payload incompatível com o backend;
- removida dependência funcional da lista de municípios para concluir o cadastro;
- atualizado contrato/documentação interna do helper de API.

Closes #180