### PR TITLE
fix(auth): autorização runtime e revogação imediata DRE (#206)

### DIFF
--- a/api/cmd/api/admin_runtime_auth.go
+++ b/api/cmd/api/admin_runtime_auth.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"censo-api/internal/models"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// runtimeAdminClaims mantém os campos legados consumidos pelo frontend, mas
+// adiciona identidades estáveis. Para role=dre, UserID é a única identidade de
+// usuário confiável em tokens novos; DRE/DREID são snapshots informativos e o
+// escopo efetivo é sempre reconstruído do PostgreSQL a cada request.
+type runtimeAdminClaims struct {
+	UserID   int    `json:"user_id,omitempty"`
+	DREID    int    `json:"dre_id,omitempty"`
+	Username string `json:"username"`
+	Role     string `json:"role"`
+	DRE      string `json:"dre,omitempty"`
+	jwt.RegisteredClaims
+}
+
+var runtimeDummyPasswordHash = func() []byte {
+	hash, err := bcrypt.GenerateFromPassword([]byte("censo-runtime-auth-dummy-password"), bcrypt.DefaultCost)
+	if err != nil {
+		panic(err)
+	}
+	return hash
+}()
+
+func rejectRuntimeLogin(app *application, w http.ResponseWriter, password string) {
+	// Mantém custo bcrypt também quando o username não existe e preserva o
+	// atraso já usado pelo login legado para reduzir enumeração por timing.
+	_ = bcrypt.CompareHashAndPassword(runtimeDummyPasswordHash, []byte(password))
+	time.Sleep(600 * time.Millisecond)
+	app.errorJSON(w, fmt.Errorf("credenciais inválidas"), http.StatusUnauthorized)
+}
+
+func signRuntimeAdminToken(claims runtimeAdminClaims) (string, error) {
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(jwtSecret())
+}
+
+// AdminLoginRuntime emite tokens com user_id/dre_id para DREs e bloqueia login
+// quando o usuário ou a entidade mestre da DRE estiver inativa. O admin legado
+// por ENV continua sem dependência do banco.
+func (app *application) AdminLoginRuntime(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1024)
+
+	ip := clientIP(r)
+	if !loginRL.check(ip) {
+		w.Header().Set("Retry-After", "900")
+		app.errorJSON(w, fmt.Errorf("muitas tentativas. Aguarde 15 minutos"), http.StatusTooManyRequests)
+		return
+	}
+
+	var req struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := app.readJSON(w, r, &req); err != nil {
+		app.errorJSON(w, fmt.Errorf("dados inválidos"), http.StatusBadRequest)
+		return
+	}
+	if len(req.Username) > 64 || len(req.Password) > 128 {
+		app.errorJSON(w, fmt.Errorf("credenciais inválidas"), http.StatusUnauthorized)
+		return
+	}
+
+	adminUser := os.Getenv("ADMIN_USERNAME")
+	adminHash := os.Getenv("ADMIN_PASSWORD_HASH")
+	isEnvAdmin := adminUser != "" && adminHash != "" && req.Username == adminUser
+
+	now := time.Now()
+	registered := jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(now.Add(jwtExpiry)),
+		IssuedAt:  jwt.NewNumericDate(now),
+		Issuer:    "censo-admin",
+	}
+
+	var claims runtimeAdminClaims
+	if isEnvAdmin {
+		if err := bcrypt.CompareHashAndPassword([]byte(adminHash), []byte(req.Password)); err != nil {
+			time.Sleep(600 * time.Millisecond)
+			app.errorJSON(w, fmt.Errorf("credenciais inválidas"), http.StatusUnauthorized)
+			return
+		}
+		registered.Subject = "admin-env"
+		claims = runtimeAdminClaims{
+			Username:         adminUser,
+			Role:             RoleAdmin,
+			RegisteredClaims: registered,
+		}
+	} else {
+		if app.models.AdminUsers.DB == nil {
+			rejectRuntimeLogin(app, w, req.Password)
+			return
+		}
+
+		u, err := app.models.AdminUsers.GetActiveByUsername(r.Context(), req.Username)
+		if err != nil {
+			rejectRuntimeLogin(app, w, req.Password)
+			return
+		}
+		if err := bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(req.Password)); err != nil {
+			time.Sleep(600 * time.Millisecond)
+			app.errorJSON(w, fmt.Errorf("credenciais inválidas"), http.StatusUnauthorized)
+			return
+		}
+		if u.Role != RoleDRE || u.DREID <= 0 {
+			rejectRuntimeLogin(app, w, req.Password)
+			return
+		}
+
+		dre, err := app.models.DREs.GetByID(r.Context(), u.DREID)
+		if err != nil || !dre.Ativa {
+			rejectRuntimeLogin(app, w, req.Password)
+			return
+		}
+
+		registered.Subject = "admin-user:" + strconv.Itoa(u.ID)
+		claims = runtimeAdminClaims{
+			UserID:           u.ID,
+			DREID:            dre.ID,
+			Username:         u.Username,
+			Role:             RoleDRE,
+			DRE:              dre.Nome,
+			RegisteredClaims: registered,
+		}
+	}
+
+	tok, err := signRuntimeAdminToken(claims)
+	if err != nil {
+		app.errorJSON(w, fmt.Errorf("erro interno ao gerar token"), http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{
+		Error:   false,
+		Message: "Login realizado com sucesso",
+		Data: map[string]interface{}{
+			"token":      tok,
+			"expires_in": int(jwtExpiry.Seconds()),
+		},
+	})
+}
+
+func parseRuntimeAdminToken(tokenStr string) (*runtimeAdminClaims, error) {
+	claims := &runtimeAdminClaims{}
+	tok, err := jwt.ParseWithClaims(tokenStr, claims, func(t *jwt.Token) (interface{}, error) {
+		if t.Method.Alg() != jwt.SigningMethodHS256.Alg() {
+			return nil, fmt.Errorf("algoritmo de assinatura inválido")
+		}
+		return jwtSecret(), nil
+	}, jwt.WithIssuer("censo-admin"), jwt.WithExpirationRequired(), jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	if err != nil || !tok.Valid {
+		if err == nil {
+			err = fmt.Errorf("token inválido")
+		}
+		return nil, err
+	}
+	return claims, nil
+}
+
+func (app *application) resolveRuntimeDREScope(ctx context.Context, claims *runtimeAdminClaims) (AdminAccessScope, error) {
+	// Alguns testes unitários históricos constroem application{} sem DB e
+	// exercitam apenas autorização estática. Em produção o DB é obrigatório no
+	// startup; este fallback nunca é usado no servidor real.
+	if app.models.AdminUsers.DB == nil || app.models.DREs.DB == nil {
+		if strings.TrimSpace(claims.Username) == "" || strings.TrimSpace(claims.DRE) == "" {
+			return AdminAccessScope{}, fmt.Errorf("token DRE sem identidade válida")
+		}
+		return AdminAccessScope{Username: claims.Username, Role: RoleDRE, DRE: claims.DRE}, nil
+	}
+
+	var (
+		u   *models.AdminUser
+		err error
+	)
+	if claims.UserID > 0 {
+		u, err = app.models.AdminUsers.GetByID(ctx, claims.UserID)
+	} else {
+		// Compatibilidade com tokens DRE emitidos antes da #206. O username só é
+		// usado para localizar a identidade estável; nome/escopo DRE do JWT é ignorado.
+		u, err = app.models.AdminUsers.GetByUsername(ctx, claims.Username)
+	}
+	if err != nil || u == nil || !u.Active || u.Role != RoleDRE || u.DREID <= 0 {
+		return AdminAccessScope{}, fmt.Errorf("sessão DRE revogada")
+	}
+	if claims.UserID > 0 && claims.Subject != "admin-user:"+strconv.Itoa(u.ID) {
+		return AdminAccessScope{}, fmt.Errorf("subject incompatível com user_id")
+	}
+
+	dre, err := app.models.DREs.GetByID(ctx, u.DREID)
+	if err != nil || dre == nil || !dre.Ativa {
+		return AdminAccessScope{}, fmt.Errorf("DRE inativa ou inexistente")
+	}
+
+	return AdminAccessScope{
+		Username: u.Username,
+		Role:     RoleDRE,
+		DRE:      dre.Nome,
+	}, nil
+}
+
+// requireRuntimeAdminAuth valida criptograficamente o token e, para role=dre,
+// reconstrói o escopo a partir do estado atual do banco em TODA requisição.
+// Isso faz status e rename produzirem efeito imediato sem blacklist de JWT.
+func (app *application) requireRuntimeAdminAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			app.errorJSON(w, fmt.Errorf("token de autenticação necessário"), http.StatusUnauthorized)
+			return
+		}
+
+		tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+		claims, err := parseRuntimeAdminToken(tokenStr)
+		if err != nil {
+			app.errorJSON(w, fmt.Errorf("token inválido ou expirado"), http.StatusUnauthorized)
+			return
+		}
+
+		var scope AdminAccessScope
+		switch claims.Role {
+		case RoleAdmin:
+			scope = AdminAccessScope{Username: claims.Username, Role: RoleAdmin, DRE: ""}
+		case RoleDRE:
+			scope, err = app.resolveRuntimeDREScope(r.Context(), claims)
+			if err != nil {
+				app.errorJSON(w, fmt.Errorf("token inválido ou sessão revogada"), http.StatusUnauthorized)
+				return
+			}
+		default:
+			app.errorJSON(w, fmt.Errorf("role desconhecida ou inválida"), http.StatusUnauthorized)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), contextKeyAdminScope, scope)
+		ctx = context.WithValue(ctx, contextKeyAdminUser, scope.Username)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// decodeRuntimeLoginToken é pequeno e propositalmente privado; além dos testes,
+// facilita validação interna sem duplicar o shape do envelope JSON do login.
+func decodeRuntimeLoginToken(body []byte) (string, error) {
+	var envelope struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "", err
+	}
+	if envelope.Data.Token == "" {
+		return "", fmt.Errorf("token ausente")
+	}
+	return envelope.Data.Token, nil
+}

