### PR TITLE
fix(dre): lifecycle canônico e integridade transacional (#205)

### DIFF
--- a/api/cmd/api/dre_lifecycle_integrity_test.go
+++ b/api/cmd/api/dre_lifecycle_integrity_test.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"censo-api/internal/models"
+)
+
+func setupDRELifecycleTestDB(t *testing.T, applyCanonicalMigration bool) (*sql.DB, models.Models) {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not configured")
+	}
+
+	base := openDREIntegrationDB(t)
+	schema := fmt.Sprintf("dre205_%d", time.Now().UnixNano())
+	if _, err := base.Exec(`CREATE SCHEMA ` + schema); err != nil {
+		t.Fatalf("create lifecycle schema: %v", err)
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open lifecycle db: %v", err)
+	}
+	// Keep search_path tied to one physical connection for the whole isolated test.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		t.Fatalf("ping lifecycle db: %v", err)
+	}
+	if _, err := db.Exec(`SET search_path TO ` + schema + `, public`); err != nil {
+		_ = db.Close()
+		t.Fatalf("set lifecycle search_path: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = db.Close()
+		_, _ = base.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	})
+
+	if _, err := db.Exec(`
+		CREATE TABLE dres (
+			id SERIAL PRIMARY KEY,
+			nome VARCHAR(255) UNIQUE NOT NULL,
+			sigla VARCHAR(32),
+			municipio_sede VARCHAR(255),
+			polo VARCHAR(255),
+			gestor_nome VARCHAR(255),
+			email VARCHAR(255),
+			telefone VARCHAR(64),
+			ativa BOOLEAN NOT NULL DEFAULT true,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		CREATE TABLE schools (
+			id SERIAL PRIMARY KEY,
+			dre VARCHAR(100)
+		);
+		CREATE TABLE admin_users (
+			id SERIAL PRIMARY KEY,
+			username VARCHAR(64) UNIQUE NOT NULL,
+			password_hash VARCHAR(255) NOT NULL,
+			role VARCHAR(32) NOT NULL,
+			dre VARCHAR(128),
+			active BOOLEAN NOT NULL DEFAULT true,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+	`); err != nil {
+		t.Fatalf("create lifecycle tables: %v", err)
+	}
+
+	if applyCanonicalMigration {
+		if _, err := db.Exec(canonicalMigrationSQL(t)); err != nil {
+			t.Fatalf("apply canonical migration for lifecycle test: %v", err)
+		}
+	}
+
+	return db, models.NewModels(db)
+}
+
+func TestDRELifecycleCreateStatusAndCanonicalUser(t *testing.T) {
+	ctx := context.Background()
+	db, m := setupDRELifecycleTestDB(t, true)
+
+	inactive, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE INATIVA", Ativa: false})
+	if err != nil {
+		t.Fatalf("create inactive DRE: %v", err)
+	}
+	if inactive.Ativa {
+		t.Fatalf("DRE created with ativa=false was persisted active")
+	}
+	if _, err := m.AdminUsers.Create(ctx, "inactive.user", "password123", "dre", inactive.Nome); !errors.Is(err, models.ErrDREInactive) {
+		t.Fatalf("inactive DRE accepted new user: %v", err)
+	}
+
+	active, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE ATIVA", Ativa: true})
+	if err != nil {
+		t.Fatalf("create active DRE: %v", err)
+	}
+	user, err := m.AdminUsers.Create(ctx, "active.user", "password123", "dre", "  dre ativa  ")
+	if err != nil {
+		t.Fatalf("create canonical DRE user: %v", err)
+	}
+	if user.DREID != active.ID || user.DRE != active.Nome {
+		t.Fatalf("canonical user relation mismatch: dre_id=%d dre=%q want id=%d name=%q", user.DREID, user.DRE, active.ID, active.Nome)
+	}
+
+	var storedID int
+	var storedName string
+	if err := db.QueryRow(`SELECT dre_id, dre FROM admin_users WHERE id = $1`, user.ID).Scan(&storedID, &storedName); err != nil {
+		t.Fatalf("read stored canonical user relation: %v", err)
+	}
+	if storedID != active.ID || storedName != active.Nome {
+		t.Fatalf("stored relation is not canonical: dre_id=%d dre=%q", storedID, storedName)
+	}
+
+	if err := m.DREs.SetActive(ctx, active.ID, false); err != nil {
+		t.Fatalf("deactivate DRE: %v", err)
+	}
+	if _, err := m.AdminUsers.CreateForDREID(ctx, "blocked.by.id", "password123", "dre", active.ID); !errors.Is(err, models.ErrDREInactive) {
+		t.Fatalf("inactive DRE accepted user by dre_id: %v", err)
+	}
+	if err := m.DREs.SetActive(ctx, active.ID, true); err != nil {
+		t.Fatalf("reactivate DRE: %v", err)
+	}
+	if _, err := m.AdminUsers.CreateForDREID(ctx, "reactivated.user", "password123", "dre", active.ID); err != nil {
+		t.Fatalf("reactivated DRE did not accept user: %v", err)
+	}
+}
+
+func TestDRELifecycleNeverFallsBackToSchools(t *testing.T) {
+	ctx := context.Background()
+	db, m := setupDRELifecycleTestDB(t, false)
+
+	if _, err := db.Exec(`INSERT INTO schools (dre) VALUES ('DRE FANTASMA')`); err != nil {
+		t.Fatalf("seed legacy school text: %v", err)
+	}
+	valid, err := m.AdminUsers.ValidateDRE(ctx, "DRE FANTASMA")
+	if err != nil {
+		t.Fatalf("ValidateDRE returned infrastructure error: %v", err)
+	}
+	if valid {
+		t.Fatalf("schools text incorrectly validated a DRE absent from master table")
+	}
+	if _, err := m.AdminUsers.Create(ctx, "ghost.user", "password123", "dre", "DRE FANTASMA"); !errors.Is(err, models.ErrInvalidDRE) {
+		t.Fatalf("master-absent DRE did not return ErrInvalidDRE: %v", err)
+	}
+}
+
+func TestDRELifecycleRenamePreservesCanonicalRelationsAndRemap(t *testing.T) {
+	ctx := context.Background()
+	db, m := setupDRELifecycleTestDB(t, true)
+
+	dreA, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE ALPHA", Ativa: true})
+	if err != nil {
+		t.Fatalf("create DRE A: %v", err)
+	}
+	dreB, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE BETA", Ativa: true})
+	if err != nil {
+		t.Fatalf("create DRE B: %v", err)
+	}
+
+	var schoolID int
+	if err := db.QueryRow(`INSERT INTO schools DEFAULT VALUES RETURNING id`).Scan(&schoolID); err != nil {
+		t.Fatalf("create school: %v", err)
+	}
+	if _, _, err := m.Schools.AssignToDRE(ctx, dreA.ID, []int{schoolID}); err != nil {
+		t.Fatalf("assign school to DRE A: %v", err)
+	}
+	user, err := m.AdminUsers.CreateForDREID(ctx, "alpha.user", "password123", "dre", dreA.ID)
+	if err != nil {
+		t.Fatalf("create DRE A user: %v", err)
+	}
+
+	dreA.Nome = "DRE ALPHA RENOMEADA"
+	updated, err := m.DREs.Update(ctx, *dreA)
+	if err != nil {
+		t.Fatalf("rename DRE: %v", err)
+	}
+	if updated.ID != dreA.ID || updated.Nome != "DRE ALPHA RENOMEADA" {
+		t.Fatalf("unexpected renamed DRE: %#v", updated)
+	}
+
+	var schoolDREID, userDREID int
+	var schoolDRE, userDRE string
+	if err := db.QueryRow(`SELECT dre_id, dre FROM schools WHERE id = $1`, schoolID).Scan(&schoolDREID, &schoolDRE); err != nil {
+		t.Fatalf("read school after rename: %v", err)
+	}
+	if err := db.QueryRow(`SELECT dre_id, dre FROM admin_users WHERE id = $1`, user.ID).Scan(&userDREID, &userDRE); err != nil {
+		t.Fatalf("read user after rename: %v", err)
+	}
+	if schoolDREID != dreA.ID || userDREID != dreA.ID || schoolDRE != updated.Nome || userDRE != updated.Nome {
+		t.Fatalf("rename broke canonical links: school=(%d,%q) user=(%d,%q)", schoolDREID, schoolDRE, userDREID, userDRE)
+	}
+
+	// This specifically guards the post-#204 bug where changing only schools.dre
+	// was ignored because the trigger correctly treated the old dre_id as source of truth.
+	if _, _, err := m.Schools.AssignToDRE(ctx, dreB.ID, []int{schoolID}); err != nil {
+		t.Fatalf("remap school to DRE B: %v", err)
+	}
+	if err := db.QueryRow(`SELECT dre_id, dre FROM schools WHERE id = $1`, schoolID).Scan(&schoolDREID, &schoolDRE); err != nil {
+		t.Fatalf("read remapped school: %v", err)
+	}
+	if schoolDREID != dreB.ID || schoolDRE != dreB.Nome {
+		t.Fatalf("school remap did not change canonical id: got (%d,%q), want (%d,%q)", schoolDREID, schoolDRE, dreB.ID, dreB.Nome)
+	}
+}
+
+func TestDRELifecycleRenameRollsBackEveryRelatedWrite(t *testing.T) {
+	ctx := context.Background()
+	db, m := setupDRELifecycleTestDB(t, true)
+
+	dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE ORIGINAL", Ativa: true})
+	if err != nil {
+		t.Fatalf("create DRE: %v", err)
+	}
+	var schoolID int
+	if err := db.QueryRow(`INSERT INTO schools DEFAULT VALUES RETURNING id`).Scan(&schoolID); err != nil {
+		t.Fatalf("create school: %v", err)
+	}
+	if _, _, err := m.Schools.AssignToDRE(ctx, dre.ID, []int{schoolID}); err != nil {
+		t.Fatalf("assign school: %v", err)
+	}
+	user, err := m.AdminUsers.CreateForDREID(ctx, "rollback.user", "password123", "dre", dre.ID)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	if _, err := db.Exec(`ALTER TABLE schools ADD CONSTRAINT reject_breaking_rename CHECK (dre <> 'DRE QUEBRA')`); err != nil {
+		t.Fatalf("install rollback fault constraint: %v", err)
+	}
+
+	dre.Nome = "DRE QUEBRA"
+	if _, err := m.DREs.Update(ctx, *dre); err == nil {
+		t.Fatalf("expected rename to fail on child constraint")
+	}
+
+	var masterName, schoolName, userName string
+	if err := db.QueryRow(`SELECT nome FROM dres WHERE id = $1`, dre.ID).Scan(&masterName); err != nil {
+		t.Fatalf("read master after rollback: %v", err)
+	}
+	if err := db.QueryRow(`SELECT dre FROM schools WHERE id = $1`, schoolID).Scan(&schoolName); err != nil {
+		t.Fatalf("read school after rollback: %v", err)
+	}
+	if err := db.QueryRow(`SELECT dre FROM admin_users WHERE id = $1`, user.ID).Scan(&userName); err != nil {
+		t.Fatalf("read user after rollback: %v", err)
+	}
+	if masterName != "DRE ORIGINAL" || schoolName != "DRE ORIGINAL" || userName != "DRE ORIGINAL" {
+		t.Fatalf("partial rename escaped rollback: master=%q school=%q user=%q", masterName, schoolName, userName)
+	}
+}
+
+func TestDRELifecycleStress12000CanonicalRelations(t *testing.T) {
+	ctx := context.Background()
+	db, m := setupDRELifecycleTestDB(t, true)
+
+	dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE STRESS", Ativa: true})
+	if err != nil {
+		t.Fatalf("create stress DRE: %v", err)
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO schools (dre_id)
+		SELECT $1 FROM generate_series(1, 6000);
+		INSERT INTO admin_users (username, password_hash, role, dre_id)
+		SELECT 'dre205.stress.' || g, 'hash', 'dre', $1
+		FROM generate_series(1, 6000) AS g;
+	`, dre.ID); err != nil {
+		t.Fatalf("seed 12000 canonical relations: %v", err)
+	}
+
+	dre.Nome = "DRE STRESS RENOMEADA"
+	if _, err := m.DREs.Update(ctx, *dre); err != nil {
+		t.Fatalf("rename DRE across 12000 relations: %v", err)
+	}
+
+	var broken int
+	if err := db.QueryRow(`
+		SELECT
+			(SELECT COUNT(*) FROM schools WHERE dre_id <> $1 OR dre IS DISTINCT FROM $2) +
+			(SELECT COUNT(*) FROM admin_users WHERE role = 'dre' AND (dre_id <> $1 OR dre IS DISTINCT FROM $2))
+	`, dre.ID, dre.Nome).Scan(&broken); err != nil {
+		t.Fatalf("count broken stress relations: %v", err)
+	}
+	if broken != 0 {
+		t.Fatalf("found %d broken relations after stress rename", broken)
+	}
+}
+
+func TestDRELifecycleStress2000ExplicitCreateFlags(t *testing.T) {
+	ctx := context.Background()
+	_, m := setupDRELifecycleTestDB(t, true)
+
+	for i := 0; i < 2000; i++ {
+		wantActive := i%2 == 0
+		dre, err := m.DREs.Create(ctx, models.DRE{
+			Nome:  fmt.Sprintf("DRE FLAG %04d", i),
+			Ativa: wantActive,
+		})
+		if err != nil {
+			t.Fatalf("iteration %d create DRE: %v", i, err)
+		}
+		if dre.Ativa != wantActive {
+			t.Fatalf("iteration %d status mismatch: got %v want %v", i, dre.Ativa, wantActive)
+		}
+	}
+}

--- a/api/cmd/api/dre_lifecycle_integrity_test.go
+++ b/api/cmd/api/dre_lifecycle_integrity_test.go
@@ -203,8 +203,6 @@ func TestDRELifecycleRenamePreservesCanonicalRelationsAndRemap(t *testing.T) {
 		t.Fatalf("rename broke canonical links: school=(%d,%q) user=(%d,%q)", schoolDREID, schoolDRE, userDREID, userDRE)
 	}
 
-	// This specifically guards the post-#204 bug where changing only schools.dre
-	// was ignored because the trigger correctly treated the old dre_id as source of truth.
 	if _, _, err := m.Schools.AssignToDRE(ctx, dreB.ID, []int{schoolID}); err != nil {
 		t.Fatalf("remap school to DRE B: %v", err)
 	}
@@ -271,12 +269,16 @@ func TestDRELifecycleStress12000CanonicalRelations(t *testing.T) {
 
 	if _, err := db.Exec(`
 		INSERT INTO schools (dre_id)
-		SELECT $1 FROM generate_series(1, 6000);
+		SELECT $1 FROM generate_series(1, 6000)
+	`, dre.ID); err != nil {
+		t.Fatalf("seed 6000 canonical school relations: %v", err)
+	}
+	if _, err := db.Exec(`
 		INSERT INTO admin_users (username, password_hash, role, dre_id)
 		SELECT 'dre205.stress.' || g, 'hash', 'dre', $1
-		FROM generate_series(1, 6000) AS g;
+		FROM generate_series(1, 6000) AS g
 	`, dre.ID); err != nil {
-		t.Fatalf("seed 12000 canonical relations: %v", err)
+		t.Fatalf("seed 6000 canonical user relations: %v", err)
 	}
 
 	dre.Nome = "DRE STRESS RENOMEADA"

--- a/api/internal/models/admin_users.go
+++ b/api/internal/models/admin_users.go
@@ -26,6 +26,7 @@ type AdminUser struct {
 	PasswordHash string    `json:"-"`
 	Role         string    `json:"role"`
 	DRE          string    `json:"dre"`
+	DREID        int       `json:"dre_id,omitempty"`
 	Active       bool      `json:"active"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
@@ -35,127 +36,92 @@ type AdminUserModel struct {
 	DB *sql.DB
 }
 
-// GetActiveByUsername localiza um usuário ativo pelo username.
-func (m *AdminUserModel) GetActiveByUsername(ctx context.Context, username string) (*AdminUser, error) {
-	query := `
-		SELECT id, username, password_hash, role, COALESCE(dre, ''), active, created_at, updated_at
-		FROM admin_users
-		WHERE LOWER(username) = LOWER($1) AND active = true`
-
-	var u AdminUser
-	err := m.DB.QueryRowContext(ctx, query, strings.TrimSpace(username)).Scan(
-		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.DRE, &u.Active, &u.CreatedAt, &u.UpdatedAt,
-	)
-	if err == sql.ErrNoRows {
-		return nil, ErrUserNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &u, nil
+type canonicalDRE struct {
+	ID     int
+	Nome   string
+	Active bool
 }
 
-// GetByUsername localiza um usuário (ativo ou inativo) pelo username.
-func (m *AdminUserModel) GetByUsername(ctx context.Context, username string) (*AdminUser, error) {
-	query := `
-		SELECT id, username, password_hash, role, COALESCE(dre, ''), active, created_at, updated_at
-		FROM admin_users
-		WHERE LOWER(username) = LOWER($1)`
-
-	var u AdminUser
-	err := m.DB.QueryRowContext(ctx, query, strings.TrimSpace(username)).Scan(
-		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.DRE, &u.Active, &u.CreatedAt, &u.UpdatedAt,
-	)
-	if err == sql.ErrNoRows {
-		return nil, ErrUserNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &u, nil
-}
-
-// ValidateDRE verifica se a DRE existe e está ativa, consultando prioritariamente a tabela 'dres'.
-// Se a DRE estiver cadastrada na tabela 'dres', verifica se está ativa (retornando ErrDREInactive caso inativa).
-// Caso não esteja na tabela 'dres', realiza fallback para a tabela 'schools'.
-func (m *AdminUserModel) ValidateDRE(ctx context.Context, dre string) (bool, error) {
+func (m *AdminUserModel) resolveDREByName(ctx context.Context, dre string) (*canonicalDRE, error) {
 	dre = strings.TrimSpace(dre)
-	if dre == "" {
-		return false, nil
-	}
-
-	// 1. Prioridade: tabela dres
-	var ativa bool
-	queryDRE := `SELECT ativa FROM dres WHERE UPPER(TRIM(nome)) = UPPER(TRIM($1))`
-	err := m.DB.QueryRowContext(ctx, queryDRE, dre).Scan(&ativa)
-	if err == nil {
-		if !ativa {
-			return false, ErrDREInactive
-		}
-		return true, nil
-	}
-
-	if err != sql.ErrNoRows {
-		// Se a tabela dres não existir (ambiente sem migration), faz fallback silencioso para schools
-		if !strings.Contains(err.Error(), "does not exist") && !strings.Contains(err.Error(), "não existe") {
-			return false, err
-		}
-	}
-
-	// 2. Fallback: tabela schools
-	querySchools := `SELECT EXISTS(SELECT 1 FROM schools WHERE UPPER(TRIM(dre)) = UPPER(TRIM($1)))`
-	var exists bool
-	err = m.DB.QueryRowContext(ctx, querySchools, dre).Scan(&exists)
-	return exists, err
-}
-
-// Create cria um novo usuário DRE com senha bcrypt e validação de DRE.
-func (m *AdminUserModel) Create(ctx context.Context, username, plainPassword, role, dre string) (*AdminUser, error) {
-	username = strings.TrimSpace(username)
-	role = strings.TrimSpace(strings.ToLower(role))
-	dre = strings.TrimSpace(dre)
-
-	if username == "" {
-		return nil, errors.New("username não pode ser vazio")
-	}
-	if len(plainPassword) < 6 {
-		return nil, errors.New("senha deve ter no mínimo 6 caracteres")
-	}
-	if role != "dre" {
-		return nil, ErrInvalidRole
-	}
 	if dre == "" {
 		return nil, ErrDRERequiredForDRE
 	}
 
-	validDRE, err := m.ValidateDRE(ctx, dre)
-	if err != nil {
-		if errors.Is(err, ErrDREInactive) {
-			return nil, ErrDREInactive
-		}
-		return nil, fmt.Errorf("erro ao validar DRE: %w", err)
+	var d canonicalDRE
+	err := m.DB.QueryRowContext(ctx, `
+		SELECT id, nome, ativa
+		FROM dres
+		WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM($1))`, dre).Scan(&d.ID, &d.Nome, &d.Active)
+	if err == sql.ErrNoRows {
+		return nil, ErrInvalidDRE
 	}
-	if !validDRE {
+	if err != nil {
+		return nil, err
+	}
+	if !d.Active {
+		return nil, ErrDREInactive
+	}
+	return &d, nil
+}
+
+func (m *AdminUserModel) resolveDREByID(ctx context.Context, dreID int) (*canonicalDRE, error) {
+	if dreID <= 0 {
 		return nil, ErrInvalidDRE
 	}
 
+	var d canonicalDRE
+	err := m.DB.QueryRowContext(ctx, `
+		SELECT id, nome, ativa
+		FROM dres
+		WHERE id = $1`, dreID).Scan(&d.ID, &d.Nome, &d.Active)
+	if err == sql.ErrNoRows {
+		return nil, ErrInvalidDRE
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !d.Active {
+		return nil, ErrDREInactive
+	}
+	return &d, nil
+}
+
+func normalizeAdminUserCreateInput(username, plainPassword, role string) (string, string, error) {
+	username = strings.TrimSpace(username)
+	role = strings.TrimSpace(strings.ToLower(role))
+
+	if username == "" {
+		return "", "", errors.New("username não pode ser vazio")
+	}
+	if len(plainPassword) < 6 {
+		return "", "", errors.New("senha deve ter no mínimo 6 caracteres")
+	}
+	if role != "dre" {
+		return "", "", ErrInvalidRole
+	}
+	return username, role, nil
+}
+
+func (m *AdminUserModel) createForCanonicalDRE(ctx context.Context, username, plainPassword, role string, dre *canonicalDRE) (*AdminUser, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(plainPassword), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, fmt.Errorf("erro ao gerar hash da senha: %w", err)
 	}
 
 	query := `
-		INSERT INTO admin_users (username, password_hash, role, dre, active, created_at, updated_at)
+		INSERT INTO admin_users (username, password_hash, role, dre_id, active, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, true, NOW(), NOW())
-		RETURNING id, username, role, dre, active, created_at, updated_at`
+		RETURNING id, username, role, COALESCE(dre, ''), dre_id, active, created_at, updated_at`
 
 	var u AdminUser
 	u.PasswordHash = string(hash)
-	err = m.DB.QueryRowContext(ctx, query, username, u.PasswordHash, role, dre).Scan(
-		&u.ID, &u.Username, &u.Role, &u.DRE, &u.Active, &u.CreatedAt, &u.UpdatedAt,
+	err = m.DB.QueryRowContext(ctx, query, username, u.PasswordHash, role, dre.ID).Scan(
+		&u.ID, &u.Username, &u.Role, &u.DRE, &u.DREID, &u.Active, &u.CreatedAt, &u.UpdatedAt,
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "unique") || strings.Contains(err.Error(), "duplicate") {
+		msg := strings.ToLower(err.Error())
+		if strings.Contains(msg, "unique") || strings.Contains(msg, "duplicate") {
 			return nil, ErrUsernameExists
 		}
 		return nil, err
@@ -163,19 +129,21 @@ func (m *AdminUserModel) Create(ctx context.Context, username, plainPassword, ro
 	return &u, nil
 }
 
-// GetByID localiza um usuário pelo seu ID numérico.
-func (m *AdminUserModel) GetByID(ctx context.Context, id int) (*AdminUser, error) {
-	if id <= 0 {
-		return nil, ErrUserNotFound
-	}
+// GetActiveByUsername localiza um usuario ativo pelo username. O nome da DRE
+// retornado e derivado do dre_id sempre que houver relacao canonica.
+func (m *AdminUserModel) GetActiveByUsername(ctx context.Context, username string) (*AdminUser, error) {
 	query := `
-		SELECT id, username, password_hash, role, COALESCE(dre, ''), active, created_at, updated_at
-		FROM admin_users
-		WHERE id = $1`
+		SELECT u.id, u.username, u.password_hash, u.role,
+		       COALESCE(d.nome, u.dre, ''), COALESCE(u.dre_id, 0),
+		       u.active, u.created_at, u.updated_at
+		FROM admin_users u
+		LEFT JOIN dres d ON d.id = u.dre_id
+		WHERE LOWER(u.username) = LOWER($1) AND u.active = true`
 
 	var u AdminUser
-	err := m.DB.QueryRowContext(ctx, query, id).Scan(
-		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.DRE, &u.Active, &u.CreatedAt, &u.UpdatedAt,
+	err := m.DB.QueryRowContext(ctx, query, strings.TrimSpace(username)).Scan(
+		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.DRE, &u.DREID,
+		&u.Active, &u.CreatedAt, &u.UpdatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, ErrUserNotFound
@@ -186,7 +154,115 @@ func (m *AdminUserModel) GetByID(ctx context.Context, id int) (*AdminUser, error
 	return &u, nil
 }
 
-// UpdatePassword atualiza a senha de um usuário existente usando bcrypt pelo username.
+// GetByUsername localiza um usuario ativo ou inativo pelo username.
+func (m *AdminUserModel) GetByUsername(ctx context.Context, username string) (*AdminUser, error) {
+	query := `
+		SELECT u.id, u.username, u.password_hash, u.role,
+		       COALESCE(d.nome, u.dre, ''), COALESCE(u.dre_id, 0),
+		       u.active, u.created_at, u.updated_at
+		FROM admin_users u
+		LEFT JOIN dres d ON d.id = u.dre_id
+		WHERE LOWER(u.username) = LOWER($1)`
+
+	var u AdminUser
+	err := m.DB.QueryRowContext(ctx, query, strings.TrimSpace(username)).Scan(
+		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.DRE, &u.DREID,
+		&u.Active, &u.CreatedAt, &u.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+// ValidateDRE valida exclusivamente a entidade mestre dres. Nao existe mais
+// fallback para schools: texto em uma escola nunca cria ou valida uma regional.
+func (m *AdminUserModel) ValidateDRE(ctx context.Context, dre string) (bool, error) {
+	dre = strings.TrimSpace(dre)
+	if dre == "" {
+		return false, nil
+	}
+
+	var ativa bool
+	err := m.DB.QueryRowContext(ctx, `
+		SELECT ativa
+		FROM dres
+		WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM($1))`, dre).Scan(&ativa)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !ativa {
+		return false, ErrDREInactive
+	}
+	return true, nil
+}
+
+// Create preserva o contrato legado que recebe o nome da DRE, mas o nome e
+// apenas resolvido na entidade mestre. O INSERT persiste o vinculo por dre_id.
+func (m *AdminUserModel) Create(ctx context.Context, username, plainPassword, role, dre string) (*AdminUser, error) {
+	username, role, err := normalizeAdminUserCreateInput(username, plainPassword, role)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(dre) == "" {
+		return nil, ErrDRERequiredForDRE
+	}
+
+	canonical, err := m.resolveDREByName(ctx, dre)
+	if err != nil {
+		return nil, err
+	}
+	return m.createForCanonicalDRE(ctx, username, plainPassword, role, canonical)
+}
+
+// CreateForDREID e o caminho canonico para novos callers/handlers. Ele evita
+// qualquer dependencia de nome textual para estabelecer o relacionamento.
+func (m *AdminUserModel) CreateForDREID(ctx context.Context, username, plainPassword, role string, dreID int) (*AdminUser, error) {
+	username, role, err := normalizeAdminUserCreateInput(username, plainPassword, role)
+	if err != nil {
+		return nil, err
+	}
+	canonical, err := m.resolveDREByID(ctx, dreID)
+	if err != nil {
+		return nil, err
+	}
+	return m.createForCanonicalDRE(ctx, username, plainPassword, role, canonical)
+}
+
+// GetByID localiza um usuario pelo seu ID numerico.
+func (m *AdminUserModel) GetByID(ctx context.Context, id int) (*AdminUser, error) {
+	if id <= 0 {
+		return nil, ErrUserNotFound
+	}
+	query := `
+		SELECT u.id, u.username, u.password_hash, u.role,
+		       COALESCE(d.nome, u.dre, ''), COALESCE(u.dre_id, 0),
+		       u.active, u.created_at, u.updated_at
+		FROM admin_users u
+		LEFT JOIN dres d ON d.id = u.dre_id
+		WHERE u.id = $1`
+
+	var u AdminUser
+	err := m.DB.QueryRowContext(ctx, query, id).Scan(
+		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.DRE, &u.DREID,
+		&u.Active, &u.CreatedAt, &u.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+// UpdatePassword atualiza a senha de um usuario existente usando bcrypt pelo username.
 func (m *AdminUserModel) UpdatePassword(ctx context.Context, username string, newPlainPassword string) error {
 	username = strings.TrimSpace(username)
 	if len(newPlainPassword) < 6 {
@@ -208,7 +284,7 @@ func (m *AdminUserModel) UpdatePassword(ctx context.Context, username string, ne
 	return err
 }
 
-// UpdatePasswordByID atualiza a senha de um usuário existente usando bcrypt pelo ID.
+// UpdatePasswordByID atualiza a senha de um usuario existente usando bcrypt pelo ID.
 func (m *AdminUserModel) UpdatePasswordByID(ctx context.Context, id int, newPlainPassword string) error {
 	if id <= 0 {
 		return ErrUserNotFound
@@ -237,7 +313,7 @@ func (m *AdminUserModel) UpdatePasswordByID(ctx context.Context, id int, newPlai
 	return nil
 }
 
-// SetActive ativa ou desativa uma conta de usuário pelo username.
+// SetActive ativa ou desativa uma conta de usuario pelo username.
 func (m *AdminUserModel) SetActive(ctx context.Context, username string, active bool) error {
 	username = strings.TrimSpace(username)
 	u, err := m.GetByUsername(ctx, username)
@@ -250,7 +326,7 @@ func (m *AdminUserModel) SetActive(ctx context.Context, username string, active 
 	return err
 }
 
-// SetActiveByID ativa ou desativa uma conta de usuário pelo ID.
+// SetActiveByID ativa ou desativa uma conta de usuario pelo ID.
 func (m *AdminUserModel) SetActiveByID(ctx context.Context, id int, active bool) error {
 	if id <= 0 {
 		return ErrUserNotFound
@@ -271,12 +347,16 @@ func (m *AdminUserModel) SetActiveByID(ctx context.Context, id int, active bool)
 	return nil
 }
 
-// List retorna todas as contas cadastradas sem expor o hash da senha.
+// List retorna todas as contas cadastradas sem expor o hash da senha e sempre
+// prefere o nome atual da DRE resolvido pela FK canonica.
 func (m *AdminUserModel) List(ctx context.Context) ([]*AdminUser, error) {
 	query := `
-		SELECT id, username, role, COALESCE(dre, ''), active, created_at, updated_at
-		FROM admin_users
-		ORDER BY username`
+		SELECT u.id, u.username, u.role,
+		       COALESCE(d.nome, u.dre, ''), COALESCE(u.dre_id, 0),
+		       u.active, u.created_at, u.updated_at
+		FROM admin_users u
+		LEFT JOIN dres d ON d.id = u.dre_id
+		ORDER BY u.username`
 
 	rows, err := m.DB.QueryContext(ctx, query)
 	if err != nil {
@@ -287,7 +367,10 @@ func (m *AdminUserModel) List(ctx context.Context) ([]*AdminUser, error) {
 	users := make([]*AdminUser, 0)
 	for rows.Next() {
 		var u AdminUser
-		if err := rows.Scan(&u.ID, &u.Username, &u.Role, &u.DRE, &u.Active, &u.CreatedAt, &u.UpdatedAt); err != nil {
+		if err := rows.Scan(
+			&u.ID, &u.Username, &u.Role, &u.DRE, &u.DREID,
+			&u.Active, &u.CreatedAt, &u.UpdatedAt,
+		); err != nil {
 			return nil, err
 		}
 		users = append(users, &u)

--- a/api/internal/models/dres.go
+++ b/api/internal/models/dres.go
@@ -34,8 +34,17 @@ type DREModel struct {
 	DB *sql.DB
 }
 
-// Create insere uma nova DRE. O campo 'nome' é obrigatório.
-// Por padrão, uma nova DRE é criada com status ativo.
+func isDREDuplicateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique") || strings.Contains(msg, "duplicate")
+}
+
+// Create insere uma nova DRE. O campo nome e obrigatorio e o status recebido
+// pelo caller e respeitado literalmente. O handler HTTP e responsavel pelo
+// default ativa=true quando o campo nao vier no payload.
 func (m *DREModel) Create(ctx context.Context, dre DRE) (*DRE, error) {
 	nome := strings.TrimSpace(dre.Nome)
 	if nome == "" {
@@ -48,12 +57,6 @@ func (m *DREModel) Create(ctx context.Context, dre DRE) (*DRE, error) {
 	gestorNome := strings.TrimSpace(dre.GestorNome)
 	email := strings.TrimSpace(dre.Email)
 	telefone := strings.TrimSpace(dre.Telefone)
-	ativa := true
-	if dre.ID != 0 {
-		ativa = dre.Ativa
-	} else if dre.Ativa {
-		ativa = true
-	}
 
 	query := `
 		INSERT INTO dres (nome, sigla, municipio_sede, polo, gestor_nome, email, telefone, ativa, created_at, updated_at)
@@ -64,14 +67,14 @@ func (m *DREModel) Create(ctx context.Context, dre DRE) (*DRE, error) {
 
 	var d DRE
 	err := m.DB.QueryRowContext(ctx, query,
-		nome, sigla, municipioSede, polo, gestorNome, email, telefone, ativa,
+		nome, sigla, municipioSede, polo, gestorNome, email, telefone, dre.Ativa,
 	).Scan(
 		&d.ID, &d.Nome, &d.Sigla, &d.MunicipioSede, &d.Polo,
 		&d.GestorNome, &d.Email, &d.Telefone,
 		&d.Ativa, &d.CreatedAt, &d.UpdatedAt,
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "unique") || strings.Contains(err.Error(), "duplicate") {
+		if isDREDuplicateError(err) {
 			return nil, ErrDREExists
 		}
 		return nil, err
@@ -79,7 +82,7 @@ func (m *DREModel) Create(ctx context.Context, dre DRE) (*DRE, error) {
 	return &d, nil
 }
 
-// GetByID busca uma DRE pelo seu ID numérico.
+// GetByID busca uma DRE pelo seu ID numerico.
 func (m *DREModel) GetByID(ctx context.Context, id int) (*DRE, error) {
 	if id <= 0 {
 		return nil, ErrDREInvalidID
@@ -107,7 +110,7 @@ func (m *DREModel) GetByID(ctx context.Context, id int) (*DRE, error) {
 	return &d, nil
 }
 
-// GetByNome busca uma DRE pelo seu nome (busca sem diferenciar maiúsculas/minúsculas e tolerante a espaços).
+// GetByNome busca uma DRE pelo seu nome sem diferenciar caixa e tolerando espacos.
 func (m *DREModel) GetByNome(ctx context.Context, nome string) (*DRE, error) {
 	nome = strings.TrimSpace(nome)
 	if nome == "" {
@@ -166,7 +169,10 @@ func (m *DREModel) List(ctx context.Context) ([]*DRE, error) {
 	return dres, rows.Err()
 }
 
-// Update atualiza os dados de uma DRE existente pelo seu ID.
+// Update atualiza a entidade mestre e sincroniza, na MESMA transacao, os nomes
+// legados mantidos em schools/admin_users. Os vinculos permanecem identificados
+// por dre_id; o texto e apenas compatibilidade. Qualquer falha no meio do rename
+// faz rollback de toda a operacao.
 func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 	if dre.ID <= 0 {
 		return nil, ErrDREInvalidID
@@ -184,6 +190,12 @@ func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 	email := strings.TrimSpace(dre.Email)
 	telefone := strings.TrimSpace(dre.Telefone)
 
+	tx, err := m.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	query := `
 		UPDATE dres
 		SET nome = $1, sigla = $2, municipio_sede = $3, polo = $4,
@@ -194,7 +206,7 @@ func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 		          ativa, created_at, updated_at`
 
 	var d DRE
-	err := m.DB.QueryRowContext(ctx, query,
+	err = tx.QueryRowContext(ctx, query,
 		nome, sigla, municipioSede, polo, gestorNome, email, telefone, dre.Ativa, dre.ID,
 	).Scan(
 		&d.ID, &d.Nome, &d.Sigla, &d.MunicipioSede, &d.Polo,
@@ -205,9 +217,28 @@ func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 		return nil, ErrDRENotFound
 	}
 	if err != nil {
-		if strings.Contains(err.Error(), "unique") || strings.Contains(err.Error(), "duplicate") {
+		if isDREDuplicateError(err) {
 			return nil, ErrDREExists
 		}
+		return nil, err
+	}
+
+	// dre_id e a referencia canonica. Atualizamos apenas a copia textual para
+	// consumidores legados; os triggers da migration 0020 reafirmam o mesmo ID.
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE admin_users
+		SET dre = $1, updated_at = NOW()
+		WHERE dre_id = $2 AND dre IS DISTINCT FROM $1`, d.Nome, d.ID); err != nil {
+		return nil, err
+	}
+	if _, err = tx.ExecContext(ctx, `
+		UPDATE schools
+		SET dre = $1
+		WHERE dre_id = $2 AND dre IS DISTINCT FROM $1`, d.Nome, d.ID); err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
 		return nil, err
 	}
 	return &d, nil
@@ -236,7 +267,8 @@ func (m *DREModel) SetActive(ctx context.Context, id int, active bool) error {
 	return nil
 }
 
-// SetActiveByNome ativa ou desativa uma DRE pelo nome.
+// SetActiveByNome existe apenas para compatibilidade de callers legados. Novos
+// fluxos devem preferir SetActive por ID.
 func (m *DREModel) SetActiveByNome(ctx context.Context, nome string, active bool) error {
 	nome = strings.TrimSpace(nome)
 	if nome == "" {

--- a/api/internal/models/dres.go
+++ b/api/internal/models/dres.go
@@ -170,9 +170,10 @@ func (m *DREModel) List(ctx context.Context) ([]*DRE, error) {
 }
 
 // Update atualiza a entidade mestre e sincroniza, na MESMA transacao, os nomes
-// legados mantidos em schools/admin_users. Os vinculos permanecem identificados
-// por dre_id; o texto e apenas compatibilidade. Qualquer falha no meio do rename
-// faz rollback de toda a operacao.
+// legados mantidos em schools/admin_users. No schema pos-0020 a selecao dos
+// filhos usa dre_id. Durante a janela de rollout em um schema anterior, o nome
+// antigo bloqueado na mesma transacao e usado apenas para localizar os registros
+// legados. Qualquer falha faz rollback de toda a operacao.
 func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 	if dre.ID <= 0 {
 		return nil, ErrDREInvalidID
@@ -196,6 +197,25 @@ func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	var oldName string
+	err = tx.QueryRowContext(ctx, `SELECT nome FROM dres WHERE id = $1 FOR UPDATE`, dre.ID).Scan(&oldName)
+	if err == sql.ErrNoRows {
+		return nil, ErrDRENotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	oldName = strings.TrimSpace(oldName)
+
+	schoolsCanonical, err := hasColumn(ctx, tx, "schools", "dre_id")
+	if err != nil {
+		return nil, err
+	}
+	usersCanonical, err := hasColumn(ctx, tx, "admin_users", "dre_id")
+	if err != nil {
+		return nil, err
+	}
+
 	query := `
 		UPDATE dres
 		SET nome = $1, sigla = $2, municipio_sede = $3, polo = $4,
@@ -213,9 +233,6 @@ func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 		&d.GestorNome, &d.Email, &d.Telefone,
 		&d.Ativa, &d.CreatedAt, &d.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
-		return nil, ErrDRENotFound
-	}
 	if err != nil {
 		if isDREDuplicateError(err) {
 			return nil, ErrDREExists
@@ -223,18 +240,33 @@ func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 		return nil, err
 	}
 
-	// dre_id e a referencia canonica. Atualizamos apenas a copia textual para
-	// consumidores legados; os triggers da migration 0020 reafirmam o mesmo ID.
-	if _, err = tx.ExecContext(ctx, `
-		UPDATE admin_users
-		SET dre = $1, updated_at = NOW()
-		WHERE dre_id = $2 AND dre IS DISTINCT FROM $1`, d.Nome, d.ID); err != nil {
+	if usersCanonical {
+		_, err = tx.ExecContext(ctx, `
+			UPDATE admin_users
+			SET dre = $1, updated_at = NOW()
+			WHERE dre_id = $2 AND dre IS DISTINCT FROM $1`, d.Nome, d.ID)
+	} else {
+		_, err = tx.ExecContext(ctx, `
+			UPDATE admin_users
+			SET dre = $1, updated_at = NOW()
+			WHERE UPPER(BTRIM(COALESCE(dre, ''))) = UPPER(BTRIM($2))`, d.Nome, oldName)
+	}
+	if err != nil {
 		return nil, err
 	}
-	if _, err = tx.ExecContext(ctx, `
-		UPDATE schools
-		SET dre = $1
-		WHERE dre_id = $2 AND dre IS DISTINCT FROM $1`, d.Nome, d.ID); err != nil {
+
+	if schoolsCanonical {
+		_, err = tx.ExecContext(ctx, `
+			UPDATE schools
+			SET dre = $1
+			WHERE dre_id = $2 AND dre IS DISTINCT FROM $1`, d.Nome, d.ID)
+	} else {
+		_, err = tx.ExecContext(ctx, `
+			UPDATE schools
+			SET dre = $1
+			WHERE UPPER(BTRIM(COALESCE(dre, ''))) = UPPER(BTRIM($2))`, d.Nome, oldName)
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/api/internal/models/schema_capability.go
+++ b/api/internal/models/schema_capability.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"context"
+	"database/sql"
+)
+
+type rowQuerier interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// hasColumn is used only during the rollout window between the legacy schema
+// and migration 0020. Runtime identity never falls back to schools: this helper
+// merely selects the write shape supported by the physical schema.
+func hasColumn(ctx context.Context, q rowQuerier, tableName, columnName string) (bool, error) {
+	var exists bool
+	err := q.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = CURRENT_SCHEMA()
+			  AND table_name = $1
+			  AND column_name = $2
+		)`, tableName, columnName).Scan(&exists)
+	return exists, err
+}

--- a/api/internal/models/school_dre.go
+++ b/api/internal/models/school_dre.go
@@ -58,9 +58,11 @@ func normalizedSchoolIDsForUpdate(ids []int) ([]int, error) {
 }
 
 // AssignToDRE associates one or more schools with a master DRE atomically.
-// dre_id is the source of truth; the legacy text column is hydrated by the
-// compatibility trigger from migration 0020. If any school does not exist,
-// the entire batch is rolled back.
+// On the post-0020 schema, dre_id is the source of truth and the compatibility
+// trigger hydrates schools.dre. During the short rollout window where a test or
+// old deployment still lacks dre_id, the same operation writes the legacy text
+// after validating and locking the master DRE. This is schema compatibility,
+// not an identity fallback: the DRE always comes from the master table `dres`.
 func (m *SchoolModel) AssignToDRE(ctx context.Context, dreID int, schoolIDs []int) (string, int, error) {
 	if dreID <= 0 {
 		return "", 0, ErrDREInvalidID
@@ -99,14 +101,29 @@ func (m *SchoolModel) AssignToDRE(ctx context.Context, dreID int, schoolIDs []in
 		return "", 0, ErrDRENameRequired
 	}
 
-	stmt, err := tx.PrepareContext(ctx, `UPDATE schools SET dre_id = $1 WHERE id = $2`)
+	canonicalSchema, err := hasColumn(ctx, tx, "schools", "dre_id")
+	if err != nil {
+		return "", 0, err
+	}
+
+	var stmt *sql.Stmt
+	if canonicalSchema {
+		stmt, err = tx.PrepareContext(ctx, `UPDATE schools SET dre_id = $1 WHERE id = $2`)
+	} else {
+		stmt, err = tx.PrepareContext(ctx, `UPDATE schools SET dre = $1 WHERE id = $2`)
+	}
 	if err != nil {
 		return "", 0, err
 	}
 	defer stmt.Close()
 
 	for _, schoolID := range ids {
-		result, err := stmt.ExecContext(ctx, dreID, schoolID)
+		var result sql.Result
+		if canonicalSchema {
+			result, err = stmt.ExecContext(ctx, dreID, schoolID)
+		} else {
+			result, err = stmt.ExecContext(ctx, dreName, schoolID)
+		}
 		if err != nil {
 			return "", 0, err
 		}

--- a/api/internal/models/school_dre.go
+++ b/api/internal/models/school_dre.go
@@ -58,9 +58,9 @@ func normalizedSchoolIDsForUpdate(ids []int) ([]int, error) {
 }
 
 // AssignToDRE associates one or more schools with a master DRE atomically.
-// The canonical DRE name is read and locked inside the same transaction used
-// to update schools, preventing stale or differently formatted DRE values from
-// being persisted. If any school does not exist, the whole batch is rolled back.
+// dre_id is the source of truth; the legacy text column is hydrated by the
+// compatibility trigger from migration 0020. If any school does not exist,
+// the entire batch is rolled back.
 func (m *SchoolModel) AssignToDRE(ctx context.Context, dreID int, schoolIDs []int) (string, int, error) {
 	if dreID <= 0 {
 		return "", 0, ErrDREInvalidID
@@ -99,14 +99,14 @@ func (m *SchoolModel) AssignToDRE(ctx context.Context, dreID int, schoolIDs []in
 		return "", 0, ErrDRENameRequired
 	}
 
-	stmt, err := tx.PrepareContext(ctx, `UPDATE schools SET dre = $1 WHERE id = $2`)
+	stmt, err := tx.PrepareContext(ctx, `UPDATE schools SET dre_id = $1 WHERE id = $2`)
 	if err != nil {
 		return "", 0, err
 	}
 	defer stmt.Close()
 
 	for _, schoolID := range ids {
-		result, err := stmt.ExecContext(ctx, dreName, schoolID)
+		result, err := stmt.ExecContext(ctx, dreID, schoolID)
 		if err != nil {
 			return "", 0, err
 		}

--- a/api/internal/models/school_dre_test.go
+++ b/api/internal/models/school_dre_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -123,8 +124,9 @@ type fakeSchoolDRETx struct {
 type fakeSchoolDREStmt struct{ conn *fakeSchoolDREConn }
 
 type fakeSchoolDRERows struct {
-	values []driver.Value
-	done   bool
+	columns []string
+	values  []driver.Value
+	done    bool
 }
 
 func (fakeSchoolDREDriver) Open(name string) (driver.Conn, error) {
@@ -153,7 +155,14 @@ func (c *fakeSchoolDREConn) BeginTx(context.Context, driver.TxOptions) (driver.T
 func (c *fakeSchoolDREConn) PrepareContext(context.Context, string) (driver.Stmt, error) {
 	return &fakeSchoolDREStmt{conn: c}, nil
 }
-func (c *fakeSchoolDREConn) QueryContext(_ context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
+func (c *fakeSchoolDREConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if strings.Contains(query, "information_schema.columns") {
+		if len(args) != 2 {
+			return nil, fmt.Errorf("expected table/column args, got %d", len(args))
+		}
+		return &fakeSchoolDRERows{columns: []string{"exists"}, values: []driver.Value{true}}, nil
+	}
+
 	if len(args) != 1 {
 		return nil, fmt.Errorf("expected one DRE arg, got %d", len(args))
 	}
@@ -165,9 +174,9 @@ func (c *fakeSchoolDREConn) QueryContext(_ context.Context, _ string, args []dri
 	dre, exists := c.state.dres[int(id)]
 	c.state.mu.Unlock()
 	if !exists {
-		return &fakeSchoolDRERows{}, nil
+		return &fakeSchoolDRERows{columns: []string{"nome", "ativa"}}, nil
 	}
-	return &fakeSchoolDRERows{values: []driver.Value{dre.name, dre.active}}, nil
+	return &fakeSchoolDRERows{columns: []string{"nome", "ativa"}, values: []driver.Value{dre.name, dre.active}}, nil
 }
 
 func (tx *fakeSchoolDRETx) Commit() error {
@@ -210,10 +219,23 @@ func (s *fakeSchoolDREStmt) ExecContext(_ context.Context, args []driver.NamedVa
 	if len(args) != 2 {
 		return nil, fmt.Errorf("expected 2 update args, got %d", len(args))
 	}
-	dreName, ok := args[0].Value.(string)
-	if !ok {
-		return nil, fmt.Errorf("unexpected DRE name type %T", args[0].Value)
+
+	var dreName string
+	switch value := args[0].Value.(type) {
+	case string:
+		dreName = value
+	case int64:
+		s.conn.state.mu.Lock()
+		dre, ok := s.conn.state.dres[int(value)]
+		s.conn.state.mu.Unlock()
+		if !ok {
+			return nil, fmt.Errorf("unknown canonical DRE id %d", value)
+		}
+		dreName = strings.TrimSpace(dre.name)
+	default:
+		return nil, fmt.Errorf("unexpected DRE value type %T", args[0].Value)
 	}
+
 	id64, ok := args[1].Value.(int64)
 	if !ok {
 		return nil, fmt.Errorf("unexpected school ID type %T", args[1].Value)
@@ -226,8 +248,13 @@ func (s *fakeSchoolDREStmt) ExecContext(_ context.Context, args []driver.NamedVa
 	return driver.RowsAffected(1), nil
 }
 
-func (r *fakeSchoolDRERows) Columns() []string { return []string{"nome", "ativa"} }
-func (r *fakeSchoolDRERows) Close() error      { return nil }
+func (r *fakeSchoolDRERows) Columns() []string {
+	if len(r.columns) > 0 {
+		return r.columns
+	}
+	return []string{"nome", "ativa"}
+}
+func (r *fakeSchoolDRERows) Close() error { return nil }
 func (r *fakeSchoolDRERows) Next(dest []driver.Value) error {
 	if r.done || len(r.values) == 0 {
 		return io.EOF


### PR DESCRIPTION
## Objetivo
Implementa a #205 sobre a `develop` já contendo a #204, tornando o lifecycle da DRE consistente e usando `dre_id` como referência efetiva sem quebrar consumidores durante a transição de schema.

Closes #205
Parent epic: #203

## O que foi corrigido
- `DREModel.Create` agora respeita literalmente `ativa=false`; o default `true` continua sendo responsabilidade do handler quando o campo é omitido;
- `ValidateDRE` consulta exclusivamente a entidade mestre `dres` e não faz mais fallback para texto existente em `schools`;
- `AdminUser` passa a carregar `DREID` e novos vínculos são persistidos por `admin_users.dre_id`;
- o contrato legado `Create(..., dre string)` continua aceito pelo frontend atual, mas o nome é primeiro resolvido na entidade mestre e então convertido para o ID canônico;
- foi adicionado `CreateForDREID` para novos callers;
- consultas/listagem de usuários resolvem o nome atual da regional através de `dre_id -> dres.id`;
- `DREModel.Update` faz rename da entidade mestre e sincronização dos campos textuais legados de usuários/escolas na mesma transação;
- uma falha em qualquer etapa do rename provoca rollback integral;
- `SchoolModel.AssignToDRE` usa `schools.dre_id` quando a migration #204 está presente, corrigindo o bug em que alterar somente `schools.dre` podia ser ignorado pelo trigger canônico;
- DRE inativa rejeita novos vínculos por nome e por ID.

## Compatibilidade durante rollout
O CI atual compartilhado ainda inicializa o schema até `0019`; a aplicação de `0020` no gate global pertence à #210 do Ed. Para não criar conflito entre as branches, esta implementação detecta a presença física de `dre_id`:
- schema pós-#204: writes por ID;
- schema transitório pré-0020: write textual somente depois de resolver/bloquear a DRE em `dres`.

Isso **não** reintroduz fallback de identidade para `schools`: uma DRE inexistente em `dres` continua inválida em qualquer schema.

## Testes específicos da #205
`dre_lifecycle_integrity_test.go` usa PostgreSQL real em schema isolado e cobre:
- criação explícita ativa/inativa;
- DRE inativa bloqueando usuário por nome e por `dre_id`;
- reativação restaurando criação;
- ausência completa de fallback para `schools`;
- persistência canônica de usuário por `dre_id`;
- rename preservando IDs de usuário e escola;
- remapeamento real de escola DRE A -> DRE B;
- rollback integral forçado quando child update falha;
- stress de rename com **12.000 relações** (6.000 escolas + 6.000 usuários);
- **2.000 criações** alternando explicitamente `ativa=true/false`.

A suíte existente ainda executa milhares de casos property/stress de normalização, lote e remapeamento, além dos testes da migration #204.

## Validação do CI
A primeira execução identificou duas incompatibilidades reais nos artefatos novos:
1. a suíte compartilhada ainda não aplica `0020`, então o write direto em `dre_id` precisava suportar o schema transitório sem tocar no workflow da #210;
2. o seed de stress enviava dois comandos parametrizados no mesmo prepared statement do pgx.

Ambos foram corrigidos e toda a suíte foi executada novamente no head `3a7c154`.

Rodada final verde:
- PostgreSQL 16 real ✅
- `go vet ./...` ✅
- `go test ./... -count=1` ✅
- DRE deterministic property stress ✅
- DRE PostgreSQL batch stress ✅
- DRE PostgreSQL remap stress ✅
- DRE integration race detector ✅

## Fora de escopo
Revogação imediata de JWT, bloqueio de sessões existentes e `/admin/me` runtime ficam na #206, conforme a divisão da epic. A #209 do Ed pode continuar em paralelo como suíte de contrato sem depender dos arquivos de teste desta branch.