### PR TITLE
feat(admin): atualização reativa e invalidação de cache DRE (#182)

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -395,6 +395,8 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
   const [filtrosOpcoes, setFiltrosOpcoes] = useState<FiltrosOpcoes | null>(null);
   const [presentationMode, setPresentationMode] = useState(false);
   const [showMobilePresAlert, setShowMobilePresAlert] = useState(false);
+  const [dataVersion, setDataVersion] = useState(0);
+  const handleDataChanged = useCallback(() => setDataVersion((v) => v + 1), []);
 
   /* const logout = useCallback(() => { clearToken(); clearApiCache(); onLogout(); }, [onLogout]); */
   const logout = useCallback(() => { 
@@ -481,7 +483,7 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
     apiFetch<FiltrosOpcoes>(url, token)
       .then(setFiltrosOpcoes)
       .catch((e) => { if ((e as Error).message === "UNAUTHORIZED") logout(); });
-  }, [filters, token, logout]);
+  }, [filters, token, logout, dataVersion]);
 
 
   async function handleSync() {
@@ -751,7 +753,7 @@ function Dashboard({ token, onLogout }: { token: string; onLogout: () => void })
 
             {profile?.role === "admin" && visited.has("gestao") && (
               <div style={{ display: tab === "gestao" ? undefined : "none" }}>
-                <AbaGestaoDres token={token} onUnauth={logout} />
+                <AbaGestaoDres token={token} onUnauth={logout} onDataChanged={handleDataChanged} />
               </div>
             )}
           </div>

--- a/web/src/components/admin/AbaGestaoDres.tsx
+++ b/web/src/components/admin/AbaGestaoDres.tsx
@@ -42,9 +42,10 @@ import type { DREItem, AdminUserItem } from "./shared/types";
 interface AbaGestaoDresProps {
   token: string;
   onUnauth: () => void;
+  onDataChanged?: () => void;
 }
 
-export function AbaGestaoDres({ token, onUnauth }: AbaGestaoDresProps) {
+export function AbaGestaoDres({ token, onUnauth, onDataChanged }: AbaGestaoDresProps) {
   const [dres, setDres] = useState<DREItem[]>([]);
   const [users, setUsers] = useState<AdminUserItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -231,6 +232,7 @@ export function AbaGestaoDres({ token, onUnauth }: AbaGestaoDresProps) {
         ...dre,
         ativa: nextActive,
       });
+      onDataChanged?.();
       showToast(`Status da ${dre.nome} atualizado para ${nextActive ? "Ativa" : "Inativa"}.`);
     } catch (err: unknown) {
       // Reverter
@@ -253,6 +255,7 @@ export function AbaGestaoDres({ token, onUnauth }: AbaGestaoDresProps) {
 
     try {
       await updateAdminUserStatus(token, user.id, nextActive);
+      onDataChanged?.();
       showToast(`Usuário ${user.username} ${nextActive ? "ativado" : "desativado"} com sucesso.`);
     } catch (err: unknown) {
       // Reverter
@@ -300,18 +303,18 @@ export function AbaGestaoDres({ token, onUnauth }: AbaGestaoDresProps) {
       }
       return [savedDre, ...prev];
     });
+    onDataChanged?.();
     showToast(`DRE "${savedDre.nome}" ${dreToEdit ? "atualizada" : "cadastrada"} com sucesso.`);
   };
 
   const handleUserSuccess = (createdUser: AdminUserItem, pass: string) => {
     setIsUserModalOpen(false);
     setUsers((prev) => [createdUser, ...prev]);
-    // Expandir automaticamente a DRE do usuário criado
     const targetDre = dres.find((d) => d.nome.trim().toLowerCase() === createdUser.dre.trim().toLowerCase());
     if (targetDre) {
       setExpandedDres((prev) => new Set(prev).add(targetDre.id));
     }
-    // Abrir modal de credenciais prontas para cópia segura
+    onDataChanged?.();
     setCredentialsModal({
       isOpen: true,
       title: "Novo Usuário Cadastrado!",

--- a/web/src/components/admin/shared/api.ts
+++ b/web/src/components/admin/shared/api.ts
@@ -162,6 +162,7 @@ export async function prefetchDashboard(token: string, role?: string): Promise<v
 // O formulário usa nomes amigáveis para os dados do responsável; o mapeamento
 // abaixo mantém o contrato HTTP centralizado neste helper.
 export async function createDre(token: string, payload: DreCreatePayload): Promise<DreRecord> {
+  clearApiCache();
   const backendPayload = {
     nome: payload.nome,
     sigla: payload.sigla,

--- a/web/src/components/admin/shared/api.ts
+++ b/web/src/components/admin/shared/api.ts
@@ -52,6 +52,14 @@ export async function apiFetch<T>(path: string, token: string, opts?: RequestIni
   return data;
 }
 
+// Mutations invalidam o cache somente após sucesso. Assim, uma escrita que falha
+// não descarta dados válidos nem força refetch desnecessário no dashboard.
+async function apiMutation<T>(path: string, token: string, opts: RequestInit): Promise<T> {
+  const data = await apiFetch<T>(path, token, opts);
+  clearApiCache();
+  return data;
+}
+
 export async function fetchAdminMe(token: string): Promise<AdminProfile> {
   return apiFetch<AdminProfile>("/v1/admin/me", token);
 }
@@ -61,16 +69,14 @@ export async function fetchDREs(token: string): Promise<DREItem[]> {
 }
 
 export async function createDRE(token: string, payload: Partial<DREItem>): Promise<DREItem> {
-  clearApiCache();
-  return apiFetch<DREItem>("/v1/admin/dres", token, {
+  return apiMutation<DREItem>("/v1/admin/dres", token, {
     method: "POST",
     body: JSON.stringify(payload),
   });
 }
 
 export async function updateDRE(token: string, id: number, payload: Partial<DREItem>): Promise<DREItem> {
-  clearApiCache();
-  return apiFetch<DREItem>(`/v1/admin/dres/${id}`, token, {
+  return apiMutation<DREItem>(`/v1/admin/dres/${id}`, token, {
     method: "PUT",
     body: JSON.stringify(payload),
   });
@@ -84,8 +90,7 @@ export async function createAdminUser(
   token: string,
   payload: { username: string; password: string; role?: string; dre: string }
 ): Promise<AdminUserItem> {
-  clearApiCache();
-  return apiFetch<AdminUserItem>("/v1/admin/users", token, {
+  return apiMutation<AdminUserItem>("/v1/admin/users", token, {
     method: "POST",
     body: JSON.stringify(payload),
   });
@@ -96,8 +101,7 @@ export async function updateAdminUserStatus(
   id: number,
   active: boolean
 ): Promise<AdminUserItem> {
-  clearApiCache();
-  return apiFetch<AdminUserItem>(`/v1/admin/users/${id}/status`, token, {
+  return apiMutation<AdminUserItem>(`/v1/admin/users/${id}/status`, token, {
     method: "PATCH",
     body: JSON.stringify({ active }),
   });
@@ -158,12 +162,10 @@ export async function prefetchDashboard(token: string, role?: string): Promise<v
 
 // ── Escrita: Gestão de DREs ─────────────────────────────────────────────────
 
-// Criação de nova DRE — contrato do backend definido em POST /v1/admin/dres.
-// O formulário usa nomes amigáveis para os dados do responsável; o mapeamento
-// abaixo mantém o contrato HTTP centralizado neste helper.
+// Compatibilidade com o payload legado do modal: mapeia os nomes amigáveis e
+// reutiliza o caminho canônico de criação para manter uma única regra de cache.
 export async function createDre(token: string, payload: DreCreatePayload): Promise<DreRecord> {
-  clearApiCache();
-  const backendPayload = {
+  return createDRE(token, {
     nome: payload.nome,
     sigla: payload.sigla,
     municipio_sede: payload.municipio_sede,
@@ -171,11 +173,6 @@ export async function createDre(token: string, payload: DreCreatePayload): Promi
     gestor_nome: payload.responsavel_nome,
     email: payload.responsavel_email,
     telefone: payload.responsavel_telefone,
-  };
-
-  return apiFetch<DreRecord>("/v1/admin/dres", token, {
-    method: "POST",
-    body: JSON.stringify(backendPayload),
   });
 }
 


### PR DESCRIPTION
## Objetivo
Implementa a atualização reativa dos filtros administrativos após alterações em DREs e usuários, sem necessidade de F5.

Closes #182

## O que foi alterado
- adiciona `dataVersion` no dashboard para disparar novo carregamento de `/v1/admin/analytics/filtros/opcoes` após mutations administrativas;
- notifica o dashboard após criação/edição de DRE, criação de usuário e alterações de status;
- centraliza mutations que afetam dados administrativos em `apiMutation()`;
- invalida o cache **somente depois de uma escrita bem-sucedida**;
- faz o helper legado `createDre()` reutilizar `createDRE()` em vez de manter uma segunda implementação do mesmo POST.

## Por que a revisão adicional é melhor
Antes, os helpers limpavam o cache antes da requisição. Se a escrita falhasse, dados ainda válidos eram descartados e o dashboard poderia fazer refetch desnecessário. Além disso, `createDRE()` e `createDre()` possuíam caminhos separados para criar a mesma entidade, aumentando o risco de comportamento divergente no futuro.

Agora a regra fica centralizada: a mutation executa, o cache só é invalidado após sucesso e, em seguida, `onDataChanged` força os filtros globais a buscar dados novos. Isso mantém o comportamento da task #182, reduz duplicação e torna o fluxo de cache mais previsível.

## Validação
- PR permanece focado em frontend/admin;
- não há alteração no contrato HTTP dos endpoints;
- `dataVersion` só muda após mutations, evitando loop de requests;
- Vercel/build deve validar o commit mais recente antes do merge.