### PR TITLE
feat(api): associação e remanejamento de escolas por DRE (#188)

### DIFF
--- a/api/cmd/api/admin_school_dre.go
+++ b/api/cmd/api/admin_school_dre.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"censo-api/internal/models"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (app *application) requireAdminDREManagement(w http.ResponseWriter, r *http.Request) bool {
+	scope, ok := GetAdminAccessScope(r.Context())
+	if !ok || scope.Role != RoleAdmin {
+		app.errorJSON(w, fmt.Errorf("acesso restrito para administradores"), http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+func parsePositiveRouteID(r *http.Request, param, label string) (int, error) {
+	raw := strings.TrimSpace(chi.URLParam(r, param))
+	id, err := strconv.Atoi(raw)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("%s inválido", label)
+	}
+	return id, nil
+}
+
+func schoolDREErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, models.ErrDREInvalidID),
+		errors.Is(err, models.ErrDRENameRequired),
+		errors.Is(err, models.ErrSchoolIDsRequired),
+		errors.Is(err, models.ErrSchoolInvalidID),
+		errors.Is(err, models.ErrSchoolBatchTooLarge):
+		return http.StatusBadRequest
+	case errors.Is(err, models.ErrDRENotFound), errors.Is(err, models.ErrSchoolNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, models.ErrDREInactive):
+		return http.StatusConflict
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// AdminAssignSchoolsToDRE associates one or more schools with a DRE.
+// Both school_ids (batch) and school_id (single-item convenience) are accepted.
+func (app *application) AdminAssignSchoolsToDRE(w http.ResponseWriter, r *http.Request) {
+	if !app.requireAdminDREManagement(w, r) {
+		return
+	}
+
+	dreID, err := parsePositiveRouteID(r, "id", "ID de DRE")
+	if err != nil {
+		app.errorJSON(w, err, http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		SchoolIDs []int `json:"school_ids"`
+		SchoolID  *int  `json:"school_id,omitempty"`
+	}
+	if err := app.readJSON(w, r, &req); err != nil {
+		app.errorJSON(w, fmt.Errorf("dados inválidos: %w", err), http.StatusBadRequest)
+		return
+	}
+	if req.SchoolID != nil {
+		req.SchoolIDs = append(req.SchoolIDs, *req.SchoolID)
+	}
+
+	canonicalDRE, updated, err := app.models.Schools.AssignToDRE(r.Context(), dreID, req.SchoolIDs)
+	if err != nil {
+		status := schoolDREErrorStatus(err)
+		if status == http.StatusInternalServerError {
+			app.errorJSON(w, fmt.Errorf("erro ao associar escolas à DRE: %w", err), status)
+			return
+		}
+		app.errorJSON(w, err, status)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{
+		Error:   false,
+		Message: "Escolas associadas à DRE com sucesso",
+		Data: map[string]interface{}{
+			"dre_id":          dreID,
+			"dre":             canonicalDRE,
+			"updated_schools": updated,
+		},
+	})
+}
+
+// AdminMoveSchoolToDRE remaps one school to another master DRE.
+// Prefer dre_id. The dre name form is accepted for backwards-compatible clients
+// and is always resolved back to the canonical master DRE before persistence.
+func (app *application) AdminMoveSchoolToDRE(w http.ResponseWriter, r *http.Request) {
+	if !app.requireAdminDREManagement(w, r) {
+		return
+	}
+
+	schoolID, err := parsePositiveRouteID(r, "id", "ID de escola")
+	if err != nil {
+		app.errorJSON(w, err, http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		DREID *int   `json:"dre_id,omitempty"`
+		DRE   string `json:"dre,omitempty"`
+	}
+	if err := app.readJSON(w, r, &req); err != nil {
+		app.errorJSON(w, fmt.Errorf("dados inválidos: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	dreName := strings.TrimSpace(req.DRE)
+	if req.DREID != nil && dreName != "" {
+		app.errorJSON(w, fmt.Errorf("informe apenas dre_id ou dre"), http.StatusBadRequest)
+		return
+	}
+	if req.DREID == nil && dreName == "" {
+		app.errorJSON(w, fmt.Errorf("dre_id ou dre é obrigatório"), http.StatusBadRequest)
+		return
+	}
+
+	var dreID int
+	if req.DREID != nil {
+		dreID = *req.DREID
+		if dreID <= 0 {
+			app.errorJSON(w, models.ErrDREInvalidID, http.StatusBadRequest)
+			return
+		}
+	} else {
+		dre, err := app.models.DREs.GetByNome(r.Context(), dreName)
+		if err != nil {
+			status := schoolDREErrorStatus(err)
+			if status == http.StatusInternalServerError {
+				app.errorJSON(w, fmt.Errorf("erro ao resolver DRE de destino: %w", err), status)
+				return
+			}
+			app.errorJSON(w, err, status)
+			return
+		}
+		dreID = dre.ID
+	}
+
+	canonicalDRE, _, err := app.models.Schools.AssignToDRE(r.Context(), dreID, []int{schoolID})
+	if err != nil {
+		status := schoolDREErrorStatus(err)
+		if status == http.StatusInternalServerError {
+			app.errorJSON(w, fmt.Errorf("erro ao remanejar escola: %w", err), status)
+			return
+		}
+		app.errorJSON(w, err, status)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{
+		Error:   false,
+		Message: "Escola remanejada com sucesso",
+		Data: map[string]interface{}{
+			"school_id": schoolID,
+			"dre_id":    dreID,
+			"dre":       canonicalDRE,
+		},
+	})
+}

--- a/api/cmd/api/admin_school_dre_test.go
+++ b/api/cmd/api/admin_school_dre_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"censo-api/internal/models"
+)
+
+func TestSchoolDREErrorStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"invalid DRE id", models.ErrDREInvalidID, http.StatusBadRequest},
+		{"missing schools", models.ErrSchoolIDsRequired, http.StatusBadRequest},
+		{"invalid school id wrapped", errors.New("placeholder"), http.StatusInternalServerError},
+		{"DRE not found", models.ErrDRENotFound, http.StatusNotFound},
+		{"school not found", models.ErrSchoolNotFound, http.StatusNotFound},
+		{"inactive DRE", models.ErrDREInactive, http.StatusConflict},
+		{"unexpected", errors.New("db down"), http.StatusInternalServerError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := schoolDREErrorStatus(tc.err); got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+
+	wrappedInvalidSchool := errors.Join(errors.New("context"), models.ErrSchoolInvalidID)
+	if got := schoolDREErrorStatus(wrappedInvalidSchool); got != http.StatusBadRequest {
+		t.Fatalf("wrapped ErrSchoolInvalidID: got %d", got)
+	}
+}
+
+func TestSchoolDREManagementHandlersRequireAdmin(t *testing.T) {
+	app := setupTestApp()
+	tests := []struct {
+		name    string
+		method  string
+		url     string
+		body    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{"batch association", http.MethodPost, "/v1/admin/dres/1/schools", `{"school_ids":[1]}`, app.AdminAssignSchoolsToDRE},
+		{"single remap", http.MethodPatch, "/v1/admin/schools/1/dre", `{"dre_id":1}`, app.AdminMoveSchoolToDRE},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name+" missing scope", func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.url, strings.NewReader(tc.body))
+			rr := httptest.NewRecorder()
+			tc.handler(rr, req)
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("got %d, want 403", rr.Code)
+			}
+		})
+		t.Run(tc.name+" DRE role", func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.url, strings.NewReader(tc.body))
+			scope := AdminAccessScope{Username: "dre-user", Role: RoleDRE, DRE: "DRE BELEM"}
+			req = req.WithContext(context.WithValue(req.Context(), contextKeyAdminScope, scope))
+			rr := httptest.NewRecorder()
+			tc.handler(rr, req)
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("got %d, want 403", rr.Code)
+			}
+		})
+	}
+}
+
+func TestSchoolDREManagementRoutesAuth(t *testing.T) {
+	app := setupTestApp()
+	handler := app.routes()
+	adminToken := createTestJWT("admin", RoleAdmin, "")
+	dreToken := createTestJWT("dre-user", RoleDRE, "DRE BELEM")
+
+	routes := []struct {
+		method string
+		url    string
+		body   string
+	}{
+		{http.MethodPost, "/v1/admin/dres/0/schools", `{"school_ids":[1]}`},
+		{http.MethodPatch, "/v1/admin/schools/0/dre", `{"dre_id":1}`},
+	}
+
+	for _, route := range routes {
+		t.Run(route.method+" "+route.url+" unauthenticated", func(t *testing.T) {
+			req := httptest.NewRequest(route.method, route.url, strings.NewReader(route.body))
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("got %d, want 401; body=%s", rr.Code, rr.Body.String())
+			}
+		})
+		t.Run(route.method+" "+route.url+" DRE token", func(t *testing.T) {
+			req := httptest.NewRequest(route.method, route.url, strings.NewReader(route.body))
+			req.Header.Set("Authorization", "Bearer "+dreToken)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("got %d, want 403; body=%s", rr.Code, rr.Body.String())
+			}
+		})
+		t.Run(route.method+" "+route.url+" admin reaches validation", func(t *testing.T) {
+			req := httptest.NewRequest(route.method, route.url, strings.NewReader(route.body))
+			req.Header.Set("Authorization", "Bearer "+adminToken)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("got %d, want 400; body=%s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestAdminAssignSchoolsToDREValidationBeforeDatabase(t *testing.T) {
+	app := setupTestApp()
+	handler := app.routes()
+	adminToken := createTestJWT("admin", RoleAdmin, "")
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"empty school list", `{}`},
+		{"zero school id", `{"school_ids":[1,0]}`},
+		{"negative convenience id", `{"school_id":-1}`},
+		{"malformed JSON", `{"school_ids":[1,}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/admin/dres/1/schools", strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer "+adminToken)
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("got %d, want 400; body=%s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestAdminMoveSchoolToDREValidationBeforeDatabase(t *testing.T) {
+	app := setupTestApp()
+	handler := app.routes()
+	adminToken := createTestJWT("admin", RoleAdmin, "")
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"missing target", `{}`},
+		{"invalid DRE id", `{"dre_id":0}`},
+		{"both target forms", `{"dre_id":1,"dre":"DRE BELEM"}`},
+		{"blank name", `{"dre":"   "}`},
+		{"malformed JSON", `{"dre_id":`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPatch, "/v1/admin/schools/1/dre", strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer "+adminToken)
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("got %d, want 400; body=%s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -340,6 +340,8 @@ func (app *application) routes() http.Handler {
 			protected.Post("/admin/dres", app.AdminCreateDRE)
 			protected.Get("/admin/dres", app.AdminListDREs)
 			protected.Put("/admin/dres/{id}", app.AdminUpdateDRE)
+			protected.Post("/admin/dres/{id}/schools", app.AdminAssignSchoolsToDRE)
+			protected.Patch("/admin/schools/{id}/dre", app.AdminMoveSchoolToDRE)
 
 			// Gestão de Usuários Administrativos (exclusivo role=admin)
 			protected.Post("/admin/users", app.AdminCreateUser)

--- a/api/internal/models/school_dre.go
+++ b/api/internal/models/school_dre.go
@@ -45,6 +45,18 @@ func normalizeSchoolIDs(ids []int) ([]int, error) {
 	return normalized, nil
 }
 
+func normalizedSchoolIDsForUpdate(ids []int) ([]int, error) {
+	normalized, err := normalizeSchoolIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	// Acquire school row locks in a deterministic order. Concurrent admins may
+	// submit the same schools in different request orders; sorting minimizes the
+	// classic 1->2 / 2->1 lock inversion that can otherwise deadlock PostgreSQL.
+	sort.Ints(normalized)
+	return normalized, nil
+}
+
 // AssignToDRE associates one or more schools with a master DRE atomically.
 // The canonical DRE name is read and locked inside the same transaction used
 // to update schools, preventing stale or differently formatted DRE values from
@@ -54,14 +66,10 @@ func (m *SchoolModel) AssignToDRE(ctx context.Context, dreID int, schoolIDs []in
 		return "", 0, ErrDREInvalidID
 	}
 
-	ids, err := normalizeSchoolIDs(schoolIDs)
+	ids, err := normalizedSchoolIDsForUpdate(schoolIDs)
 	if err != nil {
 		return "", 0, err
 	}
-	// Acquire school row locks in a deterministic order. Concurrent admins may
-	// submit the same schools in different request orders; sorting minimizes the
-	// classic 1->2 / 2->1 lock inversion that can otherwise deadlock PostgreSQL.
-	sort.Ints(ids)
 
 	tx, err := m.DB.BeginTx(ctx, nil)
 	if err != nil {

--- a/api/internal/models/school_dre.go
+++ b/api/internal/models/school_dre.go
@@ -1,0 +1,113 @@
+package models
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrSchoolNotFound      = errors.New("escola não encontrada")
+	ErrSchoolIDsRequired   = errors.New("ao menos uma escola deve ser informada")
+	ErrSchoolInvalidID     = errors.New("ID de escola inválido")
+	ErrSchoolBatchTooLarge = errors.New("lote de escolas excede o limite permitido")
+)
+
+const maxSchoolDREBatchSize = 1000
+
+func normalizeSchoolIDs(ids []int) ([]int, error) {
+	if len(ids) == 0 {
+		return nil, ErrSchoolIDsRequired
+	}
+	if len(ids) > maxSchoolDREBatchSize {
+		return nil, ErrSchoolBatchTooLarge
+	}
+
+	seen := make(map[int]struct{}, len(ids))
+	normalized := make([]int, 0, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			return nil, fmt.Errorf("%w: %d", ErrSchoolInvalidID, id)
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		normalized = append(normalized, id)
+	}
+
+	if len(normalized) == 0 {
+		return nil, ErrSchoolIDsRequired
+	}
+	return normalized, nil
+}
+
+// AssignToDRE associates one or more schools with a master DRE atomically.
+// The canonical DRE name is read and locked inside the same transaction used
+// to update schools, preventing stale or differently formatted DRE values from
+// being persisted. If any school does not exist, the whole batch is rolled back.
+func (m *SchoolModel) AssignToDRE(ctx context.Context, dreID int, schoolIDs []int) (string, int, error) {
+	if dreID <= 0 {
+		return "", 0, ErrDREInvalidID
+	}
+
+	ids, err := normalizeSchoolIDs(schoolIDs)
+	if err != nil {
+		return "", 0, err
+	}
+
+	tx, err := m.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var dreName string
+	var active bool
+	err = tx.QueryRowContext(ctx, `
+		SELECT TRIM(nome), ativa
+		FROM dres
+		WHERE id = $1
+		FOR SHARE`, dreID).Scan(&dreName, &active)
+	if err == sql.ErrNoRows {
+		return "", 0, ErrDRENotFound
+	}
+	if err != nil {
+		return "", 0, err
+	}
+	if !active {
+		return "", 0, ErrDREInactive
+	}
+
+	dreName = strings.TrimSpace(dreName)
+	if dreName == "" {
+		return "", 0, ErrDRENameRequired
+	}
+
+	stmt, err := tx.PrepareContext(ctx, `UPDATE schools SET dre = $1 WHERE id = $2`)
+	if err != nil {
+		return "", 0, err
+	}
+	defer stmt.Close()
+
+	for _, schoolID := range ids {
+		result, err := stmt.ExecContext(ctx, dreName, schoolID)
+		if err != nil {
+			return "", 0, err
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return "", 0, err
+		}
+		if rowsAffected != 1 {
+			return "", 0, fmt.Errorf("%w: %d", ErrSchoolNotFound, schoolID)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", 0, err
+	}
+	return dreName, len(ids), nil
+}

--- a/api/internal/models/school_dre.go
+++ b/api/internal/models/school_dre.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -57,6 +58,10 @@ func (m *SchoolModel) AssignToDRE(ctx context.Context, dreID int, schoolIDs []in
 	if err != nil {
 		return "", 0, err
 	}
+	// Acquire school row locks in a deterministic order. Concurrent admins may
+	// submit the same schools in different request orders; sorting minimizes the
+	// classic 1->2 / 2->1 lock inversion that can otherwise deadlock PostgreSQL.
+	sort.Ints(ids)
 
 	tx, err := m.DB.BeginTx(ctx, nil)
 	if err != nil {

--- a/api/internal/models/school_dre_order_test.go
+++ b/api/internal/models/school_dre_order_test.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNormalizedSchoolIDsForUpdateUsesDeterministicLockOrder(t *testing.T) {
+	input := []int{9, 3, 7, 3, 1, 9, 2}
+	got, err := normalizedSchoolIDsForUpdate(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []int{1, 2, 3, 7, 9}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got %v, want deterministic order %v", got, want)
+	}
+}
+
+func TestNormalizedSchoolIDsForUpdatePreservesValidation(t *testing.T) {
+	if _, err := normalizedSchoolIDsForUpdate([]int{2, 0, 1}); !errors.Is(err, ErrSchoolInvalidID) {
+		t.Fatalf("expected ErrSchoolInvalidID, got %v", err)
+	}
+}

--- a/api/internal/models/school_dre_test.go
+++ b/api/internal/models/school_dre_test.go
@@ -1,0 +1,319 @@
+package models
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync"
+	"testing"
+)
+
+func TestNormalizeSchoolIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []int
+		want    []int
+		wantErr error
+	}{
+		{name: "empty", input: nil, wantErr: ErrSchoolIDsRequired},
+		{name: "single", input: []int{7}, want: []int{7}},
+		{name: "deduplicates preserving order", input: []int{3, 1, 3, 2, 1}, want: []int{3, 1, 2}},
+		{name: "zero invalid", input: []int{1, 0}, wantErr: ErrSchoolInvalidID},
+		{name: "negative invalid", input: []int{-1}, wantErr: ErrSchoolInvalidID},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeSchoolIDs(tc.input)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fmt.Sprint(got) != fmt.Sprint(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSchoolIDsBatchLimit(t *testing.T) {
+	atLimit := make([]int, maxSchoolDREBatchSize)
+	for i := range atLimit {
+		atLimit[i] = i + 1
+	}
+	if _, err := normalizeSchoolIDs(atLimit); err != nil {
+		t.Fatalf("exact limit should be accepted: %v", err)
+	}
+
+	overLimit := append(append([]int(nil), atLimit...), maxSchoolDREBatchSize+1)
+	if _, err := normalizeSchoolIDs(overLimit); !errors.Is(err, ErrSchoolBatchTooLarge) {
+		t.Fatalf("expected batch-too-large error, got %v", err)
+	}
+}
+
+// Property-style regression coverage: thousands of deterministic random input
+// sets prove that normalization only emits positive unique IDs and preserves
+// first-seen ordering.
+func TestNormalizeSchoolIDsProperties(t *testing.T) {
+	rng := rand.New(rand.NewSource(188))
+	for iteration := 0; iteration < 5000; iteration++ {
+		length := 1 + rng.Intn(80)
+		input := make([]int, length)
+		for i := range input {
+			input[i] = 1 + rng.Intn(40)
+		}
+
+		got, err := normalizeSchoolIDs(input)
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", iteration, err)
+		}
+
+		seen := make(map[int]bool)
+		want := make([]int, 0, len(input))
+		for _, id := range input {
+			if !seen[id] {
+				seen[id] = true
+				want = append(want, id)
+			}
+		}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("iteration %d: got %v, want %v", iteration, got, want)
+		}
+	}
+}
+
+type fakeDRE struct {
+	name   string
+	active bool
+}
+
+type fakeSchoolDREState struct {
+	mu      sync.Mutex
+	dres    map[int]fakeDRE
+	schools map[int]string
+}
+
+var fakeSchoolDRERegistry = struct {
+	sync.Mutex
+	states map[string]*fakeSchoolDREState
+}{states: make(map[string]*fakeSchoolDREState)}
+
+type fakeSchoolDREDriver struct{}
+
+type fakeSchoolDREConn struct {
+	state *fakeSchoolDREState
+	tx    *fakeSchoolDRETx
+}
+
+type fakeSchoolDRETx struct {
+	conn   *fakeSchoolDREConn
+	staged map[int]string
+	done   bool
+}
+
+type fakeSchoolDREStmt struct{ conn *fakeSchoolDREConn }
+
+type fakeSchoolDRERows struct {
+	values []driver.Value
+	done   bool
+}
+
+func (fakeSchoolDREDriver) Open(name string) (driver.Conn, error) {
+	fakeSchoolDRERegistry.Lock()
+	state := fakeSchoolDRERegistry.states[name]
+	fakeSchoolDRERegistry.Unlock()
+	if state == nil {
+		return nil, fmt.Errorf("unknown fake DB %q", name)
+	}
+	return &fakeSchoolDREConn{state: state}, nil
+}
+
+func (c *fakeSchoolDREConn) Prepare(string) (driver.Stmt, error) { return &fakeSchoolDREStmt{conn: c}, nil }
+func (c *fakeSchoolDREConn) Close() error                        { return nil }
+func (c *fakeSchoolDREConn) Begin() (driver.Tx, error)           { return c.BeginTx(context.Background(), driver.TxOptions{}) }
+func (c *fakeSchoolDREConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	c.state.mu.Lock()
+	staged := make(map[int]string, len(c.state.schools))
+	for id, dre := range c.state.schools {
+		staged[id] = dre
+	}
+	c.state.mu.Unlock()
+	c.tx = &fakeSchoolDRETx{conn: c, staged: staged}
+	return c.tx, nil
+}
+func (c *fakeSchoolDREConn) PrepareContext(context.Context, string) (driver.Stmt, error) {
+	return &fakeSchoolDREStmt{conn: c}, nil
+}
+func (c *fakeSchoolDREConn) QueryContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("expected one DRE arg, got %d", len(args))
+	}
+	id, ok := args[0].Value.(int64)
+	if !ok {
+		return nil, fmt.Errorf("unexpected DRE arg type %T", args[0].Value)
+	}
+	c.state.mu.Lock()
+	dre, exists := c.state.dres[int(id)]
+	c.state.mu.Unlock()
+	if !exists {
+		return &fakeSchoolDRERows{}, nil
+	}
+	return &fakeSchoolDRERows{values: []driver.Value{dre.name, dre.active}}, nil
+}
+
+func (tx *fakeSchoolDRETx) Commit() error {
+	if tx.done {
+		return errors.New("transaction already finished")
+	}
+	tx.conn.state.mu.Lock()
+	tx.conn.state.schools = make(map[int]string, len(tx.staged))
+	for id, dre := range tx.staged {
+		tx.conn.state.schools[id] = dre
+	}
+	tx.conn.state.mu.Unlock()
+	tx.done = true
+	return nil
+}
+func (tx *fakeSchoolDRETx) Rollback() error {
+	if tx.done {
+		return sql.ErrTxDone
+	}
+	tx.done = true
+	return nil
+}
+
+func (s *fakeSchoolDREStmt) Close() error  { return nil }
+func (s *fakeSchoolDREStmt) NumInput() int { return 2 }
+func (s *fakeSchoolDREStmt) Exec(args []driver.Value) (driver.Result, error) {
+	named := make([]driver.NamedValue, len(args))
+	for i, v := range args {
+		named[i] = driver.NamedValue{Ordinal: i + 1, Value: v}
+	}
+	return s.ExecContext(context.Background(), named)
+}
+func (s *fakeSchoolDREStmt) Query([]driver.Value) (driver.Rows, error) {
+	return nil, errors.New("query not supported")
+}
+func (s *fakeSchoolDREStmt) ExecContext(_ context.Context, args []driver.NamedValue) (driver.Result, error) {
+	if s.conn.tx == nil || s.conn.tx.done {
+		return nil, errors.New("no active transaction")
+	}
+	if len(args) != 2 {
+		return nil, fmt.Errorf("expected 2 update args, got %d", len(args))
+	}
+	dreName, ok := args[0].Value.(string)
+	if !ok {
+		return nil, fmt.Errorf("unexpected DRE name type %T", args[0].Value)
+	}
+	id64, ok := args[1].Value.(int64)
+	if !ok {
+		return nil, fmt.Errorf("unexpected school ID type %T", args[1].Value)
+	}
+	id := int(id64)
+	if _, exists := s.conn.tx.staged[id]; !exists {
+		return driver.RowsAffected(0), nil
+	}
+	s.conn.tx.staged[id] = dreName
+	return driver.RowsAffected(1), nil
+}
+
+func (r *fakeSchoolDRERows) Columns() []string { return []string{"nome", "ativa"} }
+func (r *fakeSchoolDRERows) Close() error      { return nil }
+func (r *fakeSchoolDRERows) Next(dest []driver.Value) error {
+	if r.done || len(r.values) == 0 {
+		return io.EOF
+	}
+	copy(dest, r.values)
+	r.done = true
+	return nil
+}
+
+var registerFakeSchoolDREDriver sync.Once
+
+func openFakeSchoolDREDB(t *testing.T, state *fakeSchoolDREState) *sql.DB {
+	t.Helper()
+	registerFakeSchoolDREDriver.Do(func() { sql.Register("school-dre-fake", fakeSchoolDREDriver{}) })
+	name := t.Name()
+	fakeSchoolDRERegistry.Lock()
+	fakeSchoolDRERegistry.states[name] = state
+	fakeSchoolDRERegistry.Unlock()
+	t.Cleanup(func() {
+		fakeSchoolDRERegistry.Lock()
+		delete(fakeSchoolDRERegistry.states, name)
+		fakeSchoolDRERegistry.Unlock()
+	})
+	db, err := sql.Open("school-dre-fake", name)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestAssignToDREAtomicSuccessAndCanonicalization(t *testing.T) {
+	state := &fakeSchoolDREState{
+		dres:    map[int]fakeDRE{10: {name: "  DRE CANÔNICA  ", active: true}},
+		schools: map[int]string{1: "DRE ANTIGA", 2: "Outra"},
+	}
+	model := &SchoolModel{DB: openFakeSchoolDREDB(t, state)}
+
+	name, updated, err := model.AssignToDRE(context.Background(), 10, []int{1, 1, 2})
+	if err != nil {
+		t.Fatalf("AssignToDRE: %v", err)
+	}
+	if name != "DRE CANÔNICA" || updated != 2 {
+		t.Fatalf("got name=%q updated=%d", name, updated)
+	}
+	if state.schools[1] != "DRE CANÔNICA" || state.schools[2] != "DRE CANÔNICA" {
+		t.Fatalf("canonical DRE was not persisted atomically: %+v", state.schools)
+	}
+}
+
+func TestAssignToDRERollsBackWholeBatchWhenSchoolMissing(t *testing.T) {
+	state := &fakeSchoolDREState{
+		dres:    map[int]fakeDRE{10: {name: "DRE NOVA", active: true}},
+		schools: map[int]string{1: "DRE ORIGINAL"},
+	}
+	model := &SchoolModel{DB: openFakeSchoolDREDB(t, state)}
+
+	_, _, err := model.AssignToDRE(context.Background(), 10, []int{1, 999})
+	if !errors.Is(err, ErrSchoolNotFound) {
+		t.Fatalf("expected ErrSchoolNotFound, got %v", err)
+	}
+	if state.schools[1] != "DRE ORIGINAL" {
+		t.Fatalf("partial update escaped rollback: %+v", state.schools)
+	}
+}
+
+func TestAssignToDRERejectsMissingOrInactiveMasterDRE(t *testing.T) {
+	tests := []struct {
+		name    string
+		dres    map[int]fakeDRE
+		wantErr error
+	}{
+		{name: "missing", dres: map[int]fakeDRE{}, wantErr: ErrDRENotFound},
+		{name: "inactive", dres: map[int]fakeDRE{10: {name: "DRE INATIVA", active: false}}, wantErr: ErrDREInactive},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := &fakeSchoolDREState{dres: tc.dres, schools: map[int]string{1: "DRE ORIGINAL"}}
+			model := &SchoolModel{DB: openFakeSchoolDREDB(t, state)}
+			_, _, err := model.AssignToDRE(context.Background(), 10, []int{1})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+			if state.schools[1] != "DRE ORIGINAL" {
+				t.Fatalf("school changed after rejected DRE: %+v", state.schools)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Objetivo
Implementa a **LUCAS-02 — Associação e Remanejamento de Escolas à DRE** (#188).

## Alterações
- adiciona `POST /v1/admin/dres/{id}/schools` para associação individual ou em lote;
- adiciona `PATCH /v1/admin/schools/{id}/dre` para remanejamento;
- restringe ambas as operações a `role=admin`;
- valida a DRE de destino contra a entidade mestre e rejeita DRE inexistente/inativa;
- persiste sempre o nome canônico da DRE retornado pela tabela `dres`;
- sanitiza whitespace antes da persistência;
- remove IDs duplicados e limita lotes a 1000 entradas;
- ordena os IDs antes das atualizações para adquirir locks de escolas em ordem determinística e reduzir inversão de locks/deadlocks concorrentes;
- executa associação/remanejamento em transação: se qualquer escola do lote não existir ou alguma atualização falhar, todo o lote é revertido;
- trava a DRE mestre durante a transação para evitar inconsistência concorrente com alteração/desativação.

## Testes adicionados
- validação de entrada e limites de lote;
- **5.000 iterações determinísticas de teste por propriedades** sobre IDs, deduplicação e ordenação;
- teste explícito da ordem determinística usada para aquisição de locks;
- canonicalização do nome da DRE;
- sucesso transacional em lote;
- rollback integral quando uma escola do lote não existe;
- rejeição de DRE inexistente e inativa sem alterar escolas;
- autenticação das novas rotas: sem token `401`, perfil DRE `403`, admin passa pelo gate;
- validações de payload das duas rotas, incluindo JSON inválido e IDs inválidos.

## Validação
- branch atualizada com a `develop` antes da implementação;
- branch permanece sem divergência para trás de `develop` na revisão final;
- Vercel reportou `success` para o HEAD anterior à última melhoria de concorrência; o status do HEAD final é verificado separadamente;
- testes de modelo/transação passaram no harness local;
- após a melhoria de concorrência, o código atualizado foi recompilado em harness isolado e executou novamente **5.000 casos determinísticos**, além dos testes de ordenação e validação, todos passando.

> Observação: o ambiente local disponível nesta execução tem Go 1.23 enquanto o módulo declara Go 1.24 e não possui cache das dependências externas; portanto não foi possível afirmar falsamente que `go test ./...` do repositório inteiro foi executado localmente. Os testes adicionados que não dependem dessas bibliotecas foram compilados e executados, e o PR permanece sujeito aos checks do repositório/plataforma.

Closes #188