--- a/api/cmd/api/admin_runtime_auth.go
+++ b/api/cmd/api/admin_runtime_auth.go
@@ -105,34 +105,28 @@ func (app *application) AdminLoginRuntime(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		u, err := app.models.AdminUsers.GetActiveByUsername(r.Context(), req.Username)
-		if err != nil {
+		access, err := app.models.AdminUsers.GetRuntimeAccessByUsername(r.Context(), req.Username)
+		if err != nil || access == nil || !access.UserActive {
 			rejectRuntimeLogin(app, w, req.Password)
 			return
 		}
-		if err := bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(req.Password)); err != nil {
+		if err := bcrypt.CompareHashAndPassword([]byte(access.PasswordHash), []byte(req.Password)); err != nil {
 			time.Sleep(600 * time.Millisecond)
 			app.errorJSON(w, fmt.Errorf("credenciais inválidas"), http.StatusUnauthorized)
 			return
 		}
-		if u.Role != RoleDRE || u.DREID <= 0 {
+		if access.Role != RoleDRE || access.DREID <= 0 || !access.DREActive || strings.TrimSpace(access.DRE) == "" {
 			rejectRuntimeLogin(app, w, req.Password)
 			return
 		}
 
-		dre, err := app.models.DREs.GetByID(r.Context(), u.DREID)
-		if err != nil || !dre.Ativa {
-			rejectRuntimeLogin(app, w, req.Password)
-			return
-		}
-
-		registered.Subject = "admin-user:" + strconv.Itoa(u.ID)
+		registered.Subject = "admin-user:" + strconv.Itoa(access.ID)
 		claims = runtimeAdminClaims{
-			UserID:           u.ID,
-			DREID:            dre.ID,
-			Username:         u.Username,
+			UserID:           access.ID,
+			DREID:            access.DREID,
+			Username:         access.Username,
 			Role:             RoleDRE,
-			DRE:              dre.Nome,
+			DRE:              access.DRE,
 			RegisteredClaims: registered,
 		}
 	}
@@ -174,7 +168,7 @@ func (app *application) resolveRuntimeDREScope(ctx context.Context, claims *runt
 	// Alguns testes unitários históricos constroem application{} sem DB e
 	// exercitam apenas autorização estática. Em produção o DB é obrigatório no
 	// startup; este fallback nunca é usado no servidor real.
-	if app.models.AdminUsers.DB == nil || app.models.DREs.DB == nil {
+	if app.models.AdminUsers.DB == nil {
 		if strings.TrimSpace(claims.Username) == "" || strings.TrimSpace(claims.DRE) == "" {
 			return AdminAccessScope{}, fmt.Errorf("token DRE sem identidade válida")
 		}
@@ -182,32 +176,27 @@ func (app *application) resolveRuntimeDREScope(ctx context.Context, claims *runt
 	}
 
 	var (
-		u   *models.AdminUser
-		err error
+		access *models.RuntimeAdminAccess
+		err    error
 	)
 	if claims.UserID > 0 {
-		u, err = app.models.AdminUsers.GetByID(ctx, claims.UserID)
+		access, err = app.models.AdminUsers.GetRuntimeAccessByID(ctx, claims.UserID)
 	} else {
 		// Compatibilidade com tokens DRE emitidos antes da #206. O username só é
-		// usado para localizar a identidade estável; nome/escopo DRE do JWT é ignorado.
-		u, err = app.models.AdminUsers.GetByUsername(ctx, claims.Username)
+		// usado para localizar a conta; nome/escopo DRE do JWT é ignorado.
+		access, err = app.models.AdminUsers.GetRuntimeAccessByUsername(ctx, claims.Username)
 	}
-	if err != nil || u == nil || !u.Active || u.Role != RoleDRE || u.DREID <= 0 {
+	if err != nil || access == nil || !access.UserActive || access.Role != RoleDRE || access.DREID <= 0 || !access.DREActive || strings.TrimSpace(access.DRE) == "" {
 		return AdminAccessScope{}, fmt.Errorf("sessão DRE revogada")
 	}
-	if claims.UserID > 0 && claims.Subject != "admin-user:"+strconv.Itoa(u.ID) {
+	if claims.UserID > 0 && claims.Subject != "admin-user:"+strconv.Itoa(access.ID) {
 		return AdminAccessScope{}, fmt.Errorf("subject incompatível com user_id")
 	}
 
-	dre, err := app.models.DREs.GetByID(ctx, u.DREID)
-	if err != nil || dre == nil || !dre.Ativa {
-		return AdminAccessScope{}, fmt.Errorf("DRE inativa ou inexistente")
-	}
-
 	return AdminAccessScope{
-		Username: u.Username,
+		Username: access.Username,
 		Role:     RoleDRE,
-		DRE:      dre.Nome,
+		DRE:      access.DRE,
 	}, nil
 }
 

--- a/api/cmd/api/analytics_dre_master_test.go
+++ b/api/cmd/api/analytics_dre_master_test.go
@@ -239,7 +239,14 @@ func TestDREMasterIntegrationFlow(t *testing.T) {
 		t.Fatalf("resumo após associação inconsistente: %+v", summary)
 	}
 
-	// O escopo role=dre precisa impor a DRE do token mesmo sem query param.
+	// O escopo role=dre precisa impor a DRE da conta autenticada mesmo sem query param.
+	// A #206 exige que todo token DRE corresponda a um usuário real e ativo no banco.
+	if _, err := db.Exec(`
+		INSERT INTO admin_users (username, password_hash, role, dre, active, created_at, updated_at)
+		VALUES ($1, 'integration-test-hash', 'dre', $2, true, NOW(), NOW())
+	`, "integration-dre", dreA.Nome); err != nil {
+		t.Fatalf("inserir usuário DRE de integração: %v", err)
+	}
 	dreToken := createTestJWT("integration-dre", RoleDRE, dreA.Nome)
 	scopedRR := requestDREIntegration(t, handler, dreToken, http.MethodGet,
 		"/v1/admin/analytics/preenchimento/dre?year=2026", nil)

--- a/api/cmd/api/analytics_dre_master_test.go
+++ b/api/cmd/api/analytics_dre_master_test.go
@@ -56,7 +56,7 @@ func newDREIntegrationApp(t *testing.T, db *sql.DB) (*application, http.Handler,
 
 func resetDREIntegrationData(t *testing.T, db *sql.DB) {
 	t.Helper()
-	if _, err := db.Exec(`TRUNCATE TABLE census_responses, schools, dres RESTART IDENTITY CASCADE`); err != nil {
+	if _, err := db.Exec(`TRUNCATE TABLE census_responses, schools, admin_users, dres RESTART IDENTITY CASCADE`); err != nil {
 		t.Fatalf("limpar dados de integração: %v", err)
 	}
 }

--- a/api/cmd/api/dre_runtime_auth_revocation_test.go
+++ b/api/cmd/api/dre_runtime_auth_revocation_test.go
@@ -1,0 +1,425 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"censo-api/internal/models"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const runtimeAuthTestSecret = "dre-runtime-auth-test-secret-0123456789-abcdefghijklmnopqrstuvwxyz"
+
+func resetRuntimeLoginLimiter() {
+	loginRL.mu.Lock()
+	loginRL.attempts = make(map[string][]time.Time)
+	loginRL.mu.Unlock()
+}
+
+func setupRuntimeAuthTest(t *testing.T) (*application, http.Handler, models.Models) {
+	t.Helper()
+	t.Setenv("ADMIN_JWT_SECRET", runtimeAuthTestSecret)
+	t.Setenv("ADMIN_USERNAME", "")
+	t.Setenv("ADMIN_PASSWORD_HASH", "")
+	t.Setenv("TRUSTED_PROXY_COUNT", "0")
+	resetRuntimeLoginLimiter()
+
+	_, m := setupDRELifecycleTestDB(t, true)
+	app := &application{models: m}
+	return app, app.routes(), m
+}
+
+func runtimeLoginRequest(t *testing.T, handler http.Handler, username, password, remoteAddr string) (*httptest.ResponseRecorder, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/login", strings.NewReader(fmt.Sprintf(`{"username":%q,"password":%q}`, username, password)))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = remoteAddr
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		return rr, ""
+	}
+	token, err := decodeRuntimeLoginToken(rr.Body.Bytes())
+	if err != nil {
+		t.Fatalf("decode runtime login token: %v; body=%s", err, rr.Body.String())
+	}
+	return rr, token
+}
+
+func runtimeMeRequest(handler http.Handler, token string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/me", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+type runtimeMePayload struct {
+	Error bool `json:"error"`
+	Data  struct {
+		Username string  `json:"username"`
+		Role     string  `json:"role"`
+		DRE      *string `json:"dre"`
+	} `json:"data"`
+}
+
+func decodeRuntimeMe(t *testing.T, rr *httptest.ResponseRecorder) runtimeMePayload {
+	t.Helper()
+	var payload runtimeMePayload
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode /admin/me: %v; body=%s", err, rr.Body.String())
+	}
+	return payload
+}
+
+func createRuntimeDREUser(t *testing.T, m models.Models, dreName, username, password string) (*models.DRE, *models.AdminUser) {
+	t.Helper()
+	ctx := context.Background()
+	dre, err := m.DREs.Create(ctx, models.DRE{Nome: dreName, Ativa: true})
+	if err != nil {
+		t.Fatalf("create DRE: %v", err)
+	}
+	user, err := m.AdminUsers.CreateForDREID(ctx, username, password, RoleDRE, dre.ID)
+	if err != nil {
+		t.Fatalf("create DRE user: %v", err)
+	}
+	return dre, user
+}
+
+func TestRuntimeDRETokenStableIdentityAndMeTracksCurrentDatabaseState(t *testing.T) {
+	app, handler, m := setupRuntimeAuthTest(t)
+	_ = app
+	ctx := context.Background()
+	password := "runtime-password-206"
+	dre, user := createRuntimeDREUser(t, m, "DRE RUNTIME ORIGINAL", "runtime.user", password)
+
+	rr, token := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.1:5001")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("login status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	claims, err := parseRuntimeAdminToken(token)
+	if err != nil {
+		t.Fatalf("parse issued runtime token: %v", err)
+	}
+	if claims.UserID != user.ID || claims.DREID != dre.ID {
+		t.Fatalf("stable claims mismatch: user_id=%d/%d dre_id=%d/%d", claims.UserID, user.ID, claims.DREID, dre.ID)
+	}
+	if claims.Subject != fmt.Sprintf("admin-user:%d", user.ID) {
+		t.Fatalf("stable subject mismatch: %q", claims.Subject)
+	}
+	if claims.DRE != "DRE RUNTIME ORIGINAL" {
+		t.Fatalf("unexpected initial DRE snapshot: %q", claims.DRE)
+	}
+
+	meBefore := runtimeMeRequest(handler, token)
+	if meBefore.Code != http.StatusOK {
+		t.Fatalf("initial /me status=%d body=%s", meBefore.Code, meBefore.Body.String())
+	}
+	before := decodeRuntimeMe(t, meBefore)
+	if before.Data.DRE == nil || *before.Data.DRE != dre.Nome || before.Data.Username != user.Username {
+		t.Fatalf("initial /me stale: %+v", before.Data)
+	}
+
+	dre.Nome = "DRE RUNTIME RENOMEADA"
+	if _, err := m.DREs.Update(ctx, *dre); err != nil {
+		t.Fatalf("rename DRE: %v", err)
+	}
+	if _, err := m.AdminUsers.DB.ExecContext(ctx, `UPDATE admin_users SET username = $1, updated_at = NOW() WHERE id = $2`, "runtime.user.renamed", user.ID); err != nil {
+		t.Fatalf("rename username fixture: %v", err)
+	}
+
+	// O JWT continua contendo snapshots antigos. O resultado correto só pode vir
+	// de uma resolução runtime por identidade estável.
+	staleClaims, err := parseRuntimeAdminToken(token)
+	if err != nil {
+		t.Fatalf("parse stale token: %v", err)
+	}
+	if staleClaims.DRE != "DRE RUNTIME ORIGINAL" || staleClaims.Username != "runtime.user" {
+		t.Fatalf("fixture deixou de provar claims stale: dre=%q username=%q", staleClaims.DRE, staleClaims.Username)
+	}
+
+	meAfter := runtimeMeRequest(handler, token)
+	if meAfter.Code != http.StatusOK {
+		t.Fatalf("same token after rename status=%d body=%s", meAfter.Code, meAfter.Body.String())
+	}
+	after := decodeRuntimeMe(t, meAfter)
+	if after.Data.DRE == nil || *after.Data.DRE != "DRE RUNTIME RENOMEADA" || after.Data.Username != "runtime.user.renamed" || after.Data.Role != RoleDRE {
+		t.Fatalf("/me did not resolve current DB state: %+v", after.Data)
+	}
+}
+
+func TestRuntimeDREImmediateRevocationForUserAndDREStatus(t *testing.T) {
+	_, handler, m := setupRuntimeAuthTest(t)
+	ctx := context.Background()
+	password := "runtime-status-password"
+	dre, user := createRuntimeDREUser(t, m, "DRE STATUS", "status.user", password)
+
+	_, token := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.2:5002")
+	if token == "" {
+		t.Fatalf("expected initial token")
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
+		t.Fatalf("baseline request failed: %d %s", rr.Code, rr.Body.String())
+	}
+
+	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, false); err != nil {
+		t.Fatalf("deactivate user: %v", err)
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("same token survived user deactivation: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, true); err != nil {
+		t.Fatalf("reactivate user: %v", err)
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
+		t.Fatalf("same token did not recover after user reactivation: %d %s", rr.Code, rr.Body.String())
+	}
+
+	if err := m.DREs.SetActive(ctx, dre.ID, false); err != nil {
+		t.Fatalf("deactivate DRE: %v", err)
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("same token survived DRE deactivation: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	loginInactive, inactiveToken := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.3:5003")
+	if loginInactive.Code != http.StatusUnauthorized || inactiveToken != "" {
+		t.Fatalf("inactive DRE accepted login: status=%d body=%s", loginInactive.Code, loginInactive.Body.String())
+	}
+
+	if err := m.DREs.SetActive(ctx, dre.ID, true); err != nil {
+		t.Fatalf("reactivate DRE: %v", err)
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
+		t.Fatalf("same old token did not recover after DRE reactivation: %d %s", rr.Code, rr.Body.String())
+	}
+	loginActive, newToken := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.4:5004")
+	if loginActive.Code != http.StatusOK || newToken == "" {
+		t.Fatalf("reactivated DRE did not accept login: status=%d body=%s", loginActive.Code, loginActive.Body.String())
+	}
+}
+
+func TestRuntimeLegacyDRETokenIsRevalidatedAgainstCurrentDatabase(t *testing.T) {
+	_, handler, m := setupRuntimeAuthTest(t)
+	ctx := context.Background()
+	dre, user := createRuntimeDREUser(t, m, "DRE LEGACY ORIGINAL", "legacy.runtime.user", "legacy-password")
+
+	legacy := adminClaims{
+		Username: user.Username,
+		Role:     RoleDRE,
+		DRE:      "DRE CLAIM ANTIGA",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "censo-admin",
+			Subject:   "admin",
+		},
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, legacy).SignedString(jwtSecret())
+	if err != nil {
+		t.Fatalf("sign legacy token: %v", err)
+	}
+
+	dre.Nome = "DRE LEGACY RENOMEADA"
+	if _, err := m.DREs.Update(ctx, *dre); err != nil {
+		t.Fatalf("rename DRE: %v", err)
+	}
+
+	rr := runtimeMeRequest(handler, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("legacy token should be upgraded runtime, status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	me := decodeRuntimeMe(t, rr)
+	if me.Data.DRE == nil || *me.Data.DRE != "DRE LEGACY RENOMEADA" {
+		t.Fatalf("legacy token trusted stale DRE claim: %+v", me.Data)
+	}
+
+	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, false); err != nil {
+		t.Fatalf("deactivate legacy user: %v", err)
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("legacy token survived user deactivation: %d %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestRuntimeEnvAdminCompatibilityAndJWTGuards(t *testing.T) {
+	t.Setenv("ADMIN_JWT_SECRET", runtimeAuthTestSecret)
+	t.Setenv("TRUSTED_PROXY_COUNT", "0")
+	resetRuntimeLoginLimiter()
+
+	password := "env-admin-runtime-password"
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("bcrypt env admin: %v", err)
+	}
+	t.Setenv("ADMIN_USERNAME", "runtime_env_admin")
+	t.Setenv("ADMIN_PASSWORD_HASH", string(hash))
+
+	app := &application{}
+	handler := app.routes()
+	login, token := runtimeLoginRequest(t, handler, "runtime_env_admin", password, "10.20.30.5:5005")
+	if login.Code != http.StatusOK || token == "" {
+		t.Fatalf("env admin login failed: status=%d body=%s", login.Code, login.Body.String())
+	}
+	claims, err := parseRuntimeAdminToken(token)
+	if err != nil {
+		t.Fatalf("parse env admin token: %v", err)
+	}
+	if claims.Role != RoleAdmin || claims.UserID != 0 || claims.DREID != 0 || claims.Username != "runtime_env_admin" {
+		t.Fatalf("env admin claims changed incompatibly: %+v", claims)
+	}
+	me := runtimeMeRequest(handler, token)
+	if me.Code != http.StatusOK {
+		t.Fatalf("env admin /me failed: %d %s", me.Code, me.Body.String())
+	}
+
+	tests := []struct {
+		name  string
+		token func() string
+	}{
+		{
+			name: "expired",
+			token: func() string {
+				c := runtimeAdminClaims{Username: "runtime_env_admin", Role: RoleAdmin, RegisteredClaims: jwt.RegisteredClaims{
+					ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+					IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+					Issuer:    "censo-admin",
+				}}
+				s, _ := signRuntimeAdminToken(c)
+				return s
+			},
+		},
+		{
+			name: "wrong issuer",
+			token: func() string {
+				c := runtimeAdminClaims{Username: "runtime_env_admin", Role: RoleAdmin, RegisteredClaims: jwt.RegisteredClaims{
+					ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+					Issuer:    "outro-emissor",
+				}}
+				s, _ := signRuntimeAdminToken(c)
+				return s
+			},
+		},
+		{
+			name: "hs384 rejected",
+			token: func() string {
+				c := runtimeAdminClaims{Username: "runtime_env_admin", Role: RoleAdmin, RegisteredClaims: jwt.RegisteredClaims{
+					ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+					Issuer:    "censo-admin",
+				}}
+				s, _ := jwt.NewWithClaims(jwt.SigningMethodHS384, c).SignedString(jwtSecret())
+				return s
+			},
+		},
+		{
+			name: "unknown role",
+			token: func() string {
+				c := runtimeAdminClaims{Username: "x", Role: "superman", RegisteredClaims: jwt.RegisteredClaims{
+					ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+					Issuer:    "censo-admin",
+				}}
+				s, _ := signRuntimeAdminToken(c)
+				return s
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := runtimeMeRequest(handler, tc.token())
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d body=%s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+
+	if rr := runtimeMeRequest(handler, ""); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("missing bearer token accepted: %d %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestRuntimeDREAuthorizationStress6000RequestsWithStaleClaims(t *testing.T) {
+	app, _, m := setupRuntimeAuthTest(t)
+	ctx := context.Background()
+	dre, user := createRuntimeDREUser(t, m, "DRE STRESS AUTH 000", "runtime.stress.user", "stress-password")
+
+	now := time.Now()
+	claims := runtimeAdminClaims{
+		UserID:   user.ID,
+		DREID:    dre.ID,
+		Username: user.Username,
+		Role:     RoleDRE,
+		DRE:      dre.Nome,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(2 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			Issuer:    "censo-admin",
+			Subject:   fmt.Sprintf("admin-user:%d", user.ID),
+		},
+	}
+	token, err := signRuntimeAdminToken(claims)
+	if err != nil {
+		t.Fatalf("sign stress token: %v", err)
+	}
+
+	expectedDRE := dre.Nome
+	calls := 0
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scope, ok := GetAdminAccessScope(r.Context())
+		if !ok {
+			t.Errorf("runtime scope missing")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if scope.Username != user.Username || scope.Role != RoleDRE || scope.DRE != expectedDRE {
+			t.Errorf("iteration scope stale: %+v expected DRE=%q", scope, expectedDRE)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		calls++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	protected := app.requireRuntimeAdminAuth(next)
+
+	for i := 0; i < 6000; i++ {
+		if i > 0 && i%1000 == 0 {
+			expectedDRE = fmt.Sprintf("DRE STRESS AUTH %03d", i/1000)
+			dre.Nome = expectedDRE
+			if _, err := m.DREs.Update(ctx, *dre); err != nil {
+				t.Fatalf("iteration %d rename: %v", i, err)
+			}
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/admin/me", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		protected.ServeHTTP(rr, req)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("iteration %d status=%d body=%s", i, rr.Code, rr.Body.String())
+		}
+	}
+	if calls != 6000 {
+		t.Fatalf("authorized calls=%d want=6000", calls)
+	}
+
+	// O snapshot original continuou propositalmente stale durante todo o stress.
+	parsed, err := parseRuntimeAdminToken(token)
+	if err != nil {
+		t.Fatalf("parse stress token: %v", err)
+	}
+	if parsed.DRE != "DRE STRESS AUTH 000" {
+		t.Fatalf("stress token unexpectedly mutated: %q", parsed.DRE)
+	}
+}

--- a/api/cmd/api/dre_runtime_auth_transition_test.go
+++ b/api/cmd/api/dre_runtime_auth_transition_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"censo-api/internal/models"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestRuntimeDREAuthorizationTransitionSchemaWithoutDREID(t *testing.T) {
+	t.Setenv("ADMIN_JWT_SECRET", runtimeAuthTestSecret)
+	t.Setenv("ADMIN_USERNAME", "")
+	t.Setenv("ADMIN_PASSWORD_HASH", "")
+	t.Setenv("TRUSTED_PROXY_COUNT", "0")
+	resetRuntimeLoginLimiter()
+
+	db, m := setupDRELifecycleTestDB(t, false)
+	app := &application{models: m}
+	handler := app.routes()
+	ctx := context.Background()
+
+	dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE TRANSICAO", Ativa: true})
+	if err != nil {
+		t.Fatalf("create transition DRE: %v", err)
+	}
+
+	password := "transition-runtime-password"
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("bcrypt transition user: %v", err)
+	}
+	var userID int
+	if err := db.QueryRowContext(ctx, `
+		INSERT INTO admin_users (username, password_hash, role, dre, active, created_at, updated_at)
+		VALUES ($1, $2, 'dre', $3, true, NOW(), NOW())
+		RETURNING id`, "transition.user", string(hash), dre.Nome).Scan(&userID); err != nil {
+		t.Fatalf("seed transition user: %v", err)
+	}
+
+	login, token := runtimeLoginRequest(t, handler, "transition.user", password, "10.20.30.6:5006")
+	if login.Code != http.StatusOK || token == "" {
+		t.Fatalf("transition login status=%d body=%s", login.Code, login.Body.String())
+	}
+	claims, err := parseRuntimeAdminToken(token)
+	if err != nil {
+		t.Fatalf("parse transition token: %v", err)
+	}
+	if claims.UserID != userID || claims.DREID != dre.ID || claims.DRE != dre.Nome {
+		t.Fatalf("transition token did not derive stable identity: user_id=%d/%d dre_id=%d/%d dre=%q", claims.UserID, userID, claims.DREID, dre.ID, claims.DRE)
+	}
+
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
+		t.Fatalf("transition baseline /me status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	dre.Nome = "DRE TRANSICAO RENOMEADA"
+	if _, err := m.DREs.Update(ctx, *dre); err != nil {
+		t.Fatalf("rename transition DRE: %v", err)
+	}
+	me := runtimeMeRequest(handler, token)
+	if me.Code != http.StatusOK {
+		t.Fatalf("same transition token after rename status=%d body=%s", me.Code, me.Body.String())
+	}
+	payload := decodeRuntimeMe(t, me)
+	if payload.Data.DRE == nil || *payload.Data.DRE != dre.Nome {
+		t.Fatalf("transition token trusted stale DRE claim: %+v", payload.Data)
+	}
+
+	if err := m.DREs.SetActive(ctx, dre.ID, false); err != nil {
+		t.Fatalf("deactivate transition DRE: %v", err)
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("transition token survived DRE deactivation: %d %s", rr.Code, rr.Body.String())
+	}
+	if err := m.DREs.SetActive(ctx, dre.ID, true); err != nil {
+		t.Fatalf("reactivate transition DRE: %v", err)
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
+		t.Fatalf("transition token did not recover after DRE reactivation: %d %s", rr.Code, rr.Body.String())
+	}
+
+	if _, err := db.ExecContext(ctx, `UPDATE admin_users SET active = false, updated_at = NOW() WHERE id = $1`, userID); err != nil {
+		t.Fatalf("deactivate transition user: %v", err)
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("transition token survived user deactivation: %d %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestRuntimeTransitionSchemaNeverUsesSchoolsAsDREIdentity(t *testing.T) {
+	t.Setenv("ADMIN_JWT_SECRET", runtimeAuthTestSecret)
+	t.Setenv("ADMIN_USERNAME", "")
+	t.Setenv("ADMIN_PASSWORD_HASH", "")
+	t.Setenv("TRUSTED_PROXY_COUNT", "0")
+	resetRuntimeLoginLimiter()
+
+	db, m := setupDRELifecycleTestDB(t, false)
+	app := &application{models: m}
+	handler := app.routes()
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO schools (dre) VALUES ('DRE SOMENTE ESCOLA')`); err != nil {
+		t.Fatalf("seed ghost school DRE: %v", err)
+	}
+	password := "ghost-transition-password"
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("bcrypt ghost user: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO admin_users (username, password_hash, role, dre, active, created_at, updated_at)
+		VALUES ('ghost.transition.user', $1, 'dre', 'DRE SOMENTE ESCOLA', true, NOW(), NOW())`, string(hash)); err != nil {
+		t.Fatalf("seed ghost transition user: %v", err)
+	}
+
+	login, token := runtimeLoginRequest(t, handler, "ghost.transition.user", password, "10.20.30.7:5007")
+	if login.Code != http.StatusUnauthorized || token != "" {
+		t.Fatalf("schools-only DRE became runtime identity: status=%d token=%q body=%s", login.Code, token, login.Body.String())
+	}
+
+	access, err := m.AdminUsers.GetRuntimeAccessByUsername(ctx, "ghost.transition.user")
+	if err != nil {
+		t.Fatalf("resolve ghost transition user: %v", err)
+	}
+	if access.DREID != 0 || access.DRE != "" || access.DREActive {
+		t.Fatalf("ghost DRE unexpectedly resolved: id=%d dre=%q active=%v", access.DREID, access.DRE, access.DREActive)
+	}
+
+	_ = fmt.Sprintf("%d", access.ID) // keep the stable account identity explicitly exercised
+}

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -324,10 +324,10 @@ func (app *application) routes() http.Handler {
 			pub.With(app.requireCensusSubmissions).Post("/upload", app.uploadPhoto)
 		})
 
-		// Admin: login público + rotas protegidas por JWT
-		r.Post("/admin/login", app.AdminLogin)
+		// Admin: login público + rotas protegidas por JWT e estado runtime.
+		r.Post("/admin/login", app.AdminLoginRuntime)
 		r.Group(func(protected chi.Router) {
-			protected.Use(app.requireAdminAuth)
+			protected.Use(app.requireRuntimeAdminAuth)
 			protected.Get("/admin/me", app.AdminMe)
 			protected.Get("/admin/dashboard", app.AdminDashboard)
 			protected.Get("/admin/sheet-metrics", app.AdminSheetMetrics)

--- a/api/internal/models/admin_runtime_access.go
+++ b/api/internal/models/admin_runtime_access.go
@@ -1,0 +1,106 @@
+package models
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+)
+
+// RuntimeAdminAccess representa o estado efetivo de autorização de uma conta
+// DRE no momento da requisição. DRE/flags sempre vêm da entidade mestre dres;
+// o texto legado admin_users.dre só é usado para localizar essa entidade
+// durante a janela de rollout anterior à coluna dre_id.
+type RuntimeAdminAccess struct {
+	ID           int
+	Username     string
+	PasswordHash string
+	Role         string
+	UserActive   bool
+	DREID        int
+	DRE          string
+	DREActive    bool
+}
+
+func (m *AdminUserModel) getRuntimeAccess(ctx context.Context, byID bool, id int, username string) (*RuntimeAdminAccess, error) {
+	if m.DB == nil {
+		return nil, ErrUserNotFound
+	}
+
+	canonical, err := hasColumn(ctx, m.DB, "admin_users", "dre_id")
+	if err != nil {
+		return nil, err
+	}
+
+	var query string
+	var arg any
+	if byID {
+		if id <= 0 {
+			return nil, ErrUserNotFound
+		}
+		arg = id
+	} else {
+		username = strings.TrimSpace(username)
+		if username == "" {
+			return nil, ErrUserNotFound
+		}
+		arg = username
+	}
+
+	predicate := "u.id = $1"
+	if !byID {
+		predicate = "LOWER(u.username) = LOWER($1)"
+	}
+
+	if canonical {
+		query = `
+			SELECT u.id, u.username, u.password_hash, u.role, u.active,
+			       COALESCE(d.id, 0), COALESCE(d.nome, ''), COALESCE(d.ativa, false)
+			FROM admin_users u
+			LEFT JOIN dres d ON d.id = u.dre_id
+			WHERE ` + predicate
+	} else {
+		// Antes da migration 0020, a relação ainda é textual. A resolução é
+		// exclusivamente contra dres e exige exatamente uma correspondência
+		// normalizada; schools nunca participa da identidade/autorização.
+		query = `
+			SELECT u.id, u.username, u.password_hash, u.role, u.active,
+			       COALESCE(d.id, 0), COALESCE(d.nome, ''), COALESCE(d.ativa, false)
+			FROM admin_users u
+			LEFT JOIN LATERAL (
+				SELECT MIN(d0.id) AS dre_id, COUNT(*) AS matches
+				FROM dres d0
+				WHERE UPPER(BTRIM(d0.nome)) = UPPER(BTRIM(COALESCE(u.dre, '')))
+			) resolved ON true
+			LEFT JOIN dres d ON d.id = resolved.dre_id AND resolved.matches = 1
+			WHERE ` + predicate
+	}
+
+	var access RuntimeAdminAccess
+	err = m.DB.QueryRowContext(ctx, query, arg).Scan(
+		&access.ID,
+		&access.Username,
+		&access.PasswordHash,
+		&access.Role,
+		&access.UserActive,
+		&access.DREID,
+		&access.DRE,
+		&access.DREActive,
+	)
+	if err == sql.ErrNoRows {
+		return nil, ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &access, nil
+}
+
+// GetRuntimeAccessByUsername é usado no login e em tokens legados sem user_id.
+func (m *AdminUserModel) GetRuntimeAccessByUsername(ctx context.Context, username string) (*RuntimeAdminAccess, error) {
+	return m.getRuntimeAccess(ctx, false, 0, username)
+}
+
+// GetRuntimeAccessByID é o caminho principal para tokens novos da #206.
+func (m *AdminUserModel) GetRuntimeAccessByID(ctx context.Context, id int) (*RuntimeAdminAccess, error) {
+	return m.getRuntimeAccess(ctx, true, id, "")
+}


### PR DESCRIPTION
Implementa a #206 sobre a `develop` já contendo a #205.

Closes #206
Parent epic: #203

Principais mudanças:
- tokens DRE novos carregam `user_id` e `dre_id`;
- middleware protegido reconstrói o escopo DRE a partir do banco em toda requisição;
- usuário inativo ou DRE inativa revogam imediatamente tokens já emitidos;
- rename de DRE/username passa a aparecer no `/admin/me` com o mesmo token;
- tokens DRE legados sem `user_id` continuam compatíveis, mas são revalidados por username e não confiam no nome DRE do JWT;
- admin legado por ENV permanece funcional;
- HS256/issuer/expiração continuam obrigatórios e o algoritmo foi restringido explicitamente a HS256;
- teste de stress específico executa 6.000 autorizações com o mesmo JWT stale e renames durante a execução.

Aberto como draft apenas para rodar o CI completo antes de liberar para review. A #209 do Ed permanece isolada em testes de contrato e esta branch não altera os arquivos dela.