### PR TITLE
test(api): integração completa dos analytics de DRE (#190)

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -60,11 +60,13 @@ jobs:
           PGPASSWORD: postgres
         run: |
           set -euo pipefail
-          # infra/init.sql já espelha as migrations 0001..0017. Reaplicá-las
-          # aqui duplica constraints que alguns scripts antigos não tornam
-          # plenamente idempotentes. As entidades administrativas 0018/0019
-          # ainda não fazem parte do init e são aplicadas explicitamente.
+          # infra/init.sql contém o schema/base analítica, mas a tabela de
+          # regiões (0014) e as entidades administrativas de perfis DRE
+          # (0018/0019) são carregadas explicitamente para os testes reais.
+          # As demais migrations não são reaplicadas porque parte delas já é
+          # espelhada no init.sql e scripts históricos não são 100% idempotentes.
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/init.sql
+          psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0014_reg_integracao.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0018_create_admin_users.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0019_create_dres_master.sql
 

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -60,11 +60,13 @@ jobs:
           PGPASSWORD: postgres
         run: |
           set -euo pipefail
+          # infra/init.sql já espelha as migrations 0001..0017. Reaplicá-las
+          # aqui duplica constraints que alguns scripts antigos não tornam
+          # plenamente idempotentes. As entidades administrativas 0018/0019
+          # ainda não fazem parte do init e são aplicadas explicitamente.
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/init.sql
-          for migration in api/cmd/api/migrations/*.sql; do
-            echo "Applying $migration"
-            psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f "$migration"
-          done
+          psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0018_create_admin_users.sql
+          psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0019_create_dres_master.sql
 
       - name: Vet
         working-directory: api

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -6,6 +6,7 @@ on:
       - develop
     paths:
       - "api/**"
+      - "infra/init.sql"
       - ".github/workflows/api-ci.yml"
 
 permissions:
@@ -19,6 +20,25 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: censo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d censo_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/censo_test?sslmode=disable
+      ADMIN_JWT_SECRET: dre-ci-secret-0123456789-abcdefghijklmnopqrstuvwxyz
 
     steps:
       - name: Checkout
@@ -35,6 +55,17 @@ jobs:
         working-directory: api
         run: go mod download
 
+      - name: Initialize PostgreSQL integration schema
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+          psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/init.sql
+          for migration in api/cmd/api/migrations/*.sql; do
+            echo "Applying $migration"
+            psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f "$migration"
+          done
+
       - name: Vet
         working-directory: api
         run: go vet ./...
@@ -43,6 +74,14 @@ jobs:
         working-directory: api
         run: go test ./... -count=1
 
-      - name: DRE analytics stress regression
+      - name: DRE deterministic property stress
         working-directory: api
-        run: go test ./cmd/api -run '^TestDREAnalyticsProperties20000Scenarios$' -count=5
+        run: go test ./cmd/api -run '^(TestDREAnalyticsProperties20000Scenarios|TestDREMasterIntegrationProperties50000Scenarios)$' -count=4
+
+      - name: DRE PostgreSQL batch stress
+        working-directory: api
+        run: go test ./cmd/api -run '^TestDREMasterIntegrationBatch1000Schools$' -count=3
+
+      - name: DRE integration race detector
+        working-directory: api
+        run: go test -race ./cmd/api -run '^TestDREMasterIntegrationFlow$' -count=1

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -86,6 +86,10 @@ jobs:
         working-directory: api
         run: go test ./cmd/api -run '^TestDREMasterIntegrationBatch1000Schools$' -count=3
 
+      - name: DRE PostgreSQL remap stress
+        working-directory: api
+        run: go test ./cmd/api -run '^TestDREMasterIntegrationRemap1000Schools5Cycles$' -count=2
+
       - name: DRE integration race detector
         working-directory: api
         run: go test -race ./cmd/api -run '^TestDREMasterIntegrationFlow$' -count=1

--- a/api/cmd/api/analytics_dre_master_test.go
+++ b/api/cmd/api/analytics_dre_master_test.go
@@ -130,7 +130,7 @@ func seedIntegrationCensus(t *testing.T, db *sql.DB, schoolID int, status string
 	t.Helper()
 	_, err := db.Exec(`
 		INSERT INTO census_responses (school_id, year, status, data, created_at, updated_at)
-		VALUES ($1, $2, $3, jsonb_build_object('total_alunos', $4), NOW(), NOW())
+		VALUES ($1, $2, $3, jsonb_build_object('total_alunos', $4::int), NOW(), NOW())
 	`, schoolID, dreIntegrationYear, status, totalStudents)
 	if err != nil {
 		t.Fatalf("inserir censo da escola %d: %v", schoolID, err)
@@ -332,7 +332,7 @@ func TestDREMasterIntegrationBatch1000Schools(t *testing.T) {
 	}
 	censusStmt, err := censusTx.Prepare(`
 		INSERT INTO census_responses (school_id, year, status, data, created_at, updated_at)
-		VALUES ($1, $2, $3, jsonb_build_object('total_alunos', $4), NOW(), NOW())
+		VALUES ($1, $2, $3, jsonb_build_object('total_alunos', $4::int), NOW(), NOW())
 	`)
 	if err != nil {
 		_ = censusTx.Rollback()

--- a/api/cmd/api/analytics_dre_master_test.go
+++ b/api/cmd/api/analytics_dre_master_test.go
@@ -1,0 +1,450 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"censo-api/internal/models"
+)
+
+const dreIntegrationYear = 2026
+
+type dreIntegrationEnvelope[T any] struct {
+	Error   bool   `json:"error"`
+	Message string `json:"message"`
+	Data    T      `json:"data"`
+}
+
+func openDREIntegrationDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := strings.TrimSpace(os.Getenv("TEST_DATABASE_URL"))
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL não configurada; integração PostgreSQL roda no CI")
+	}
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("abrir PostgreSQL de integração: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		t.Fatalf("ping PostgreSQL de integração: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func newDREIntegrationApp(t *testing.T, db *sql.DB) (*application, http.Handler, string) {
+	t.Helper()
+	t.Setenv("ADMIN_JWT_SECRET", "dre-integration-secret-0123456789-abcdefghijklmnopqrstuvwxyz")
+	app := &application{
+		models: models.NewModels(db),
+		logger: log.New(io.Discard, "", 0),
+	}
+	return app, app.routes(), createTestJWT("integration-admin", RoleAdmin, "")
+}
+
+func resetDREIntegrationData(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`TRUNCATE TABLE census_responses, schools, dres RESTART IDENTITY CASCADE`); err != nil {
+		t.Fatalf("limpar dados de integração: %v", err)
+	}
+}
+
+func requestDREIntegration(t *testing.T, handler http.Handler, token, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("serializar request %s %s: %v", method, path, err)
+		}
+		reader = strings.NewReader(string(encoded))
+	}
+	req := httptest.NewRequest(method, path, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func decodeDREIntegrationData[T any](t *testing.T, rr *httptest.ResponseRecorder, wantStatus int) T {
+	t.Helper()
+	if rr.Code != wantStatus {
+		t.Fatalf("status=%d; want %d; body=%s", rr.Code, wantStatus, rr.Body.String())
+	}
+	var envelope dreIntegrationEnvelope[T]
+	if err := json.Unmarshal(rr.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decodificar resposta JSON: %v; body=%s", err, rr.Body.String())
+	}
+	if envelope.Error {
+		t.Fatalf("API retornou error=true: %s", envelope.Message)
+	}
+	return envelope.Data
+}
+
+func createDREThroughAPI(t *testing.T, handler http.Handler, token, name string) models.DRE {
+	t.Helper()
+	rr := requestDREIntegration(t, handler, token, http.MethodPost, "/v1/admin/dres", map[string]any{
+		"nome":           name,
+		"sigla":          "INT",
+		"municipio_sede": "BELEM",
+		"polo":           "POLO TESTE",
+		"gestor_nome":    "Gestor Integração",
+		"email":          "integracao@example.test",
+		"telefone":       "91999999999",
+	})
+	return decodeDREIntegrationData[models.DRE](t, rr, http.StatusCreated)
+}
+
+func seedIntegrationSchool(t *testing.T, db *sql.DB, inep, name, dre string) int {
+	t.Helper()
+	var id int
+	err := db.QueryRow(`
+		INSERT INTO schools (nome_escola, codigo_inep, municipio, dre, zona)
+		VALUES ($1, $2, 'BELEM', $3, 'Urbana')
+		RETURNING id
+	`, name, inep, dre).Scan(&id)
+	if err != nil {
+		t.Fatalf("inserir escola %s: %v", inep, err)
+	}
+	return id
+}
+
+func seedIntegrationCensus(t *testing.T, db *sql.DB, schoolID int, status string, totalStudents int) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO census_responses (school_id, year, status, data, created_at, updated_at)
+		VALUES ($1, $2, $3, jsonb_build_object('total_alunos', $4), NOW(), NOW())
+	`, schoolID, dreIntegrationYear, status, totalStudents)
+	if err != nil {
+		t.Fatalf("inserir censo da escola %d: %v", schoolID, err)
+	}
+}
+
+func findIntegrationPreenchimentoRow(t *testing.T, payload PreenchimentoDrePayload, dre string) PreenchimentoDreRow {
+	t.Helper()
+	for _, row := range payload.DREs {
+		if strings.EqualFold(strings.TrimSpace(row.DRE), strings.TrimSpace(dre)) {
+			return row
+		}
+	}
+	t.Fatalf("DRE %q não encontrada em preenchimento: %+v", dre, payload.DREs)
+	return PreenchimentoDreRow{}
+}
+
+func containsIntegrationString(items []string, want string) bool {
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSpace(item), strings.TrimSpace(want)) {
+			return true
+		}
+	}
+	return false
+}
+
+func schoolIDsFromOptions(items []FiltrosEscolaItem) map[int]bool {
+	out := make(map[int]bool, len(items))
+	for _, item := range items {
+		out[item.SchoolID] = true
+	}
+	return out
+}
+
+// TestDREMasterIntegrationFlow reproduz o fluxo de aceite da #190 usando
+// PostgreSQL real e o roteador HTTP completo, incluindo autenticação JWT.
+func TestDREMasterIntegrationFlow(t *testing.T) {
+	db := openDREIntegrationDB(t)
+	resetDREIntegrationData(t, db)
+	_, handler, adminToken := newDREIntegrationApp(t, db)
+
+	dreA := createDREThroughAPI(t, handler, adminToken, "DRE INTEGRACAO A")
+	if dreA.ID <= 0 || dreA.Nome != "DRE INTEGRACAO A" || !dreA.Ativa {
+		t.Fatalf("DRE criada inválida: %+v", dreA)
+	}
+
+	// A DRE mestre precisa aparecer imediatamente nos filtros, mesmo sem escolas.
+	filtersRR := requestDREIntegration(t, handler, adminToken, http.MethodGet,
+		"/v1/admin/analytics/filtros/opcoes?year=2026", nil)
+	filters := decodeDREIntegrationData[FiltrosOpcoes](t, filtersRR, http.StatusOK)
+	if !containsIntegrationString(filters.DREs, dreA.Nome) {
+		t.Fatalf("DRE ativa recém-criada não apareceu nos filtros: %+v", filters.DREs)
+	}
+
+	emptyPath := "/v1/admin/analytics/preenchimento/dre?year=2026&dre=" + url.QueryEscape(dreA.Nome)
+	emptyRR := requestDREIntegration(t, handler, adminToken, http.MethodGet, emptyPath, nil)
+	emptyPayload := decodeDREIntegrationData[PreenchimentoDrePayload](t, emptyRR, http.StatusOK)
+	emptyRow := findIntegrationPreenchimentoRow(t, emptyPayload, dreA.Nome)
+	if emptyRow.Total != 0 || emptyRow.Completed != 0 || emptyRow.Draft != 0 || emptyRow.Pending != 0 || emptyRow.CompletionPercentage != 0 {
+		t.Fatalf("DRE sem escolas deve estar zerada: %+v", emptyRow)
+	}
+
+	school1 := seedIntegrationSchool(t, db, "15900001", "Escola Integração 1", "DRE LEGADA")
+	school2 := seedIntegrationSchool(t, db, "15900002", "Escola Integração 2", "DRE LEGADA")
+	controlSchool := seedIntegrationSchool(t, db, "15900003", "Escola Controle", "DRE CONTROLE")
+
+	assignRR := requestDREIntegration(t, handler, adminToken, http.MethodPost,
+		fmt.Sprintf("/v1/admin/dres/%d/schools", dreA.ID),
+		map[string]any{"school_ids": []int{school2, school1}})
+	if assignRR.Code != http.StatusOK {
+		t.Fatalf("associação em lote status=%d; body=%s", assignRR.Code, assignRR.Body.String())
+	}
+
+	var assignedCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schools WHERE UPPER(TRIM(dre)) = UPPER(TRIM($1))`, dreA.Nome).Scan(&assignedCount); err != nil {
+		t.Fatalf("contar escolas associadas: %v", err)
+	}
+	if assignedCount != 2 {
+		t.Fatalf("associação persistida=%d escolas; want 2", assignedCount)
+	}
+
+	seedIntegrationCensus(t, db, school1, "completed", 321)
+	seedIntegrationCensus(t, db, school2, "draft", 999)
+	seedIntegrationCensus(t, db, controlSchool, "completed", 777)
+
+	// O filtro pela DRE nova deve restringir escolas e não vazar a escola controle.
+	filteredPath := "/v1/admin/analytics/filtros/opcoes?year=2026&dre=" + url.QueryEscape(dreA.Nome)
+	filteredRR := requestDREIntegration(t, handler, adminToken, http.MethodGet, filteredPath, nil)
+	filtered := decodeDREIntegrationData[FiltrosOpcoes](t, filteredRR, http.StatusOK)
+	filteredIDs := schoolIDsFromOptions(filtered.Escolas)
+	if len(filteredIDs) != 2 || !filteredIDs[school1] || !filteredIDs[school2] || filteredIDs[controlSchool] {
+		t.Fatalf("filtro DRE retornou escolas incorretas: %+v", filtered.Escolas)
+	}
+
+	preRR := requestDREIntegration(t, handler, adminToken, http.MethodGet, emptyPath, nil)
+	pre := decodeDREIntegrationData[PreenchimentoDrePayload](t, preRR, http.StatusOK)
+	row := findIntegrationPreenchimentoRow(t, pre, dreA.Nome)
+	if row.Total != 2 || row.Completed != 1 || row.Draft != 1 || row.Pending != 0 || row.CompletionPercentage != 50 {
+		t.Fatalf("preenchimento após associação inconsistente: %+v", row)
+	}
+
+	summaryRR := requestDREIntegration(t, handler, adminToken, http.MethodGet,
+		fmt.Sprintf("/v1/admin/dres/%d/resumo?year=%d", dreA.ID, dreIntegrationYear), nil)
+	summary := decodeDREIntegrationData[DRESummaryPayload](t, summaryRR, http.StatusOK)
+	if summary.TotalEscolas != 2 || summary.TotalAlunos != 321 || summary.CensusAdherencePercentage != 50 {
+		t.Fatalf("resumo após associação inconsistente: %+v", summary)
+	}
+
+	// O escopo role=dre precisa impor a DRE do token mesmo sem query param.
+	dreToken := createTestJWT("integration-dre", RoleDRE, dreA.Nome)
+	scopedRR := requestDREIntegration(t, handler, dreToken, http.MethodGet,
+		"/v1/admin/analytics/preenchimento/dre?year=2026", nil)
+	scoped := decodeDREIntegrationData[PreenchimentoDrePayload](t, scopedRR, http.StatusOK)
+	if len(scoped.DREs) != 1 || !strings.EqualFold(scoped.DREs[0].DRE, dreA.Nome) {
+		t.Fatalf("escopo DRE vazou dados de outra DRE: %+v", scoped.DREs)
+	}
+
+	scopedFiltersRR := requestDREIntegration(t, handler, dreToken, http.MethodGet,
+		"/v1/admin/analytics/filtros/opcoes?year=2026", nil)
+	scopedFilters := decodeDREIntegrationData[FiltrosOpcoes](t, scopedFiltersRR, http.StatusOK)
+	if len(scopedFilters.DREs) != 1 || !strings.EqualFold(scopedFilters.DREs[0], dreA.Nome) {
+		t.Fatalf("opções de DRE não respeitaram autorização: %+v", scopedFilters.DREs)
+	}
+
+	// Remanejamento deve refletir imediatamente nos dois lados dos analytics.
+	dreB := createDREThroughAPI(t, handler, adminToken, "DRE INTEGRACAO B")
+	moveRR := requestDREIntegration(t, handler, adminToken, http.MethodPatch,
+		fmt.Sprintf("/v1/admin/schools/%d/dre", school2), map[string]any{"dre_id": dreB.ID})
+	if moveRR.Code != http.StatusOK {
+		t.Fatalf("remanejamento status=%d; body=%s", moveRR.Code, moveRR.Body.String())
+	}
+
+	summaryARR := requestDREIntegration(t, handler, adminToken, http.MethodGet,
+		fmt.Sprintf("/v1/admin/dres/%d/resumo?year=%d", dreA.ID, dreIntegrationYear), nil)
+	summaryA := decodeDREIntegrationData[DRESummaryPayload](t, summaryARR, http.StatusOK)
+	if summaryA.TotalEscolas != 1 || summaryA.TotalAlunos != 321 || summaryA.CensusAdherencePercentage != 100 {
+		t.Fatalf("resumo origem após remanejamento inconsistente: %+v", summaryA)
+	}
+
+	summaryBRR := requestDREIntegration(t, handler, adminToken, http.MethodGet,
+		fmt.Sprintf("/v1/admin/dres/%d/resumo?year=%d", dreB.ID, dreIntegrationYear), nil)
+	summaryB := decodeDREIntegrationData[DRESummaryPayload](t, summaryBRR, http.StatusOK)
+	if summaryB.TotalEscolas != 1 || summaryB.TotalAlunos != 0 || summaryB.CensusAdherencePercentage != 0 {
+		t.Fatalf("resumo destino após remanejamento inconsistente: %+v", summaryB)
+	}
+
+	filteredAfterRR := requestDREIntegration(t, handler, adminToken, http.MethodGet, filteredPath, nil)
+	filteredAfter := decodeDREIntegrationData[FiltrosOpcoes](t, filteredAfterRR, http.StatusOK)
+	idsAfter := schoolIDsFromOptions(filteredAfter.Escolas)
+	if len(idsAfter) != 1 || !idsAfter[school1] || idsAfter[school2] {
+		t.Fatalf("filtros não refletiram remanejamento: %+v", filteredAfter.Escolas)
+	}
+}
+
+// TestDREMasterIntegrationBatch1000Schools cobre o limite máximo permitido pelo
+// endpoint de associação em lote usando uma transação real e analytics reais.
+func TestDREMasterIntegrationBatch1000Schools(t *testing.T) {
+	db := openDREIntegrationDB(t)
+	resetDREIntegrationData(t, db)
+	_, handler, adminToken := newDREIntegrationApp(t, db)
+	dre := createDREThroughAPI(t, handler, adminToken, "DRE STRESS 1000")
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin seed stress: %v", err)
+	}
+	stmt, err := tx.Prepare(`
+		INSERT INTO schools (nome_escola, codigo_inep, municipio, dre, zona)
+		VALUES ($1, $2, 'BELEM', 'DRE LEGADA STRESS', 'Urbana') RETURNING id
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("prepare escolas stress: %v", err)
+	}
+	ids := make([]int, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		var id int
+		if err := stmt.QueryRow(fmt.Sprintf("Escola Stress %04d", i), fmt.Sprintf("158%05d", i)).Scan(&id); err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			t.Fatalf("seed escola stress %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+	_ = stmt.Close()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit escolas stress: %v", err)
+	}
+
+	assignRR := requestDREIntegration(t, handler, adminToken, http.MethodPost,
+		fmt.Sprintf("/v1/admin/dres/%d/schools", dre.ID), map[string]any{"school_ids": ids})
+	if assignRR.Code != http.StatusOK {
+		t.Fatalf("associação de 1000 escolas status=%d; body=%s", assignRR.Code, assignRR.Body.String())
+	}
+
+	censusTx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin censos stress: %v", err)
+	}
+	censusStmt, err := censusTx.Prepare(`
+		INSERT INTO census_responses (school_id, year, status, data, created_at, updated_at)
+		VALUES ($1, $2, $3, jsonb_build_object('total_alunos', $4), NOW(), NOW())
+	`)
+	if err != nil {
+		_ = censusTx.Rollback()
+		t.Fatalf("prepare censos stress: %v", err)
+	}
+	wantStudents := 0
+	for i, id := range ids {
+		status := ""
+		students := 0
+		switch {
+		case i < 400:
+			status = "completed"
+			students = i + 1
+			wantStudents += students
+		case i < 700:
+			status = "draft"
+			students = 9999
+		default:
+			continue
+		}
+		if _, err := censusStmt.Exec(id, dreIntegrationYear, status, students); err != nil {
+			_ = censusStmt.Close()
+			_ = censusTx.Rollback()
+			t.Fatalf("seed censo stress %d: %v", i, err)
+		}
+	}
+	_ = censusStmt.Close()
+	if err := censusTx.Commit(); err != nil {
+		t.Fatalf("commit censos stress: %v", err)
+	}
+
+	prePath := "/v1/admin/analytics/preenchimento/dre?year=2026&dre=" + url.QueryEscape(dre.Nome)
+	preRR := requestDREIntegration(t, handler, adminToken, http.MethodGet, prePath, nil)
+	pre := decodeDREIntegrationData[PreenchimentoDrePayload](t, preRR, http.StatusOK)
+	row := findIntegrationPreenchimentoRow(t, pre, dre.Nome)
+	if row.Total != 1000 || row.Completed != 400 || row.Draft != 300 || row.Pending != 300 || row.CompletionPercentage != 40 {
+		t.Fatalf("analytics do lote de 1000 inconsistente: %+v", row)
+	}
+
+	summaryRR := requestDREIntegration(t, handler, adminToken, http.MethodGet,
+		fmt.Sprintf("/v1/admin/dres/%d/resumo?year=%d", dre.ID, dreIntegrationYear), nil)
+	summary := decodeDREIntegrationData[DRESummaryPayload](t, summaryRR, http.StatusOK)
+	if summary.TotalEscolas != 1000 || summary.TotalAlunos != float64(wantStudents) || summary.CensusAdherencePercentage != 40 {
+		t.Fatalf("resumo do lote de 1000 inconsistente: %+v; want alunos=%d", summary, wantStudents)
+	}
+
+	var canonicalized int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schools WHERE dre = $1`, dre.Nome).Scan(&canonicalized); err != nil {
+		t.Fatalf("contar canonicalização stress: %v", err)
+	}
+	if canonicalized != 1000 {
+		t.Fatalf("canonicalização persistida em %d/1000 escolas", canonicalized)
+	}
+}
+
+// TestDREMasterIntegrationProperties50000Scenarios estressa invariantes de
+// associação/remanejamento em 50 mil cenários determinísticos. O teste modela
+// a transferência de escolas completed/draft/pending entre duas DREs e garante
+// conservação das contagens e percentuais válidos nos dois lados.
+func TestDREMasterIntegrationProperties50000Scenarios(t *testing.T) {
+	rng := rand.New(rand.NewSource(190))
+	for scenario := 0; scenario < 50000; scenario++ {
+		total := rng.Intn(5001)
+		completed := 0
+		draft := 0
+		if total > 0 {
+			completed = rng.Intn(total + 1)
+			draft = rng.Intn(total - completed + 1)
+		}
+		pending := total - completed - draft
+
+		moveCompleted := 0
+		moveDraft := 0
+		movePending := 0
+		if completed > 0 {
+			moveCompleted = rng.Intn(completed + 1)
+		}
+		if draft > 0 {
+			moveDraft = rng.Intn(draft + 1)
+		}
+		if pending > 0 {
+			movePending = rng.Intn(pending + 1)
+		}
+		moved := moveCompleted + moveDraft + movePending
+
+		before := buildPreenchimentoDreRow("A", total, completed, draft)
+		afterA := buildPreenchimentoDreRow("A", total-moved, completed-moveCompleted, draft-moveDraft)
+		afterB := buildPreenchimentoDreRow("B", moved, moveCompleted, moveDraft)
+
+		if before.Completed+before.Draft+before.Pending != total {
+			t.Fatalf("scenario %d: estado inicial não particiona total: %+v", scenario, before)
+		}
+		if afterA.Total+afterB.Total != before.Total ||
+			afterA.Completed+afterB.Completed != before.Completed ||
+			afterA.Draft+afterB.Draft != before.Draft ||
+			afterA.Pending+afterB.Pending != before.Pending {
+			t.Fatalf("scenario %d: remanejamento perdeu/duplicou contagens: before=%+v A=%+v B=%+v", scenario, before, afterA, afterB)
+		}
+		for _, row := range []PreenchimentoDreRow{before, afterA, afterB} {
+			if row.Total < 0 || row.Completed < 0 || row.Draft < 0 || row.Pending < 0 {
+				t.Fatalf("scenario %d: contagem negativa: %+v", scenario, row)
+			}
+			if row.CompletionPercentage < 0 || row.CompletionPercentage > 100 {
+				t.Fatalf("scenario %d: percentual fora de 0..100: %+v", scenario, row)
+			}
+			want := 0
+			if row.Total > 0 {
+				want = int(math.Round(float64(row.Completed) / float64(row.Total) * 100))
+			}
+			if row.CompletionPercentage != want {
+				t.Fatalf("scenario %d: percentual=%d; want=%d; row=%+v", scenario, row.CompletionPercentage, want, row)
+			}
+		}
+	}
+}

--- a/api/cmd/api/analytics_dre_remap_stress_test.go
+++ b/api/cmd/api/analytics_dre_remap_stress_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func seedRemapStressSchools(t *testing.T, db *sql.DB, total int) []int {
+	t.Helper()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin seed remap: %v", err)
+	}
+	stmt, err := tx.Prepare(`
+		INSERT INTO schools (nome_escola, codigo_inep, municipio, dre, zona)
+		VALUES ($1, $2, 'BELEM', 'DRE REMAP LEGADA', 'Urbana') RETURNING id
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("prepare escolas remap: %v", err)
+	}
+	ids := make([]int, 0, total)
+	for i := 0; i < total; i++ {
+		var id int
+		if err := stmt.QueryRow(
+			fmt.Sprintf("Escola Remap %04d", i),
+			fmt.Sprintf("157%05d", i),
+		).Scan(&id); err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			t.Fatalf("seed escola remap %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+	_ = stmt.Close()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit escolas remap: %v", err)
+	}
+	return ids
+}
+
+func seedRemapStressCensuses(t *testing.T, db *sql.DB, ids []int) float64 {
+	t.Helper()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin censos remap: %v", err)
+	}
+	stmt, err := tx.Prepare(`
+		INSERT INTO census_responses (school_id, year, status, data, created_at, updated_at)
+		VALUES ($1, $2, $3, jsonb_build_object('total_alunos', $4::int), NOW(), NOW())
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("prepare censos remap: %v", err)
+	}
+
+	var totalStudents float64
+	for i, id := range ids {
+		status := ""
+		students := 0
+		switch {
+		case i < 500:
+			status = "completed"
+			students = 100 + (i % 31)
+			totalStudents += float64(students)
+		case i < 750:
+			status = "draft"
+			students = 9999
+		default:
+			continue
+		}
+		if _, err := stmt.Exec(id, dreIntegrationYear, status, students); err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			t.Fatalf("seed censo remap %d: %v", i, err)
+		}
+	}
+	_ = stmt.Close()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit censos remap: %v", err)
+	}
+	return totalStudents
+}
+
+func assignRemapStressBatch(t *testing.T, handler http.Handler, token string, dreID int, ids []int) {
+	t.Helper()
+	rr := requestDREIntegration(t, handler, token, http.MethodPost,
+		fmt.Sprintf("/v1/admin/dres/%d/schools", dreID),
+		map[string]any{"school_ids": ids})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("remanejamento em lote para DRE %d: status=%d body=%s", dreID, rr.Code, rr.Body.String())
+	}
+}
+
+func assertRemapStressAnalytics(
+	t *testing.T,
+	handler http.Handler,
+	token string,
+	dreID int,
+	dreName string,
+	wantTotal, wantCompleted, wantDraft, wantPending, wantPct int,
+	wantStudents float64,
+	checkFilters bool,
+) {
+	t.Helper()
+
+	prePath := "/v1/admin/analytics/preenchimento/dre?year=2026&dre=" + url.QueryEscape(dreName)
+	preRR := requestDREIntegration(t, handler, token, http.MethodGet, prePath, nil)
+	pre := decodeDREIntegrationData[PreenchimentoDrePayload](t, preRR, http.StatusOK)
+	row := findIntegrationPreenchimentoRow(t, pre, dreName)
+	if row.Total != wantTotal || row.Completed != wantCompleted || row.Draft != wantDraft ||
+		row.Pending != wantPending || row.CompletionPercentage != wantPct {
+		t.Fatalf("preenchimento %s inconsistente: got=%+v want total=%d completed=%d draft=%d pending=%d pct=%d",
+			dreName, row, wantTotal, wantCompleted, wantDraft, wantPending, wantPct)
+	}
+
+	summaryRR := requestDREIntegration(t, handler, token, http.MethodGet,
+		fmt.Sprintf("/v1/admin/dres/%d/resumo?year=%d", dreID, dreIntegrationYear), nil)
+	summary := decodeDREIntegrationData[DRESummaryPayload](t, summaryRR, http.StatusOK)
+	if summary.TotalEscolas != wantTotal || summary.TotalAlunos != wantStudents ||
+		summary.CensusAdherencePercentage != wantPct {
+		t.Fatalf("resumo %s inconsistente: got=%+v want total=%d alunos=%v pct=%d",
+			dreName, summary, wantTotal, wantStudents, wantPct)
+	}
+
+	if checkFilters {
+		filtersPath := "/v1/admin/analytics/filtros/opcoes?year=2026&dre=" + url.QueryEscape(dreName)
+		filtersRR := requestDREIntegration(t, handler, token, http.MethodGet, filtersPath, nil)
+		filters := decodeDREIntegrationData[FiltrosOpcoes](t, filtersRR, http.StatusOK)
+		if len(filters.Escolas) != wantTotal {
+			t.Fatalf("filtros %s retornaram %d escolas; want %d", dreName, len(filters.Escolas), wantTotal)
+		}
+	}
+}
+
+// TestDREMasterIntegrationRemap1000Schools5Cycles executa remanejamento REAL no
+// PostgreSQL por meio do endpoint de associação. São 1.000 escolas movidas de
+// A -> B e B -> A em cinco ciclos, totalizando 10.000 remanejamentos efetivos
+// por execução, e os analytics são consultados após cada movimento.
+func TestDREMasterIntegrationRemap1000Schools5Cycles(t *testing.T) {
+	db := openDREIntegrationDB(t)
+	resetDREIntegrationData(t, db)
+	_, handler, adminToken := newDREIntegrationApp(t, db)
+
+	dreA := createDREThroughAPI(t, handler, adminToken, "DRE REMAP A")
+	dreB := createDREThroughAPI(t, handler, adminToken, "DRE REMAP B")
+	ids := seedRemapStressSchools(t, db, 1000)
+	wantStudents := seedRemapStressCensuses(t, db, ids)
+
+	// Estado inicial canônico em A.
+	assignRemapStressBatch(t, handler, adminToken, dreA.ID, ids)
+	assertRemapStressAnalytics(t, handler, adminToken, dreA.ID, dreA.Nome,
+		1000, 500, 250, 250, 50, wantStudents, true)
+	assertRemapStressAnalytics(t, handler, adminToken, dreB.ID, dreB.Nome,
+		0, 0, 0, 0, 0, 0, false)
+
+	for cycle := 1; cycle <= 5; cycle++ {
+		assignRemapStressBatch(t, handler, adminToken, dreB.ID, ids)
+		assertRemapStressAnalytics(t, handler, adminToken, dreA.ID, dreA.Nome,
+			0, 0, 0, 0, 0, 0, false)
+		assertRemapStressAnalytics(t, handler, adminToken, dreB.ID, dreB.Nome,
+			1000, 500, 250, 250, 50, wantStudents, true)
+
+		assignRemapStressBatch(t, handler, adminToken, dreA.ID, ids)
+		assertRemapStressAnalytics(t, handler, adminToken, dreB.ID, dreB.Nome,
+			0, 0, 0, 0, 0, 0, false)
+		assertRemapStressAnalytics(t, handler, adminToken, dreA.ID, dreA.Nome,
+			1000, 500, 250, 250, 50, wantStudents, true)
+
+		var inA, inB int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM schools WHERE dre = $1`, dreA.Nome).Scan(&inA); err != nil {
+			t.Fatalf("ciclo %d contar DRE A: %v", cycle, err)
+		}
+		if err := db.QueryRow(`SELECT COUNT(*) FROM schools WHERE dre = $1`, dreB.Nome).Scan(&inB); err != nil {
+			t.Fatalf("ciclo %d contar DRE B: %v", cycle, err)
+		}
+		if inA != 1000 || inB != 0 {
+			t.Fatalf("ciclo %d terminou inconsistente: A=%d B=%d", cycle, inA, inB)
+		}
+	}
+}


### PR DESCRIPTION
## Objetivo
Implementa a **LUCAS-04 — Testes de Integração dos Analytics de DRE** (#190).

## Cobertura adicionada
- cria DRE pela API real autenticada;
- valida DRE ativa aparecendo nos filtros mesmo sem escolas;
- valida preenchimento zerado para DRE sem escolas;
- associa escolas existentes em lote e confirma persistência canônica;
- valida filtros globais sem vazamento de escolas de outra DRE;
- valida `preenchimento/dre` após associação;
- valida `dres/{id}/resumo` com total de escolas, alunos e adesão;
- valida escopo `role=dre` impondo a DRE do JWT;
- remaneja escola entre duas DREs e confirma atualização imediata dos dois lados;
- cobre o lote máximo de **1.000 escolas** contra PostgreSQL real;
- mantém **50.000 cenários determinísticos** como guarda matemática complementar;
- adiciona stress de **remanejamento real**: 1.000 escolas A → B → A por 5 ciclos, verificando banco, filtros, preenchimento e resumo após os movimentos.

## CI de integração
O workflow da API sobe **PostgreSQL 16 real**, carrega `infra/init.sql` e as migrations complementares necessárias ao fluxo (`0014`, `0018`, `0019`) antes dos testes.

### Resultado final no HEAD sincronizado com `develop`
- PostgreSQL/schema/migrations ✅
- `go vet ./...` ✅
- `go test ./... -count=1` ✅
- stress determinístico de **20.000 + 50.000 cenários**, repetido 4× ✅
- considerando a suíte completa + stress dedicado: **350.000 cenários de propriedades executados** ✅
- associação/analytics com lote de **1.000 escolas**, executada na suíte completa + 3 repetições dedicadas (**4.000 associações de lote validadas**) ✅
- stress real A ↔ B de 1.000 escolas × 5 ciclos, executado na suíte completa + 2 repetições dedicadas: **30.000 remanejamentos reais validados** ✅
- fluxo HTTP completo criação → associação → filtros → preenchimento → resumo → remanejamento executado também sob `-race` ✅
- Vercel Preview do HEAD final ✅

Durante a validação, o CI detectou problemas do próprio fixture/bootstrap (migration duplicada, `reg_integracao` ausente no banco de teste e tipagem de parâmetro JSONB); todos foram corrigidos antes da entrega final. Uma revisão automática também apontou corretamente que o stress puramente matemático não exercitava o sistema real; o PR foi reforçado com o stress A ↔ B em PostgreSQL descrito acima.

A branch está sincronizada com a `develop` mais recente: **0 commits atrás**, diff limitado aos 3 arquivos desta task e PR sem conflitos.

Closes #190