### PR TITLE
feat(dre): relações canônicas por ID e backfill (#204)

### DIFF
--- a/api/cmd/api/dre_canonical_relations_migration_test.go
+++ b/api/cmd/api/dre_canonical_relations_migration_test.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"io/fs"
+	"strings"
+	"testing"
+	"time"
+)
+
+func canonicalMigrationSQL(t *testing.T) string {
+	t.Helper()
+	content, err := fs.ReadFile(migrationsFS, "migrations/0020_dre_canonical_relations.sql")
+	if err != nil {
+		t.Fatalf("read canonical DRE migration: %v", err)
+	}
+	return string(content)
+}
+
+func setupDRECanonicalSchema(t *testing.T) *sql.Tx {
+	t.Helper()
+	db := openDREIntegrationDB(t)
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin canonical migration transaction: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	schema := fmt.Sprintf("dre204_%d", time.Now().UnixNano())
+	if _, err := tx.Exec(`CREATE SCHEMA ` + schema); err != nil {
+		t.Fatalf("create isolated schema: %v", err)
+	}
+	if _, err := tx.Exec(`SET LOCAL search_path TO ` + schema + `, public`); err != nil {
+		t.Fatalf("set isolated search_path: %v", err)
+	}
+	if _, err := tx.Exec(`
+		CREATE TABLE dres (
+			id SERIAL PRIMARY KEY,
+			nome VARCHAR(255) UNIQUE NOT NULL,
+			ativa BOOLEAN NOT NULL DEFAULT true
+		);
+		CREATE TABLE schools (
+			id SERIAL PRIMARY KEY,
+			dre VARCHAR(100)
+		);
+		CREATE TABLE admin_users (
+			id SERIAL PRIMARY KEY,
+			username VARCHAR(64) UNIQUE NOT NULL,
+			password_hash VARCHAR(255) NOT NULL,
+			role VARCHAR(32) NOT NULL,
+			dre VARCHAR(128),
+			active BOOLEAN NOT NULL DEFAULT true
+		);
+	`); err != nil {
+		t.Fatalf("create isolated legacy schema: %v", err)
+	}
+	return tx
+}
+
+func TestDRECanonicalRelationsMigrationBackfillAndCompatibilityBridge(t *testing.T) {
+	tx := setupDRECanonicalSchema(t)
+	if _, err := tx.Exec(`
+		INSERT INTO dres (id, nome) VALUES
+			(10, 'DRE ALPHA'),
+			(20, 'DRE BETA');
+		INSERT INTO schools (id, dre) VALUES
+			(1, '  dre alpha  '),
+			(2, NULL);
+		INSERT INTO admin_users (id, username, password_hash, role, dre) VALUES
+			(1, 'alpha.user', 'hash', 'dre', 'Dre Alpha');
+	`); err != nil {
+		t.Fatalf("seed legacy rows: %v", err)
+	}
+
+	migration := canonicalMigrationSQL(t)
+	if _, err := tx.Exec(migration); err != nil {
+		t.Fatalf("apply canonical migration: %v", err)
+	}
+
+	var schoolDREID int
+	var schoolDRE string
+	if err := tx.QueryRow(`SELECT dre_id, dre FROM schools WHERE id = 1`).Scan(&schoolDREID, &schoolDRE); err != nil {
+		t.Fatalf("read backfilled school: %v", err)
+	}
+	if schoolDREID != 10 || schoolDRE != "DRE ALPHA" {
+		t.Fatalf("school backfill mismatch: dre_id=%d dre=%q", schoolDREID, schoolDRE)
+	}
+
+	var userDREID int
+	var userDRE string
+	if err := tx.QueryRow(`SELECT dre_id, dre FROM admin_users WHERE id = 1`).Scan(&userDREID, &userDRE); err != nil {
+		t.Fatalf("read backfilled user: %v", err)
+	}
+	if userDREID != 10 || userDRE != "DRE ALPHA" {
+		t.Fatalf("user backfill mismatch: dre_id=%d dre=%q", userDREID, userDRE)
+	}
+
+	var insertedID int
+	var insertedName string
+	if err := tx.QueryRow(`INSERT INTO schools (dre) VALUES ('  dre beta ') RETURNING dre_id, dre`).Scan(&insertedID, &insertedName); err != nil {
+		t.Fatalf("legacy school write should resolve canonical DRE: %v", err)
+	}
+	if insertedID != 20 || insertedName != "DRE BETA" {
+		t.Fatalf("legacy school bridge mismatch: id=%d name=%q", insertedID, insertedName)
+	}
+
+	if err := tx.QueryRow(`INSERT INTO admin_users (username, password_hash, role, dre) VALUES ('beta.user', 'hash', 'dre', 'DRE BETA') RETURNING dre_id, dre`).Scan(&insertedID, &insertedName); err != nil {
+		t.Fatalf("legacy admin-user write should resolve canonical DRE: %v", err)
+	}
+	if insertedID != 20 || insertedName != "DRE BETA" {
+		t.Fatalf("legacy user bridge mismatch: id=%d name=%q", insertedID, insertedName)
+	}
+
+	if err := tx.QueryRow(`INSERT INTO schools (dre_id) VALUES (10) RETURNING dre_id, dre`).Scan(&insertedID, &insertedName); err != nil {
+		t.Fatalf("canonical school write should hydrate legacy name: %v", err)
+	}
+	if insertedID != 10 || insertedName != "DRE ALPHA" {
+		t.Fatalf("canonical school bridge mismatch: id=%d name=%q", insertedID, insertedName)
+	}
+}
+
+func TestDRECanonicalRelationsMigrationIdempotentAndIDWinsAfterRename(t *testing.T) {
+	tx := setupDRECanonicalSchema(t)
+	if _, err := tx.Exec(`
+		INSERT INTO dres (id, nome) VALUES (10, 'DRE ALPHA');
+		INSERT INTO schools (id, dre) VALUES (1, 'DRE ALPHA');
+		INSERT INTO admin_users (id, username, password_hash, role, dre)
+		VALUES (1, 'alpha.user', 'hash', 'dre', 'DRE ALPHA');
+	`); err != nil {
+		t.Fatalf("seed rows: %v", err)
+	}
+	migration := canonicalMigrationSQL(t)
+	if _, err := tx.Exec(migration); err != nil {
+		t.Fatalf("first migration: %v", err)
+	}
+	if _, err := tx.Exec(`UPDATE dres SET nome = 'DRE ALPHA RENAMED' WHERE id = 10`); err != nil {
+		t.Fatalf("rename master DRE: %v", err)
+	}
+	if _, err := tx.Exec(migration); err != nil {
+		t.Fatalf("reapply canonical migration: %v", err)
+	}
+
+	var schoolDREID int
+	var schoolDRE string
+	if err := tx.QueryRow(`SELECT dre_id, dre FROM schools WHERE id = 1`).Scan(&schoolDREID, &schoolDRE); err != nil {
+		t.Fatalf("read school after migration reexecution: %v", err)
+	}
+	if schoolDREID != 10 || schoolDRE != "DRE ALPHA RENAMED" {
+		t.Fatalf("reexecution did not honor canonical ID: id=%d name=%q", schoolDREID, schoolDRE)
+	}
+
+	var userDREID int
+	var userDRE string
+	if err := tx.QueryRow(`SELECT dre_id, dre FROM admin_users WHERE id = 1`).Scan(&userDREID, &userDRE); err != nil {
+		t.Fatalf("read user after migration reexecution: %v", err)
+	}
+	if userDREID != 10 || userDRE != "DRE ALPHA RENAMED" {
+		t.Fatalf("user reexecution did not honor canonical ID: id=%d name=%q", userDREID, userDRE)
+	}
+}
+
+func TestDRECanonicalRelationsMigrationRejectsInvalidWrites(t *testing.T) {
+	tx := setupDRECanonicalSchema(t)
+	if _, err := tx.Exec(`INSERT INTO dres (id, nome) VALUES (10, 'DRE ALPHA')`); err != nil {
+		t.Fatalf("seed DRE: %v", err)
+	}
+	if _, err := tx.Exec(canonicalMigrationSQL(t)); err != nil {
+		t.Fatalf("apply migration: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{name: "invalid school dre_id", sql: `INSERT INTO schools (dre_id) VALUES (999999)`},
+		{name: "unmapped textual school DRE", sql: `INSERT INTO schools (dre) VALUES ('DRE FANTASMA')`},
+		{name: "DRE user without relation", sql: `INSERT INTO admin_users (username, password_hash, role) VALUES ('missing.dre', 'hash', 'dre')`},
+		{name: "DRE user with invalid dre_id", sql: `INSERT INTO admin_users (username, password_hash, role, dre_id) VALUES ('invalid.id', 'hash', 'dre', 999999)`},
+	}
+	for i, tc := range cases {
+		sp := fmt.Sprintf("case_%d", i)
+		if _, err := tx.Exec(`SAVEPOINT ` + sp); err != nil {
+			t.Fatalf("%s: create savepoint: %v", tc.name, err)
+		}
+		if _, err := tx.Exec(tc.sql); err == nil {
+			t.Fatalf("%s: invalid write was accepted", tc.name)
+		}
+		if _, err := tx.Exec(`ROLLBACK TO SAVEPOINT ` + sp); err != nil {
+			t.Fatalf("%s: rollback savepoint: %v", tc.name, err)
+		}
+		if _, err := tx.Exec(`RELEASE SAVEPOINT ` + sp); err != nil {
+			t.Fatalf("%s: release savepoint: %v", tc.name, err)
+		}
+	}
+}
+
+func TestDRECanonicalRelationsMigrationRejectsAmbiguousLegacyNames(t *testing.T) {
+	tx := setupDRECanonicalSchema(t)
+	if _, err := tx.Exec(`
+		INSERT INTO dres (nome) VALUES ('DRE BELEM'), ('  dre belem  ');
+		INSERT INTO schools (dre) VALUES ('DRE BELEM');
+	`); err != nil {
+		t.Fatalf("seed ambiguous DREs: %v", err)
+	}
+	if _, err := tx.Exec(canonicalMigrationSQL(t)); err == nil || !strings.Contains(err.Error(), "ambiguous normalized DRE names") {
+		t.Fatalf("expected explicit ambiguity failure, got %v", err)
+	}
+}
+
+func TestDRECanonicalRelationsMigrationRejectsUnmappedLegacyData(t *testing.T) {
+	tx := setupDRECanonicalSchema(t)
+	if _, err := tx.Exec(`
+		INSERT INTO dres (nome) VALUES ('DRE EXISTENTE');
+		INSERT INTO schools (dre) VALUES ('DRE FANTASMA');
+	`); err != nil {
+		t.Fatalf("seed unmapped school: %v", err)
+	}
+	if _, err := tx.Exec(canonicalMigrationSQL(t)); err == nil || !strings.Contains(err.Error(), "unmapped school DRE") {
+		t.Fatalf("expected explicit unmapped-data failure, got %v", err)
+	}
+}
+
+func TestDRECanonicalRelationsMigrationStress30000Relations(t *testing.T) {
+	tx := setupDRECanonicalSchema(t)
+	if _, err := tx.Exec(`
+		INSERT INTO dres (id, nome)
+		SELECT g, 'DRE ' || LPAD(g::text, 3, '0')
+		FROM generate_series(1, 64) AS g;
+
+		INSERT INTO schools (dre)
+		SELECT CASE
+			WHEN g % 2 = 0 THEN LOWER('DRE ' || LPAD(((g % 64) + 1)::text, 3, '0'))
+			ELSE '  ' || ('DRE ' || LPAD(((g % 64) + 1)::text, 3, '0')) || '  '
+		END
+		FROM generate_series(1, 12000) AS g;
+
+		INSERT INTO admin_users (username, password_hash, role, dre)
+		SELECT 'legacy.user.' || g, 'hash', 'dre',
+			CASE
+				WHEN g % 2 = 0 THEN LOWER('DRE ' || LPAD(((g % 64) + 1)::text, 3, '0'))
+				ELSE ' ' || ('DRE ' || LPAD(((g % 64) + 1)::text, 3, '0')) || ' '
+			END
+		FROM generate_series(1, 8000) AS g;
+	`); err != nil {
+		t.Fatalf("seed stress legacy relations: %v", err)
+	}
+
+	migration := canonicalMigrationSQL(t)
+	if _, err := tx.Exec(migration); err != nil {
+		t.Fatalf("apply migration over 20000 legacy relations: %v", err)
+	}
+
+	// Mais 10 mil writes depois da migration exercitam os triggers de compatibilidade.
+	if _, err := tx.Exec(`
+		INSERT INTO schools (dre)
+		SELECT LOWER('DRE ' || LPAD(((g % 64) + 1)::text, 3, '0'))
+		FROM generate_series(1, 5000) AS g;
+
+		INSERT INTO admin_users (username, password_hash, role, dre)
+		SELECT 'bridge.user.' || g, 'hash', 'dre', 'DRE ' || LPAD(((g % 64) + 1)::text, 3, '0')
+		FROM generate_series(1, 5000) AS g;
+	`); err != nil {
+		t.Fatalf("exercise compatibility bridge: %v", err)
+	}
+
+	var broken int
+	if err := tx.QueryRow(`
+		SELECT COUNT(*)
+		FROM schools s
+		LEFT JOIN dres d ON d.id = s.dre_id
+		WHERE s.dre_id IS NULL OR d.id IS NULL OR s.dre IS DISTINCT FROM d.nome
+	`).Scan(&broken); err != nil {
+		t.Fatalf("count broken school relations: %v", err)
+	}
+	if broken != 0 {
+		t.Fatalf("found %d broken school canonical relations", broken)
+	}
+
+	if err := tx.QueryRow(`
+		SELECT COUNT(*)
+		FROM admin_users u
+		LEFT JOIN dres d ON d.id = u.dre_id
+		WHERE u.role = 'dre' AND (u.dre_id IS NULL OR d.id IS NULL OR u.dre IS DISTINCT FROM d.nome)
+	`).Scan(&broken); err != nil {
+		t.Fatalf("count broken user relations: %v", err)
+	}
+	if broken != 0 {
+		t.Fatalf("found %d broken user canonical relations", broken)
+	}
+
+	if _, err := tx.Exec(migration); err != nil {
+		t.Fatalf("stress migration must remain idempotent: %v", err)
+	}
+}

--- a/api/cmd/api/dre_canonical_relations_migration_test.go
+++ b/api/cmd/api/dre_canonical_relations_migration_test.go
@@ -64,11 +64,11 @@ func TestDRECanonicalRelationsMigrationBackfillAndCompatibilityBridge(t *testing
 		INSERT INTO dres (id, nome) VALUES
 			(10, 'DRE ALPHA'),
 			(20, 'DRE BETA');
-		INSERT INTO schools (id, dre) VALUES
-			(1, '  dre alpha  '),
-			(2, NULL);
-		INSERT INTO admin_users (id, username, password_hash, role, dre) VALUES
-			(1, 'alpha.user', 'hash', 'dre', 'Dre Alpha');
+		INSERT INTO schools (dre) VALUES
+			('  dre alpha  '),
+			(NULL);
+		INSERT INTO admin_users (username, password_hash, role, dre) VALUES
+			('alpha.user', 'hash', 'dre', 'Dre Alpha');
 	`); err != nil {
 		t.Fatalf("seed legacy rows: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestDRECanonicalRelationsMigrationBackfillAndCompatibilityBridge(t *testing
 
 	var schoolDREID int
 	var schoolDRE string
-	if err := tx.QueryRow(`SELECT dre_id, dre FROM schools WHERE id = 1`).Scan(&schoolDREID, &schoolDRE); err != nil {
+	if err := tx.QueryRow(`SELECT dre_id, dre FROM schools WHERE dre_id = 10 LIMIT 1`).Scan(&schoolDREID, &schoolDRE); err != nil {
 		t.Fatalf("read backfilled school: %v", err)
 	}
 	if schoolDREID != 10 || schoolDRE != "DRE ALPHA" {
@@ -89,7 +89,7 @@ func TestDRECanonicalRelationsMigrationBackfillAndCompatibilityBridge(t *testing
 
 	var userDREID int
 	var userDRE string
-	if err := tx.QueryRow(`SELECT dre_id, dre FROM admin_users WHERE id = 1`).Scan(&userDREID, &userDRE); err != nil {
+	if err := tx.QueryRow(`SELECT dre_id, dre FROM admin_users WHERE username = 'alpha.user'`).Scan(&userDREID, &userDRE); err != nil {
 		t.Fatalf("read backfilled user: %v", err)
 	}
 	if userDREID != 10 || userDRE != "DRE ALPHA" {
@@ -124,9 +124,9 @@ func TestDRECanonicalRelationsMigrationIdempotentAndIDWinsAfterRename(t *testing
 	tx := setupDRECanonicalSchema(t)
 	if _, err := tx.Exec(`
 		INSERT INTO dres (id, nome) VALUES (10, 'DRE ALPHA');
-		INSERT INTO schools (id, dre) VALUES (1, 'DRE ALPHA');
-		INSERT INTO admin_users (id, username, password_hash, role, dre)
-		VALUES (1, 'alpha.user', 'hash', 'dre', 'DRE ALPHA');
+		INSERT INTO schools (dre) VALUES ('DRE ALPHA');
+		INSERT INTO admin_users (username, password_hash, role, dre)
+		VALUES ('alpha.user', 'hash', 'dre', 'DRE ALPHA');
 	`); err != nil {
 		t.Fatalf("seed rows: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestDRECanonicalRelationsMigrationIdempotentAndIDWinsAfterRename(t *testing
 
 	var schoolDREID int
 	var schoolDRE string
-	if err := tx.QueryRow(`SELECT dre_id, dre FROM schools WHERE id = 1`).Scan(&schoolDREID, &schoolDRE); err != nil {
+	if err := tx.QueryRow(`SELECT dre_id, dre FROM schools WHERE dre_id = 10 LIMIT 1`).Scan(&schoolDREID, &schoolDRE); err != nil {
 		t.Fatalf("read school after migration reexecution: %v", err)
 	}
 	if schoolDREID != 10 || schoolDRE != "DRE ALPHA RENAMED" {
@@ -152,7 +152,7 @@ func TestDRECanonicalRelationsMigrationIdempotentAndIDWinsAfterRename(t *testing
 
 	var userDREID int
 	var userDRE string
-	if err := tx.QueryRow(`SELECT dre_id, dre FROM admin_users WHERE id = 1`).Scan(&userDREID, &userDRE); err != nil {
+	if err := tx.QueryRow(`SELECT dre_id, dre FROM admin_users WHERE username = 'alpha.user'`).Scan(&userDREID, &userDRE); err != nil {
 		t.Fatalf("read user after migration reexecution: %v", err)
 	}
 	if userDREID != 10 || userDRE != "DRE ALPHA RENAMED" {

--- a/api/cmd/api/migrations/0020_dre_canonical_relations.sql
+++ b/api/cmd/api/migrations/0020_dre_canonical_relations.sql
@@ -1,0 +1,295 @@
+-- 0020_dre_canonical_relations.sql
+-- Introduz relacoes canonicas por ID entre DREs, usuarios administrativos e escolas.
+-- As colunas textuais `dre` permanecem temporariamente por compatibilidade, mas deixam
+-- de ser a fonte de verdade. Triggers de compatibilidade mantem writes legados
+-- sincronizados ate que os handlers sejam migrados integralmente para `dre_id`.
+
+-- `dres.nome` suporta 255 caracteres. As colunas legadas precisam comportar o nome
+-- canonico inteiro enquanto existirem como camada de compatibilidade.
+ALTER TABLE schools
+    ALTER COLUMN dre TYPE VARCHAR(255);
+
+ALTER TABLE admin_users
+    ALTER COLUMN dre TYPE VARCHAR(255);
+
+ALTER TABLE schools
+    ADD COLUMN IF NOT EXISTS dre_id INTEGER;
+
+ALTER TABLE admin_users
+    ADD COLUMN IF NOT EXISTS dre_id INTEGER;
+
+-- Nunca escolher uma DRE arbitrariamente quando nomes diferem apenas por caixa/espacos.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM dres
+        GROUP BY UPPER(BTRIM(nome))
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: ambiguous normalized DRE names exist';
+    END IF;
+END
+$$;
+
+-- Se uma execucao anterior/parcial ja deixou IDs preenchidos, eles precisam apontar
+-- para uma entidade mestre real antes de qualquer reconciliacao textual.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM schools s
+        LEFT JOIN dres d ON d.id = s.dre_id
+        WHERE s.dre_id IS NOT NULL AND d.id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: schools contains invalid dre_id';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM admin_users u
+        LEFT JOIN dres d ON d.id = u.dre_id
+        WHERE u.dre_id IS NOT NULL AND d.id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: admin_users contains invalid dre_id';
+    END IF;
+END
+$$;
+
+-- Quando dre_id ja existe, ele e a fonte de verdade. Isso torna a migration segura
+-- para reexecucao inclusive apos rename da DRE: o texto legado acompanha o ID.
+UPDATE schools s
+SET dre = d.nome
+FROM dres d
+WHERE s.dre_id = d.id
+  AND s.dre IS DISTINCT FROM d.nome;
+
+UPDATE admin_users u
+SET dre = d.nome
+FROM dres d
+WHERE u.dre_id = d.id
+  AND u.dre IS DISTINCT FROM d.nome;
+
+-- Backfill somente de registros ainda sem ID, usando comparacao tolerante a caixa e
+-- espacos. A verificacao de ambiguidade acima garante correspondencia deterministica.
+UPDATE schools s
+SET dre_id = d.id,
+    dre = d.nome
+FROM dres d
+WHERE s.dre_id IS NULL
+  AND BTRIM(COALESCE(s.dre, '')) <> ''
+  AND UPPER(BTRIM(s.dre)) = UPPER(BTRIM(d.nome));
+
+UPDATE admin_users u
+SET dre_id = d.id,
+    dre = d.nome
+FROM dres d
+WHERE u.dre_id IS NULL
+  AND BTRIM(COALESCE(u.dre, '')) <> ''
+  AND UPPER(BTRIM(u.dre)) = UPPER(BTRIM(d.nome));
+
+-- Dados legados nao reconciliaveis devem interromper a migration de forma explicita.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM schools
+        WHERE dre_id IS NULL
+          AND BTRIM(COALESCE(dre, '')) <> ''
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: unmapped school DRE values exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM admin_users
+        WHERE role = 'dre'
+          AND dre_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: unmapped DRE users exist';
+    END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_schools_dre_id ON schools(dre_id);
+CREATE INDEX IF NOT EXISTS idx_admin_users_dre_id ON admin_users(dre_id);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_schools_dre_id'
+          AND conrelid = 'schools'::regclass
+    ) THEN
+        ALTER TABLE schools
+            ADD CONSTRAINT fk_schools_dre_id
+            FOREIGN KEY (dre_id) REFERENCES dres(id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_admin_users_dre_id'
+          AND conrelid = 'admin_users'::regclass
+    ) THEN
+        ALTER TABLE admin_users
+            ADD CONSTRAINT fk_admin_users_dre_id
+            FOREIGN KEY (dre_id) REFERENCES dres(id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_schools_dre_canonical'
+          AND conrelid = 'schools'::regclass
+    ) THEN
+        ALTER TABLE schools
+            ADD CONSTRAINT chk_schools_dre_canonical
+            CHECK (dre_id IS NOT NULL OR dre IS NULL OR BTRIM(dre) = '');
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_admin_users_role_dre_id'
+          AND conrelid = 'admin_users'::regclass
+    ) THEN
+        ALTER TABLE admin_users
+            ADD CONSTRAINT chk_admin_users_role_dre_id
+            CHECK (role <> 'dre' OR dre_id IS NOT NULL);
+    END IF;
+END
+$$;
+
+-- Bridge temporaria para codigo legado que ainda escreve `dre` textual.
+CREATE OR REPLACE FUNCTION sync_school_dre_relation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    canonical_id INTEGER;
+    canonical_name TEXT;
+BEGIN
+    IF NEW.dre_id IS NOT NULL THEN
+        BEGIN
+            SELECT id, nome
+            INTO STRICT canonical_id, canonical_name
+            FROM dres
+            WHERE id = NEW.dre_id;
+        EXCEPTION
+            WHEN NO_DATA_FOUND THEN
+                RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id
+                    USING ERRCODE = '23503';
+        END;
+
+        NEW.dre_id := canonical_id;
+        NEW.dre := canonical_name;
+        RETURN NEW;
+    END IF;
+
+    IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
+        NEW.dre_id := NULL;
+        NEW.dre := NULL;
+        RETURN NEW;
+    END IF;
+
+    BEGIN
+        SELECT id, nome
+        INTO STRICT canonical_id, canonical_name
+        FROM dres
+        WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre
+                USING ERRCODE = '23503';
+        WHEN TOO_MANY_ROWS THEN
+            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre
+                USING ERRCODE = '23505';
+    END;
+
+    NEW.dre_id := canonical_id;
+    NEW.dre := canonical_name;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION sync_admin_user_dre_relation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    canonical_id INTEGER;
+    canonical_name TEXT;
+BEGIN
+    IF NEW.role <> 'dre'
+       AND NEW.dre_id IS NULL
+       AND BTRIM(COALESCE(NEW.dre, '')) = '' THEN
+        NEW.dre := NULL;
+        RETURN NEW;
+    END IF;
+
+    IF NEW.dre_id IS NOT NULL THEN
+        BEGIN
+            SELECT id, nome
+            INTO STRICT canonical_id, canonical_name
+            FROM dres
+            WHERE id = NEW.dre_id;
+        EXCEPTION
+            WHEN NO_DATA_FOUND THEN
+                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id
+                    USING ERRCODE = '23503';
+        END;
+
+        NEW.dre_id := canonical_id;
+        NEW.dre := canonical_name;
+        RETURN NEW;
+    END IF;
+
+    IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
+        IF NEW.role = 'dre' THEN
+            RAISE EXCEPTION 'DRE user requires a canonical DRE'
+                USING ERRCODE = '23514';
+        END IF;
+        NEW.dre := NULL;
+        RETURN NEW;
+    END IF;
+
+    BEGIN
+        SELECT id, nome
+        INTO STRICT canonical_id, canonical_name
+        FROM dres
+        WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre
+                USING ERRCODE = '23503';
+        WHEN TOO_MANY_ROWS THEN
+            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre
+                USING ERRCODE = '23505';
+    END;
+
+    NEW.dre_id := canonical_id;
+    NEW.dre := canonical_name;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS trg_schools_sync_dre_relation ON schools;
+CREATE TRIGGER trg_schools_sync_dre_relation
+BEFORE INSERT OR UPDATE OF dre, dre_id ON schools
+FOR EACH ROW
+EXECUTE FUNCTION sync_school_dre_relation();
+
+DROP TRIGGER IF EXISTS trg_admin_users_sync_dre_relation ON admin_users;
+CREATE TRIGGER trg_admin_users_sync_dre_relation
+BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users
+FOR EACH ROW
+EXECUTE FUNCTION sync_admin_user_dre_relation();
+
+COMMENT ON COLUMN schools.dre_id IS
+    'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';
+COMMENT ON COLUMN admin_users.dre_id IS
+    'Referencia canonica para dres.id. admin_users.dre e compatibilidade temporaria.';

--- a/api/cmd/api/migrations/0020_dre_canonical_relations.sql
+++ b/api/cmd/api/migrations/0020_dre_canonical_relations.sql
@@ -5,12 +5,36 @@
 -- sincronizados ate que os handlers sejam migrados integralmente para `dre_id`.
 
 -- `dres.nome` suporta 255 caracteres. As colunas legadas precisam comportar o nome
--- canonico inteiro enquanto existirem como camada de compatibilidade.
-ALTER TABLE schools
-    ALTER COLUMN dre TYPE VARCHAR(255);
+-- canonico inteiro enquanto existirem como camada de compatibilidade. A alteracao e
+-- condicional para que a migration possa ser reexecutada depois da criacao dos triggers.
+DO $$
+DECLARE
+    schools_dre_length INTEGER;
+    admin_users_dre_length INTEGER;
+BEGIN
+    SELECT character_maximum_length
+    INTO schools_dre_length
+    FROM information_schema.columns
+    WHERE table_schema = CURRENT_SCHEMA()
+      AND table_name = 'schools'
+      AND column_name = 'dre';
 
-ALTER TABLE admin_users
-    ALTER COLUMN dre TYPE VARCHAR(255);
+    IF schools_dre_length IS NOT NULL AND schools_dre_length < 255 THEN
+        ALTER TABLE schools ALTER COLUMN dre TYPE VARCHAR(255);
+    END IF;
+
+    SELECT character_maximum_length
+    INTO admin_users_dre_length
+    FROM information_schema.columns
+    WHERE table_schema = CURRENT_SCHEMA()
+      AND table_name = 'admin_users'
+      AND column_name = 'dre';
+
+    IF admin_users_dre_length IS NOT NULL AND admin_users_dre_length < 255 THEN
+        ALTER TABLE admin_users ALTER COLUMN dre TYPE VARCHAR(255);
+    END IF;
+END
+$$;
 
 ALTER TABLE schools
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;

--- a/docs/dashboard/dre-canonical-relations.md
+++ b/docs/dashboard/dre-canonical-relations.md
@@ -1,0 +1,60 @@
+# Relações canônicas de DRE por ID (#204)
+
+## Fonte de verdade
+
+A partir da migration `0020_dre_canonical_relations.sql`, `dres.id` é a identidade canônica de uma DRE.
+
+- `schools.dre_id -> dres.id`
+- `admin_users.dre_id -> dres.id`
+
+As colunas textuais `schools.dre` e `admin_users.dre` permanecem temporariamente para compatibilidade com handlers, analytics e relatórios que ainda não foram migrados. Elas não devem ser usadas para criar novas relações lógicas.
+
+## Backfill
+
+A migration resolve registros legados comparando `TRIM` + caixa ignorada, mas somente quando existe uma correspondência única na tabela mestre `dres`.
+
+A migration falha explicitamente quando:
+
+- existem duas DREs equivalentes após normalização de caixa/espaços;
+- existe `dre_id` preenchido apontando para DRE inexistente;
+- uma escola possui DRE textual não reconciliável;
+- um usuário `role=dre` não pode ser associado a uma DRE mestre.
+
+Nenhum registro é associado arbitrariamente.
+
+## Compatibilidade transitória
+
+Triggers `BEFORE INSERT/UPDATE` mantêm os dois formatos sincronizados durante a transição:
+
+- write legado com `dre` textual resolve `dre_id` e normaliza o nome;
+- write novo com `dre_id` resolve o nome textual canônico;
+- referência inválida é rejeitada pelo trigger/FK.
+
+Essa bridge existe para permitir que #204 seja integrada sem exigir que #205/#207 alterem todos os consumidores no mesmo PR.
+
+## Rename
+
+O relacionamento não quebra quando `dres.nome` muda porque o vínculo persistente é `dre_id`. A migration é idempotente e, quando reexecutada, realinha o texto legado a partir do ID canônico.
+
+A atualização transacional do texto legado no momento do rename pertence à #205. A remoção das dependências textuais de filtros/analytics pertence à #207.
+
+## Limites desta task
+
+#204 não:
+
+- remove o fallback legado de `ValidateDRE` — #205;
+- implementa revogação runtime de JWT — #206;
+- migra filtros/analytics para `dre_id` — #207;
+- cria unicidade case-insensitive permanente — #208.
+
+## Rollback
+
+Enquanto consumidores legados ainda dependerem das colunas textuais, um rollback deve ocorrer em ordem inversa:
+
+1. interromper writes que usem apenas `dre_id`;
+2. garantir que `dre` textual esteja preenchido a partir de `dres.nome`;
+3. remover triggers de compatibilidade;
+4. remover constraints/FKs e índices de `dre_id`;
+5. remover `dre_id` somente após confirmar que nenhum consumidor depende dele.
+
+Não remover `dre_id` após #205/#207 sem uma migration de rollback específica.

--- a/infra/migrations/0020_dre_canonical_relations.sql
+++ b/infra/migrations/0020_dre_canonical_relations.sql
@@ -1,0 +1,295 @@
+-- 0020_dre_canonical_relations.sql
+-- Introduz relacoes canonicas por ID entre DREs, usuarios administrativos e escolas.
+-- As colunas textuais `dre` permanecem temporariamente por compatibilidade, mas deixam
+-- de ser a fonte de verdade. Triggers de compatibilidade mantem writes legados
+-- sincronizados ate que os handlers sejam migrados integralmente para `dre_id`.
+
+-- `dres.nome` suporta 255 caracteres. As colunas legadas precisam comportar o nome
+-- canonico inteiro enquanto existirem como camada de compatibilidade.
+ALTER TABLE schools
+    ALTER COLUMN dre TYPE VARCHAR(255);
+
+ALTER TABLE admin_users
+    ALTER COLUMN dre TYPE VARCHAR(255);
+
+ALTER TABLE schools
+    ADD COLUMN IF NOT EXISTS dre_id INTEGER;
+
+ALTER TABLE admin_users
+    ADD COLUMN IF NOT EXISTS dre_id INTEGER;
+
+-- Nunca escolher uma DRE arbitrariamente quando nomes diferem apenas por caixa/espacos.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM dres
+        GROUP BY UPPER(BTRIM(nome))
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: ambiguous normalized DRE names exist';
+    END IF;
+END
+$$;
+
+-- Se uma execucao anterior/parcial ja deixou IDs preenchidos, eles precisam apontar
+-- para uma entidade mestre real antes de qualquer reconciliacao textual.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM schools s
+        LEFT JOIN dres d ON d.id = s.dre_id
+        WHERE s.dre_id IS NOT NULL AND d.id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: schools contains invalid dre_id';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM admin_users u
+        LEFT JOIN dres d ON d.id = u.dre_id
+        WHERE u.dre_id IS NOT NULL AND d.id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: admin_users contains invalid dre_id';
+    END IF;
+END
+$$;
+
+-- Quando dre_id ja existe, ele e a fonte de verdade. Isso torna a migration segura
+-- para reexecucao inclusive apos rename da DRE: o texto legado acompanha o ID.
+UPDATE schools s
+SET dre = d.nome
+FROM dres d
+WHERE s.dre_id = d.id
+  AND s.dre IS DISTINCT FROM d.nome;
+
+UPDATE admin_users u
+SET dre = d.nome
+FROM dres d
+WHERE u.dre_id = d.id
+  AND u.dre IS DISTINCT FROM d.nome;
+
+-- Backfill somente de registros ainda sem ID, usando comparacao tolerante a caixa e
+-- espacos. A verificacao de ambiguidade acima garante correspondencia deterministica.
+UPDATE schools s
+SET dre_id = d.id,
+    dre = d.nome
+FROM dres d
+WHERE s.dre_id IS NULL
+  AND BTRIM(COALESCE(s.dre, '')) <> ''
+  AND UPPER(BTRIM(s.dre)) = UPPER(BTRIM(d.nome));
+
+UPDATE admin_users u
+SET dre_id = d.id,
+    dre = d.nome
+FROM dres d
+WHERE u.dre_id IS NULL
+  AND BTRIM(COALESCE(u.dre, '')) <> ''
+  AND UPPER(BTRIM(u.dre)) = UPPER(BTRIM(d.nome));
+
+-- Dados legados nao reconciliaveis devem interromper a migration de forma explicita.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM schools
+        WHERE dre_id IS NULL
+          AND BTRIM(COALESCE(dre, '')) <> ''
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: unmapped school DRE values exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM admin_users
+        WHERE role = 'dre'
+          AND dre_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'dre canonical backfill aborted: unmapped DRE users exist';
+    END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_schools_dre_id ON schools(dre_id);
+CREATE INDEX IF NOT EXISTS idx_admin_users_dre_id ON admin_users(dre_id);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_schools_dre_id'
+          AND conrelid = 'schools'::regclass
+    ) THEN
+        ALTER TABLE schools
+            ADD CONSTRAINT fk_schools_dre_id
+            FOREIGN KEY (dre_id) REFERENCES dres(id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_admin_users_dre_id'
+          AND conrelid = 'admin_users'::regclass
+    ) THEN
+        ALTER TABLE admin_users
+            ADD CONSTRAINT fk_admin_users_dre_id
+            FOREIGN KEY (dre_id) REFERENCES dres(id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_schools_dre_canonical'
+          AND conrelid = 'schools'::regclass
+    ) THEN
+        ALTER TABLE schools
+            ADD CONSTRAINT chk_schools_dre_canonical
+            CHECK (dre_id IS NOT NULL OR dre IS NULL OR BTRIM(dre) = '');
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_admin_users_role_dre_id'
+          AND conrelid = 'admin_users'::regclass
+    ) THEN
+        ALTER TABLE admin_users
+            ADD CONSTRAINT chk_admin_users_role_dre_id
+            CHECK (role <> 'dre' OR dre_id IS NOT NULL);
+    END IF;
+END
+$$;
+
+-- Bridge temporaria para codigo legado que ainda escreve `dre` textual.
+CREATE OR REPLACE FUNCTION sync_school_dre_relation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    canonical_id INTEGER;
+    canonical_name TEXT;
+BEGIN
+    IF NEW.dre_id IS NOT NULL THEN
+        BEGIN
+            SELECT id, nome
+            INTO STRICT canonical_id, canonical_name
+            FROM dres
+            WHERE id = NEW.dre_id;
+        EXCEPTION
+            WHEN NO_DATA_FOUND THEN
+                RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id
+                    USING ERRCODE = '23503';
+        END;
+
+        NEW.dre_id := canonical_id;
+        NEW.dre := canonical_name;
+        RETURN NEW;
+    END IF;
+
+    IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
+        NEW.dre_id := NULL;
+        NEW.dre := NULL;
+        RETURN NEW;
+    END IF;
+
+    BEGIN
+        SELECT id, nome
+        INTO STRICT canonical_id, canonical_name
+        FROM dres
+        WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre
+                USING ERRCODE = '23503';
+        WHEN TOO_MANY_ROWS THEN
+            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre
+                USING ERRCODE = '23505';
+    END;
+
+    NEW.dre_id := canonical_id;
+    NEW.dre := canonical_name;
+    RETURN NEW;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION sync_admin_user_dre_relation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    canonical_id INTEGER;
+    canonical_name TEXT;
+BEGIN
+    IF NEW.role <> 'dre'
+       AND NEW.dre_id IS NULL
+       AND BTRIM(COALESCE(NEW.dre, '')) = '' THEN
+        NEW.dre := NULL;
+        RETURN NEW;
+    END IF;
+
+    IF NEW.dre_id IS NOT NULL THEN
+        BEGIN
+            SELECT id, nome
+            INTO STRICT canonical_id, canonical_name
+            FROM dres
+            WHERE id = NEW.dre_id;
+        EXCEPTION
+            WHEN NO_DATA_FOUND THEN
+                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id
+                    USING ERRCODE = '23503';
+        END;
+
+        NEW.dre_id := canonical_id;
+        NEW.dre := canonical_name;
+        RETURN NEW;
+    END IF;
+
+    IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
+        IF NEW.role = 'dre' THEN
+            RAISE EXCEPTION 'DRE user requires a canonical DRE'
+                USING ERRCODE = '23514';
+        END IF;
+        NEW.dre := NULL;
+        RETURN NEW;
+    END IF;
+
+    BEGIN
+        SELECT id, nome
+        INTO STRICT canonical_id, canonical_name
+        FROM dres
+        WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre
+                USING ERRCODE = '23503';
+        WHEN TOO_MANY_ROWS THEN
+            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre
+                USING ERRCODE = '23505';
+    END;
+
+    NEW.dre_id := canonical_id;
+    NEW.dre := canonical_name;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS trg_schools_sync_dre_relation ON schools;
+CREATE TRIGGER trg_schools_sync_dre_relation
+BEFORE INSERT OR UPDATE OF dre, dre_id ON schools
+FOR EACH ROW
+EXECUTE FUNCTION sync_school_dre_relation();
+
+DROP TRIGGER IF EXISTS trg_admin_users_sync_dre_relation ON admin_users;
+CREATE TRIGGER trg_admin_users_sync_dre_relation
+BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users
+FOR EACH ROW
+EXECUTE FUNCTION sync_admin_user_dre_relation();
+
+COMMENT ON COLUMN schools.dre_id IS
+    'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';
+COMMENT ON COLUMN admin_users.dre_id IS
+    'Referencia canonica para dres.id. admin_users.dre e compatibilidade temporaria.';

--- a/infra/migrations/0020_dre_canonical_relations.sql
+++ b/infra/migrations/0020_dre_canonical_relations.sql
@@ -5,12 +5,36 @@
 -- sincronizados ate que os handlers sejam migrados integralmente para `dre_id`.
 
 -- `dres.nome` suporta 255 caracteres. As colunas legadas precisam comportar o nome
--- canonico inteiro enquanto existirem como camada de compatibilidade.
-ALTER TABLE schools
-    ALTER COLUMN dre TYPE VARCHAR(255);
+-- canonico inteiro enquanto existirem como camada de compatibilidade. A alteracao e
+-- condicional para que a migration possa ser reexecutada depois da criacao dos triggers.
+DO $$
+DECLARE
+    schools_dre_length INTEGER;
+    admin_users_dre_length INTEGER;
+BEGIN
+    SELECT character_maximum_length
+    INTO schools_dre_length
+    FROM information_schema.columns
+    WHERE table_schema = CURRENT_SCHEMA()
+      AND table_name = 'schools'
+      AND column_name = 'dre';
 
-ALTER TABLE admin_users
-    ALTER COLUMN dre TYPE VARCHAR(255);
+    IF schools_dre_length IS NOT NULL AND schools_dre_length < 255 THEN
+        ALTER TABLE schools ALTER COLUMN dre TYPE VARCHAR(255);
+    END IF;
+
+    SELECT character_maximum_length
+    INTO admin_users_dre_length
+    FROM information_schema.columns
+    WHERE table_schema = CURRENT_SCHEMA()
+      AND table_name = 'admin_users'
+      AND column_name = 'dre';
+
+    IF admin_users_dre_length IS NOT NULL AND admin_users_dre_length < 255 THEN
+        ALTER TABLE admin_users ALTER COLUMN dre TYPE VARCHAR(255);
+    END IF;
+END
+$$;
 
 ALTER TABLE schools
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;


### PR DESCRIPTION
## Objetivo
Implementa a #204 tornando `dres.id` a identidade canônica dos vínculos de DRE sem quebrar os consumidores legados durante a transição.

Closes #204
Parent epic: #203

## O que mudou
- adiciona `schools.dre_id -> dres.id`;
- adiciona `admin_users.dre_id -> dres.id`;
- cria índices e FKs com `ON DELETE/UPDATE RESTRICT`;
- faz backfill determinístico usando nome normalizado apenas quando existe correspondência única;
- aborta migration em dados ambíguos, `dre_id` inválido ou DRE textual não reconciliável;
- mantém `schools.dre` / `admin_users.dre` somente como compatibilidade temporária;
- adiciona triggers para converter writes textuais legados em relações canônicas e hidratar o nome quando o write usa `dre_id`;
- amplia as colunas textuais de compatibilidade para `VARCHAR(255)`, alinhadas a `dres.nome`;
- espelha a migration em `api/cmd/api/migrations` e `infra/migrations`;
- documenta fonte de verdade, limites e rollback.

## Segurança/integridade
Nenhuma DRE é escolhida arbitrariamente. Se nomes forem ambíguos após `TRIM` + case-insensitive, ou se um registro legado não puder ser reconciliado, a migration falha explicitamente antes das constraints finais.

Usuários `role=dre` não podem permanecer sem `dre_id` e FKs impedem referências órfãs.

## Compatibilidade
Este PR não altera handlers/models de produção. O bridge no PostgreSQL mantém o comportamento atual enquanto as próximas tasks migram consumidores para ID, reduzindo conflito com a #209 que está sendo desenvolvida em paralelo.

## Testes adicionados
`dre_canonical_relations_migration_test.go` cobre em PostgreSQL real:
- backfill com diferenças de caixa/espaços;
- FKs/constraints;
- writes legados e canônicos;
- rejeição de IDs/DREs inválidas;
- rejeição de nomes ambíguos;
- rejeição de dados não reconciliáveis;
- reexecução/idempotência;
- rename preservando relação por ID;
- stress de 30.000 relações (20.000 registros legados migrados + 10.000 writes via bridge).

## Fora de escopo deliberado
- remover fallback de `ValidateDRE`: #205;
- revogação runtime/JWT: #206;
- migrar analytics/filtros para `dre_id`: #207;
- unicidade case-insensitive permanente: #208.

> PR aberto inicialmente como draft apenas para executar a suíte PostgreSQL/CI. Deve sair de draft somente após os checks reais ficarem verdes.