### PR TITLE
refactor(dre): propagar dre_id para filtros, escolas e analytics (#207)

### DIFF
--- a/api/cmd/api/admin_census_dre_id.go
+++ b/api/cmd/api/admin_census_dre_id.go
@@ -150,7 +150,9 @@ func (app *application) AdminGetCensusCanonical(w http.ResponseWriter, r *http.R
 }
 
 // AdminGetCensusByIDCanonical elimina a BOLA textual do caminho ativo. Em
-// schema canônico, ausência ou mismatch de dre_id falha fechado.
+// schema canônico, ausência ou mismatch de dre_id falha fechado. O booleano
+// canonical_mode permite que o CI pré-0020 continue exercitando o contrato
+// legado sem mascarar órfãos em bancos já migrados.
 func (app *application) AdminGetCensusByIDCanonical(w http.ResponseWriter, r *http.Request) {
 	scope, _ := GetAdminAccessScope(r.Context())
 
@@ -163,17 +165,19 @@ func (app *application) AdminGetCensusByIDCanonical(w http.ResponseWriter, r *ht
 	var c CensusFullRecord
 	var rawData []byte
 	var targetDREID int
+	var canonicalMode bool
 	dreName := schoolDRENameExpr("s")
 	dreID := schoolDREIDExpr("s")
 	err = app.models.Schools.DB.QueryRowContext(r.Context(), `
 		SELECT cr.id, cr.school_id, s.nome_escola, s.codigo_inep, s.municipio,
 		       `+dreName+` AS dre, `+dreID+` AS dre_id,
+		       `+canonicalSchoolDREColumnSQL+` AS canonical_mode,
 		       cr.year, cr.status, cr.data, cr.created_at, cr.updated_at,
 		       (cr.sheet_synced_at IS NOT NULL)
 		FROM census_responses cr
 		JOIN schools s ON s.id = cr.school_id
 		WHERE cr.id = $1`, id).Scan(
-		&c.CensusID, &c.SchoolID, &c.Nome, &c.INEP, &c.Municipio, &c.Dre, &targetDREID,
+		&c.CensusID, &c.SchoolID, &c.Nome, &c.INEP, &c.Municipio, &c.Dre, &targetDREID, &canonicalMode,
 		&c.Year, &c.Status, &rawData, &c.CreatedAt, &c.UpdatedAt, &c.Synced,
 	)
 	if err != nil {
@@ -181,14 +185,12 @@ func (app *application) AdminGetCensusByIDCanonical(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if scope.Role == RoleDRE && scope.DREID > 0 {
-		if targetDREID <= 0 || !scope.IsAuthorizedForDREID(targetDREID) {
+	if scope.Role == RoleDRE && canonicalMode {
+		if scope.DREID <= 0 || targetDREID <= 0 || !scope.IsAuthorizedForDREID(targetDREID) {
 			app.errorJSON(w, fmt.Errorf("acesso não permitido para esta DRE"), http.StatusForbidden)
 			return
 		}
 	} else if !scope.IsAuthorizedForDRE(c.Dre) {
-		// Compatibilidade somente para testes/tokens pré-0020. Usuários runtime
-		// pós-#206 sempre chegam ao ramo canônico acima.
 		app.errorJSON(w, fmt.Errorf("acesso não permitido para esta DRE"), http.StatusForbidden)
 		return
 	}

--- a/api/cmd/api/admin_census_dre_id.go
+++ b/api/cmd/api/admin_census_dre_id.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func canonicalCensusListWhereSQL() string {
+	dreFilter := `(
+		$8 > 0 AND ` + schoolDREAuthorizationPredicate("s", "$8", "$3") + `
+		OR $8 = 0 AND ($3 = '' OR ` + schoolDRENamePredicate("s", "$3") + `)
+	)`
+	dreSearch := schoolDRENameExpr("s")
+	return `
+	WHERE ($1 = '' OR cr.status = $1)
+	  AND ($2 = 0 OR cr.year = $2)
+	  AND ` + dreFilter + `
+	  AND ($4 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($5)))
+	  AND ($6 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($6))
+	      ))
+	  AND ($7 = ''
+	       OR s.nome_escola ILIKE '%' || $7 || '%'
+	       OR s.codigo_inep ILIKE '%' || $7 || '%'
+	       OR s.municipio ILIKE '%' || $7 || '%'
+	       OR ` + dreSearch + ` ILIKE '%' || $7 || '%'
+	       OR cr.status ILIKE '%' || $7 || '%'
+	       OR cr.year::text ILIKE '%' || $7 || '%')`
+}
+
+func canonicalCensusWhereArgs(p censusListParams, scope AdminAccessScope) []any {
+	dreID := 0
+	if scope.Role == RoleDRE {
+		dreID = scope.DREID
+	}
+	return []any{p.Status, p.Year, p.DRE, p.Municipio, p.Zona, p.RegiaoIntegracao, p.Search, dreID}
+}
+
+func canonicalCensusSummarySQL() string {
+	dreFilter := `(
+		$6 > 0 AND ` + schoolDREAuthorizationPredicate("s", "$6", "$2") + `
+		OR $6 = 0 AND ($2 = '' OR ` + schoolDRENamePredicate("s", "$2") + `)
+	)`
+	return `
+	SELECT
+		(SELECT COUNT(*)
+		 FROM schools s
+		 WHERE ` + dreFilter + `
+		   AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+		   AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+		   AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+		         SELECT UPPER(TRIM(municipio))
+		         FROM reg_integracao
+		         WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+		       ))),
+		COUNT(*) FILTER (WHERE cr.status = 'completed'),
+		COUNT(*) FILTER (WHERE cr.status = 'draft'),
+		COUNT(*) FILTER (WHERE cr.status = 'completed' AND cr.sheet_synced_at IS NULL)
+	FROM census_responses cr
+	JOIN schools s ON s.id = cr.school_id
+	WHERE ($1 = 0 OR cr.year = $1)
+	  AND ` + dreFilter + `
+	  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
+	  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
+	  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
+	        SELECT UPPER(TRIM(municipio))
+	        FROM reg_integracao
+	        WHERE UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))
+	      ))`
+}
+
+// AdminGetCensusCanonical é o caminho roteado da lista. A autorização de DRE
+// usa a identidade runtime por ID; filtros administrativos por nome são
+// resolvidos contra a entidade mestre e o vínculo canônico.
+func (app *application) AdminGetCensusCanonical(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	db := app.models.Schools.DB
+	scope, _ := GetAdminAccessScope(ctx)
+
+	p := parseCensusListParams(r.URL.Query())
+	if scope.Role == RoleDRE {
+		p.DRE = strings.TrimSpace(scope.DRE)
+	}
+	whereArgs := canonicalCensusWhereArgs(p, scope)
+	whereSQL := canonicalCensusListWhereSQL()
+
+	countSQL := `SELECT COUNT(*) FROM census_responses cr JOIN schools s ON s.id = cr.school_id` + whereSQL
+	var total int
+	if err := db.QueryRowContext(ctx, countSQL, whereArgs...).Scan(&total); err != nil {
+		app.errorJSON(w, fmt.Errorf("erro ao contar censos"), http.StatusInternalServerError)
+		return
+	}
+
+	dreName := schoolDRENameExpr("s")
+	selectSQL := `
+		SELECT cr.id, cr.school_id, s.nome_escola, s.codigo_inep, s.municipio,
+			` + dreName + ` AS dre, cr.year, cr.status, cr.updated_at,
+			(cr.sheet_synced_at IS NOT NULL)
+		FROM census_responses cr
+		JOIN schools s ON s.id = cr.school_id` + whereSQL + `
+		ORDER BY cr.updated_at DESC
+		LIMIT $9 OFFSET $10`
+	offset := (p.Page - 1) * p.Limit
+	rows, err := db.QueryContext(ctx, selectSQL, append(whereArgs, p.Limit, offset)...)
+	if err != nil {
+		app.errorJSON(w, fmt.Errorf("erro ao listar censos"), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	results := make([]CensusRow, 0)
+	for rows.Next() {
+		var c CensusRow
+		if err := rows.Scan(&c.CensusID, &c.SchoolID, &c.Nome, &c.INEP, &c.Municipio,
+			&c.Dre, &c.Year, &c.Status, &c.UpdatedAt, &c.Synced); err != nil {
+			app.errorJSON(w, err, http.StatusInternalServerError)
+			return
+		}
+		results = append(results, c)
+	}
+	if err := rows.Err(); err != nil {
+		app.errorJSON(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	dreID := 0
+	if scope.Role == RoleDRE {
+		dreID = scope.DREID
+	}
+	var summary CensusSummary
+	if err := db.QueryRowContext(ctx, canonicalCensusSummarySQL(),
+		p.Year, p.DRE, p.Municipio, p.Zona, p.RegiaoIntegracao, dreID).Scan(
+		&summary.TotalSchools, &summary.CompletedCensuses,
+		&summary.DraftCensuses, &summary.PendingSync); err != nil {
+		app.errorJSON(w, fmt.Errorf("erro ao resumir censos"), http.StatusInternalServerError)
+		return
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: CensusPageResponse{
+		Rows: results, Total: total, Page: p.Page, Limit: p.Limit, Summary: summary,
+	}})
+}
+
+// AdminGetCensusByIDCanonical elimina a BOLA textual do caminho ativo. Em
+// schema canônico, ausência ou mismatch de dre_id falha fechado.
+func (app *application) AdminGetCensusByIDCanonical(w http.ResponseWriter, r *http.Request) {
+	scope, _ := GetAdminAccessScope(r.Context())
+
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil || id <= 0 {
+		app.errorJSON(w, fmt.Errorf("id inválido"), http.StatusBadRequest)
+		return
+	}
+
+	var c CensusFullRecord
+	var rawData []byte
+	var targetDREID int
+	dreName := schoolDRENameExpr("s")
+	dreID := schoolDREIDExpr("s")
+	err = app.models.Schools.DB.QueryRowContext(r.Context(), `
+		SELECT cr.id, cr.school_id, s.nome_escola, s.codigo_inep, s.municipio,
+		       `+dreName+` AS dre, `+dreID+` AS dre_id,
+		       cr.year, cr.status, cr.data, cr.created_at, cr.updated_at,
+		       (cr.sheet_synced_at IS NOT NULL)
+		FROM census_responses cr
+		JOIN schools s ON s.id = cr.school_id
+		WHERE cr.id = $1`, id).Scan(
+		&c.CensusID, &c.SchoolID, &c.Nome, &c.INEP, &c.Municipio, &c.Dre, &targetDREID,
+		&c.Year, &c.Status, &rawData, &c.CreatedAt, &c.UpdatedAt, &c.Synced,
+	)
+	if err != nil {
+		app.errorJSON(w, fmt.Errorf("censo não encontrado"), http.StatusNotFound)
+		return
+	}
+
+	if scope.Role == RoleDRE && scope.DREID > 0 {
+		if targetDREID <= 0 || !scope.IsAuthorizedForDREID(targetDREID) {
+			app.errorJSON(w, fmt.Errorf("acesso não permitido para esta DRE"), http.StatusForbidden)
+			return
+		}
+	} else if !scope.IsAuthorizedForDRE(c.Dre) {
+		// Compatibilidade somente para testes/tokens pré-0020. Usuários runtime
+		// pós-#206 sempre chegam ao ramo canônico acima.
+		app.errorJSON(w, fmt.Errorf("acesso não permitido para esta DRE"), http.StatusForbidden)
+		return
+	}
+
+	c.Data = json.RawMessage(rawData)
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: c})
+}

--- a/api/cmd/api/admin_dashboard_dre_id.go
+++ b/api/cmd/api/admin_dashboard_dre_id.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// AdminDashboardCanonical é o caminho canônico do dashboard. Em schema
+// pós-0020, autorização e agrupamento usam schools.dre_id -> dres.id; o nome
+// textual é apenas o valor de apresentação retornado pela entidade mestre.
+func (app *application) AdminDashboardCanonical(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	db := app.models.Schools.DB
+	scope, _ := GetAdminAccessScope(ctx)
+	s := DashboardStats{ByDre: []DreStats{}, Recent: []CensusRow{}}
+	dreName := schoolDRENameExpr("s")
+
+	if scope.Role == RoleDRE {
+		auth := schoolDREAuthorizationPredicate("s", "$1", "$2")
+		args := []any{scope.DREID, strings.TrimSpace(scope.DRE)}
+
+		err := db.QueryRowContext(ctx, `
+			SELECT
+				(SELECT COUNT(*) FROM schools s WHERE `+auth+`),
+				COUNT(*) FILTER (WHERE cr.status = 'completed' AND `+auth+`),
+				COUNT(*) FILTER (WHERE cr.status = 'draft' AND `+auth+`),
+				COUNT(*) FILTER (WHERE cr.status = 'completed' AND cr.sheet_synced_at IS NULL AND `+auth+`)
+			FROM census_responses cr
+			JOIN schools s ON s.id = cr.school_id`, args...).Scan(
+			&s.TotalSchools, &s.CompletedCensuses, &s.DraftCensuses, &s.PendingSync)
+		if err != nil {
+			app.errorJSON(w, fmt.Errorf("erro ao buscar totais"), http.StatusInternalServerError)
+			return
+		}
+
+		rows, err := db.QueryContext(ctx, `
+			WITH scoped_schools AS (
+				SELECT s.id, `+dreName+` AS dre
+				FROM schools s
+				WHERE `+auth+`
+			)
+			SELECT ss.dre,
+				COUNT(DISTINCT ss.id) AS total,
+				COUNT(DISTINCT ss.id) FILTER (WHERE cr.status = 'completed') AS completed,
+				COUNT(DISTINCT ss.id) FILTER (WHERE cr.status = 'draft') AS draft
+			FROM scoped_schools ss
+			LEFT JOIN census_responses cr ON cr.school_id = ss.id
+			GROUP BY ss.dre
+			ORDER BY ss.dre`, args...)
+		if err != nil {
+			app.errorJSON(w, fmt.Errorf("erro ao buscar por DRE"), http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var d DreStats
+			if err := rows.Scan(&d.Dre, &d.Total, &d.Completed, &d.Draft); err != nil {
+				app.errorJSON(w, err, http.StatusInternalServerError)
+				return
+			}
+			s.ByDre = append(s.ByDre, d)
+		}
+		if err := rows.Err(); err != nil {
+			app.errorJSON(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		rows2, err := db.QueryContext(ctx, `
+			SELECT cr.id, cr.school_id, s.nome_escola, s.codigo_inep, s.municipio,
+				`+dreName+` AS dre, cr.year, cr.status, cr.updated_at,
+				(cr.sheet_synced_at IS NOT NULL)
+			FROM census_responses cr
+			JOIN schools s ON s.id = cr.school_id
+			WHERE `+auth+`
+			ORDER BY cr.updated_at DESC
+			LIMIT 50`, args...)
+		if err != nil {
+			app.errorJSON(w, fmt.Errorf("erro ao buscar censos recentes"), http.StatusInternalServerError)
+			return
+		}
+		defer rows2.Close()
+		for rows2.Next() {
+			var c CensusRow
+			if err := rows2.Scan(&c.CensusID, &c.SchoolID, &c.Nome, &c.INEP, &c.Municipio,
+				&c.Dre, &c.Year, &c.Status, &c.UpdatedAt, &c.Synced); err != nil {
+				app.errorJSON(w, err, http.StatusInternalServerError)
+				return
+			}
+			s.Recent = append(s.Recent, c)
+		}
+		if err := rows2.Err(); err != nil {
+			app.errorJSON(w, err, http.StatusInternalServerError)
+			return
+		}
+	} else {
+		err := db.QueryRowContext(ctx, `
+			SELECT
+				(SELECT COUNT(*) FROM schools),
+				COUNT(*) FILTER (WHERE cr.status = 'completed'),
+				COUNT(*) FILTER (WHERE cr.status = 'draft'),
+				COUNT(*) FILTER (WHERE cr.status = 'completed' AND cr.sheet_synced_at IS NULL)
+			FROM census_responses cr`).Scan(
+			&s.TotalSchools, &s.CompletedCensuses, &s.DraftCensuses, &s.PendingSync)
+		if err != nil {
+			app.errorJSON(w, fmt.Errorf("erro ao buscar totais"), http.StatusInternalServerError)
+			return
+		}
+
+		rows, err := db.QueryContext(ctx, `
+			WITH canonical_schools AS (
+				SELECT s.id, `+dreName+` AS dre
+				FROM schools s
+			)
+			SELECT cs.dre,
+				COUNT(DISTINCT cs.id) AS total,
+				COUNT(DISTINCT cs.id) FILTER (WHERE cr.status = 'completed') AS completed,
+				COUNT(DISTINCT cs.id) FILTER (WHERE cr.status = 'draft') AS draft
+			FROM canonical_schools cs
+			LEFT JOIN census_responses cr ON cr.school_id = cs.id
+			GROUP BY cs.dre
+			ORDER BY cs.dre`)
+		if err != nil {
+			app.errorJSON(w, fmt.Errorf("erro ao buscar por DRE"), http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var d DreStats
+			if err := rows.Scan(&d.Dre, &d.Total, &d.Completed, &d.Draft); err != nil {
+				app.errorJSON(w, err, http.StatusInternalServerError)
+				return
+			}
+			s.ByDre = append(s.ByDre, d)
+		}
+		if err := rows.Err(); err != nil {
+			app.errorJSON(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		rows2, err := db.QueryContext(ctx, `
+			SELECT cr.id, cr.school_id, s.nome_escola, s.codigo_inep, s.municipio,
+				`+dreName+` AS dre, cr.year, cr.status, cr.updated_at,
+				(cr.sheet_synced_at IS NOT NULL)
+			FROM census_responses cr
+			JOIN schools s ON s.id = cr.school_id
+			ORDER BY cr.updated_at DESC
+			LIMIT 50`)
+		if err != nil {
+			app.errorJSON(w, fmt.Errorf("erro ao buscar censos recentes"), http.StatusInternalServerError)
+			return
+		}
+		defer rows2.Close()
+		for rows2.Next() {
+			var c CensusRow
+			if err := rows2.Scan(&c.CensusID, &c.SchoolID, &c.Nome, &c.INEP, &c.Municipio,
+				&c.Dre, &c.Year, &c.Status, &c.UpdatedAt, &c.Synced); err != nil {
+				app.errorJSON(w, err, http.StatusInternalServerError)
+				return
+			}
+			s.Recent = append(s.Recent, c)
+		}
+		if err := rows2.Err(); err != nil {
+			app.errorJSON(w, err, http.StatusInternalServerError)
+			return
+		}
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{Error: false, Data: s})
+}

--- a/api/cmd/api/admin_dre_resumo.go
+++ b/api/cmd/api/admin_dre_resumo.go
@@ -18,6 +18,9 @@ type DRESummaryPayload struct {
 	CensusAdherencePercentage int     `json:"census_adherence_percentage"`
 }
 
+// Em schema pós-0020 o vínculo é exclusivamente schools.dre_id -> dres.id. O
+// ramo textual existe apenas para o schema de transição do CI enquanto #210
+// ainda não aplica 0020 no bootstrap compartilhado.
 const dreSummarySelectSQL = `
 	WITH target_dre AS (
 		SELECT id, TRIM(nome) AS nome
@@ -48,7 +51,15 @@ const dreSummarySelectSQL = `
 		COUNT(s.id) FILTER (WHERE cr.status = 'completed') AS completed
 	FROM target_dre d
 	LEFT JOIN schools s
-	  ON UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome))
+	  ON CASE
+		WHEN EXISTS (
+			SELECT 1 FROM pg_attribute
+			WHERE attrelid = to_regclass('schools')
+			  AND attname = 'dre_id'
+			  AND NOT attisdropped
+		) THEN NULLIF(to_jsonb(s)->>'dre_id', '')::int = d.id
+		ELSE UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome))
+	  END
 	LEFT JOIN latest_census cr ON cr.school_id = s.id
 	GROUP BY d.id, d.nome
 `

--- a/api/cmd/api/admin_me_dre_id.go
+++ b/api/cmd/api/admin_me_dre_id.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// AdminMeCanonical mantém o nome da DRE no contrato e expõe também o ID
+// canônico para clientes que já conseguem migrar para dre_id.
+func (app *application) AdminMeCanonical(w http.ResponseWriter, r *http.Request) {
+	scope, ok := GetAdminAccessScope(r.Context())
+	if !ok {
+		app.errorJSON(w, fmt.Errorf("escopo de acesso não encontrado"), http.StatusUnauthorized)
+		return
+	}
+
+	var drePtr *string
+	var dreIDPtr *int
+	if scope.Role == RoleDRE && strings.TrimSpace(scope.DRE) != "" {
+		dreVal := scope.DRE
+		drePtr = &dreVal
+		if scope.DREID > 0 {
+			dreID := scope.DREID
+			dreIDPtr = &dreID
+		}
+	}
+
+	app.writeJSON(w, http.StatusOK, jsonResponse{
+		Error: false,
+		Data: map[string]interface{}{
+			"username": scope.Username,
+			"role":     scope.Role,
+			"dre_id":   dreIDPtr,
+			"dre":      drePtr,
+		},
+	})
+}

--- a/api/cmd/api/admin_runtime_auth.go
+++ b/api/cmd/api/admin_runtime_auth.go
@@ -172,7 +172,7 @@ func (app *application) resolveRuntimeDREScope(ctx context.Context, claims *runt
 		if strings.TrimSpace(claims.Username) == "" || strings.TrimSpace(claims.DRE) == "" {
 			return AdminAccessScope{}, fmt.Errorf("token DRE sem identidade válida")
 		}
-		return AdminAccessScope{Username: claims.Username, Role: RoleDRE, DRE: claims.DRE}, nil
+		return AdminAccessScope{Username: claims.Username, Role: RoleDRE, DREID: claims.DREID, DRE: claims.DRE}, nil
 	}
 
 	var (
@@ -196,6 +196,7 @@ func (app *application) resolveRuntimeDREScope(ctx context.Context, claims *runt
 	return AdminAccessScope{
 		Username: access.Username,
 		Role:     RoleDRE,
+		DREID:    access.DREID,
 		DRE:      access.DRE,
 	}, nil
 }

--- a/api/cmd/api/admin_scope.go
+++ b/api/cmd/api/admin_scope.go
@@ -6,10 +6,13 @@ import (
 )
 
 // AdminAccessScope representa a identidade e o escopo territorial/organizacional
-// do usuário autenticado no painel administrativo.
+// do usuário autenticado no painel administrativo. DREID é a identidade
+// canônica usada para autorização; DRE permanece no contrato para exibição e
+// compatibilidade com clientes existentes.
 type AdminAccessScope struct {
 	Username string `json:"username"`
 	Role     string `json:"role"`
+	DREID    int    `json:"dre_id,omitempty"`
 	DRE      string `json:"dre"`
 }
 
@@ -31,9 +34,23 @@ func GetAdminAccessScope(ctx context.Context) (AdminAccessScope, bool) {
 	return scope, ok
 }
 
-// IsAuthorizedForDRE verifica se o escopo de acesso do usuário permite visualizar dados
-// da DRE informada. O perfil "admin" possui acesso ilimitado; o perfil "dre" só acessa
-// sua própria DRE (compara sem diferenciar maiúsculas/minúsculas nem espaços extras).
+// IsAuthorizedForDREID é a verificação canônica de autorização territorial.
+// Admin possui acesso amplo; perfil DRE só acessa objetos vinculados exatamente
+// ao mesmo dres.id resolvido no runtime.
+func (scope AdminAccessScope) IsAuthorizedForDREID(targetDREID int) bool {
+	if scope.Role == RoleAdmin {
+		return true
+	}
+	if scope.Role == RoleDRE {
+		return scope.DREID > 0 && targetDREID > 0 && scope.DREID == targetDREID
+	}
+	return false
+}
+
+// IsAuthorizedForDRE preserva o contrato textual para código/testes em schema
+// pré-0020. Em caminhos canônicos de autorização deve-se usar
+// IsAuthorizedForDREID; esta comparação não é fonte de identidade quando DREID
+// está disponível.
 func (scope AdminAccessScope) IsAuthorizedForDRE(targetDRE string) bool {
 	if scope.Role == RoleAdmin {
 		return true

--- a/api/cmd/api/analytics_dre_resumo_test.go
+++ b/api/cmd/api/analytics_dre_resumo_test.go
@@ -22,6 +22,7 @@ func TestPreenchimentoMasterQueryShape(t *testing.T) {
 		"legacy_rows AS",
 		"d.id IS NULL",
 		"UNION ALL",
+		"WHEN m.canonical AND $8 > 0 THEN NULLIF(to_jsonb(s)->>'dre_id', '')::int = $8",
 	}
 	for _, fragment := range mustContain {
 		if !strings.Contains(query, fragment) {
@@ -36,6 +37,7 @@ func TestPreenchimentoMasterQueryShape(t *testing.T) {
 func TestPreenchimentoScopedArgs(t *testing.T) {
 	f := preenchimentoDreFilters{
 		Year:             2026,
+		DREID:            77,
 		DRE:              "DRE BELEM",
 		Municipio:        "BELEM",
 		Zona:             "URBANA",
@@ -47,7 +49,7 @@ func TestPreenchimentoScopedArgs(t *testing.T) {
 	if query != preenchimentoDreScopedSelectSQL {
 		t.Fatal("buildPreenchimentoDreScopedQuery retornou SQL inesperado")
 	}
-	want := []any{2026, "DRE BELEM", "BELEM", "URBANA", "GUAJARA", 42, "15000000"}
+	want := []any{2026, "DRE BELEM", "BELEM", "URBANA", "GUAJARA", 42, "15000000", 77}
 	if len(args) != len(want) {
 		t.Fatalf("len(args)=%d; want %d", len(args), len(want))
 	}
@@ -64,6 +66,7 @@ func TestDRESummaryQueryShape(t *testing.T) {
 		"WHERE id = $1",
 		"WHERE cr.year = $2",
 		"LEFT JOIN schools s",
+		"NULLIF(to_jsonb(s)->>'dre_id', '')::int = d.id",
 		"UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome))",
 		"cr.status = 'completed'",
 		"cr.data->>'total_alunos'",

--- a/api/cmd/api/analytics_filtros.go
+++ b/api/cmd/api/analytics_filtros.go
@@ -12,9 +12,11 @@ import (
 
 // AnalyticsFilters holds the parsed query-string filters common to all
 // analytical endpoints. Default year = current year; string filters default
-// to "" (= no filter applied in WhereSQL).
+// to "" (= no filter applied in WhereSQL). DREID is authorization-only and is
+// populated from the runtime scope, never from an untrusted query string.
 type AnalyticsFilters struct {
 	Year             int
+	DREID            int
 	DRE              string
 	Municipio        string
 	Zona             string
@@ -26,6 +28,7 @@ type AnalyticsFilters struct {
 func parseAnalyticsFilters(r *http.Request) AnalyticsFilters {
 	f := parseAnalyticsFiltersFromValues(r.URL.Query(), time.Now())
 	if scope, ok := GetAdminAccessScope(r.Context()); ok && scope.Role == RoleDRE {
+		f.DREID = scope.DREID
 		f.DRE = strings.TrimSpace(scope.DRE)
 	}
 	return f
@@ -57,12 +60,16 @@ func parseAnalyticsFiltersFromValues(q url.Values, now time.Time) AnalyticsFilte
 // $1=year, $2=dre, $3=municipio, $4=zona, $5=regiao_integracao,
 // $6=school_id and $7=codigo_inep. Empty strings and school_id zero disable
 // the corresponding optional filters.
-// Pair with Args() to get the matching positional arguments.
+//
+// A view ainda expõe `dre` textual por compatibilidade, mas em bancos pós-0020
+// o filtro DRE re-resolve school_id -> schools.dre_id -> dres.id/nome. Assim o
+// texto projetado pela view deixa de determinar escopo ou agregações.
 func (f AnalyticsFilters) WhereSQL() string {
+	drePredicate := analyticsDREPredicate("school_id", "dre", "$2")
 	return `status = 'completed'
       AND year = $1
       AND census_id IS NOT NULL
-      AND ($2 = '' OR UPPER(TRIM(dre)) = UPPER(TRIM($2)))
+      AND ($2 = '' OR ` + drePredicate + `)
       AND ($3 = '' OR UPPER(TRIM(municipio)) = UPPER(TRIM($3)))
       AND ($4 = '' OR UPPER(TRIM(zona)) = UPPER(TRIM($4)))
       AND ($5 = '' OR UPPER(TRIM(municipio)) IN (
@@ -129,11 +136,11 @@ func filtrosOpcoesSchoolsWhere(f AnalyticsFilters, alias, except string) (string
 }
 
 // filtrosOpcoesSchoolsWhereWithAuthorization applies the mandatory territorial
-// scope independently from the select cascade. A DRE user's authorization
-// must survive even when the DRE select is the option being populated.
+// scope independently from the select cascade. Em schema canônico a autorização
+// usa diretamente dre_id; o nome só permanece como fallback pré-0020.
 func filtrosOpcoesSchoolsWhereWithAuthorization(f AnalyticsFilters, alias, except, authorizedDRE string) (string, []any) {
-	conditions := make([]string, 0, 6)
-	args := make([]any, 0, 6)
+	conditions := make([]string, 0, 7)
+	args := make([]any, 0, 7)
 	add := func(key, condition string, arg any) {
 		if key == except {
 			return
@@ -142,11 +149,21 @@ func filtrosOpcoesSchoolsWhereWithAuthorization(f AnalyticsFilters, alias, excep
 		conditions = append(conditions, fmt.Sprintf(condition, len(args), len(args)))
 	}
 
-	if strings.TrimSpace(authorizedDRE) != "" {
-		args = append(args, strings.TrimSpace(authorizedDRE))
-		conditions = append(conditions, "UPPER(TRIM("+alias+".dre)) = UPPER(TRIM($"+strconv.Itoa(len(args))+"))")
-	} else {
-		add("dre", "($%d = '' OR UPPER(TRIM("+alias+".dre)) = UPPER(TRIM($%d)))", f.DRE)
+	if authorizedDRE = strings.TrimSpace(authorizedDRE); authorizedDRE != "" {
+		if f.DREID > 0 {
+			args = append(args, f.DREID)
+			idPos := len(args)
+			args = append(args, authorizedDRE)
+			namePos := len(args)
+			conditions = append(conditions, schoolDREAuthorizationPredicate(alias, "$"+strconv.Itoa(idPos), "$"+strconv.Itoa(namePos)))
+		} else {
+			args = append(args, authorizedDRE)
+			conditions = append(conditions, schoolDRENamePredicate(alias, "$"+strconv.Itoa(len(args))))
+		}
+	} else if except != "dre" {
+		args = append(args, f.DRE)
+		pos := "$" + strconv.Itoa(len(args))
+		conditions = append(conditions, "("+pos+" = '' OR "+schoolDRENamePredicate(alias, pos)+")")
 	}
 	add("municipio", "($%d = '' OR UPPER(TRIM("+alias+".municipio)) = UPPER(TRIM($%d)))", f.Municipio)
 	add("zona", "($%d = '' OR UPPER(TRIM("+alias+".zona)) = UPPER(TRIM($%d)))", f.Zona)
@@ -168,10 +185,15 @@ func filtrosOpcoesDREsQuery(f AnalyticsFilters, authorizedDRE string) (string, [
 		WHERE d.ativa = TRUE
 		  AND NULLIF(TRIM(d.nome), '') IS NOT NULL
 	`
-	args := make([]any, 0, 6)
+	args := make([]any, 0, 7)
 	if authorizedDRE = strings.TrimSpace(authorizedDRE); authorizedDRE != "" {
-		args = append(args, authorizedDRE)
-		query += "\t  AND UPPER(TRIM(d.nome)) = UPPER(TRIM($" + strconv.Itoa(len(args)) + "))\n"
+		if f.DREID > 0 {
+			args = append(args, f.DREID)
+			query += "\t  AND d.id = $" + strconv.Itoa(len(args)) + "\n"
+		} else {
+			args = append(args, authorizedDRE)
+			query += "\t  AND UPPER(TRIM(d.nome)) = UPPER(TRIM($" + strconv.Itoa(len(args)) + "))\n"
+		}
 	}
 
 	if f.Municipio != "" || f.Zona != "" || f.RegiaoIntegracao != "" || f.SchoolID != 0 || f.CodigoINEP != "" {
@@ -185,7 +207,7 @@ func filtrosOpcoesDREsQuery(f AnalyticsFilters, authorizedDRE string) (string, [
 			SELECT 1
 			FROM schools s
 			WHERE ` + schoolsWhere + `
-			  AND UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome))
+			  AND ` + schoolDRENamePredicate("s", "d.nome") + `
 		)
 `
 	}
@@ -213,8 +235,13 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 	`
 	var anosArgs []any
 	if authorizedDRE != "" {
-		anosQuery += ` AND UPPER(TRIM(s.dre)) = UPPER(TRIM($1))`
-		anosArgs = append(anosArgs, authorizedDRE)
+		if f.DREID > 0 {
+			anosQuery += ` AND ` + schoolDREAuthorizationPredicate("s", "$1", "$2")
+			anosArgs = append(anosArgs, f.DREID, authorizedDRE)
+		} else {
+			anosQuery += ` AND ` + schoolDRENamePredicate("s", "$1")
+			anosArgs = append(anosArgs, authorizedDRE)
+		}
 	}
 	anosQuery += `
 		ORDER BY cr.year::text DESC
@@ -246,7 +273,7 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 		return
 	}
 
-	// DREs: filtradas por municipio, zona, regiao (não pela própria dre)
+	// DREs: derivadas da entidade mestre; escolas só participam da cascata pelos IDs.
 	dresQuery, dresArgs := filtrosOpcoesDREsQuery(f, authorizedDRE)
 	dres, err := queryStringSlice(app, ctx, dresQuery, dresArgs...)
 	if err != nil {
@@ -282,14 +309,15 @@ func (app *application) AdminAnalyticsFiltrosOpcoes(w http.ResponseWriter, r *ht
 	}
 
 	escolasWhere, escolasArgs := filtrosOpcoesSchoolsWhereWithAuthorization(f, "s", "school_id", authorizedDRE)
+	dreNameExpr := schoolDRENameExpr("s")
 	rows, err := app.models.Schools.DB.QueryContext(ctx, `
 		SELECT DISTINCT
-			id,
-			codigo_inep,
-			COALESCE(NULLIF(TRIM(nome_escola), ''), 'Sem nome') AS nome_escola,
-			COALESCE(NULLIF(TRIM(municipio), ''), 'Não informado') AS municipio,
-			COALESCE(NULLIF(TRIM(dre), ''), 'Não informado') AS dre,
-			zona
+			s.id,
+			s.codigo_inep,
+			COALESCE(NULLIF(TRIM(s.nome_escola), ''), 'Sem nome') AS nome_escola,
+			COALESCE(NULLIF(TRIM(s.municipio), ''), 'Não informado') AS municipio,
+			`+dreNameExpr+` AS dre,
+			s.zona
 		FROM schools s
 		WHERE `+escolasWhere+`
 		ORDER BY nome_escola

--- a/api/cmd/api/analytics_preenchimento.go
+++ b/api/cmd/api/analytics_preenchimento.go
@@ -34,11 +34,10 @@ type PreenchimentoDrePayload struct {
 }
 
 // preenchimentoDreFilters reúne os filtros globais do dashboard aplicados sobre
-// o cadastro de escolas. Strings vazias significam "filtro desativado". O ano
-// segue os demais endpoints analíticos: valor válido enviado pelo cliente ou o
-// ano corrente como fallback.
+// o cadastro de escolas. DREID é preenchido somente pelo escopo autenticado.
 type preenchimentoDreFilters struct {
 	Year             int
+	DREID            int
 	DRE              string
 	Municipio        string
 	Zona             string
@@ -61,18 +60,20 @@ func parsePreenchimentoDreFilters(q url.Values, now time.Time) preenchimentoDreF
 	return f
 }
 
-// preenchimentoDreSelectSQL parte da entidade mestre dres, garantindo que uma
-// DRE ativa recém-criada apareça mesmo sem escolas vinculadas. Escolas com DRE
-// legada/não mapeada continuam aparecendo numa linha própria para não provocar
-// perda silenciosa de dados operacionais durante a transição para a entidade
-// mestre.
-//
-// Filtros territoriais são aplicados primeiro a schools. Quando não existe
-// filtro de escola/território, todas as DREs ativas aparecem, inclusive com
-// total=0. Quando existe algum desses filtros, linhas mestre sem nenhuma escola
-// correspondente são omitidas, preservando a semântica de cascata do dashboard.
+// A query-base mantém o contrato histórico de cinco argumentos usado pelos
+// testes auxiliares. Em schema pós-0020, porém, filtros, join e agregação são
+// resolvidos por schools.dre_id -> dres.id. O texto de schools.dre só é
+// consultado quando a coluna dre_id ainda não existe no schema de transição.
 const preenchimentoDreSelectSQL = `
-	WITH latest_census AS (
+	WITH schema_mode AS (
+		SELECT EXISTS (
+			SELECT 1 FROM pg_attribute
+			WHERE attrelid = to_regclass('schools')
+			  AND attname = 'dre_id'
+			  AND NOT attisdropped
+		) AS canonical
+	),
+	latest_census AS (
 		SELECT DISTINCT ON (school_id)
 			school_id,
 			status
@@ -81,9 +82,21 @@ const preenchimentoDreSelectSQL = `
 		ORDER BY school_id, updated_at DESC, id DESC
 	),
 	filtered_schools AS (
-		SELECT s.id, s.dre
+		SELECT
+			s.id,
+			s.dre,
+			CASE WHEN m.canonical THEN NULLIF(to_jsonb(s)->>'dre_id', '')::int ELSE NULL END AS dre_id,
+			m.canonical
 		FROM schools s
-		WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+		CROSS JOIN schema_mode m
+		WHERE ($2 = '' OR CASE
+			WHEN m.canonical THEN EXISTS (
+				SELECT 1 FROM dres fd
+				WHERE fd.id = NULLIF(to_jsonb(s)->>'dre_id', '')::int
+				  AND UPPER(TRIM(fd.nome)) = UPPER(TRIM($2))
+			)
+			ELSE UPPER(TRIM(s.dre)) = UPPER(TRIM($2))
+		END)
 		  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
 		  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
 		  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
@@ -100,7 +113,8 @@ const preenchimentoDreSelectSQL = `
 			COUNT(s.id) FILTER (WHERE cr.status = 'draft') AS draft
 		FROM dres d
 		LEFT JOIN filtered_schools s
-		  ON UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome))
+		  ON CASE WHEN s.canonical THEN s.dre_id = d.id
+		          ELSE UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome)) END
 		LEFT JOIN latest_census cr ON cr.school_id = s.id
 		WHERE d.ativa = TRUE
 		  AND NULLIF(TRIM(d.nome), '') IS NOT NULL
@@ -116,8 +130,8 @@ const preenchimentoDreSelectSQL = `
 			COUNT(s.id) FILTER (WHERE cr.status = 'draft') AS draft
 		FROM filtered_schools s
 		LEFT JOIN dres d
-		  ON d.ativa = TRUE
-		 AND UPPER(TRIM(d.nome)) = UPPER(TRIM(s.dre))
+		  ON CASE WHEN s.canonical THEN s.dre_id = d.id
+		          ELSE UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome)) END
 		LEFT JOIN latest_census cr ON cr.school_id = s.id
 		WHERE d.id IS NULL
 		  AND ($2 = '' OR UPPER(TRIM(COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado'))) = UPPER(TRIM($2)))
@@ -142,11 +156,19 @@ func buildPreenchimentoDreQuery(f preenchimentoDreFilters) (string, []any) {
 	}
 }
 
-// A variante scoped adiciona school_id/codigo_inep sem alterar o contrato da
-// query-base usado pelos testes e por chamadas que só precisam dos cinco filtros
-// históricos.
+// A variante scoped adiciona school_id/codigo_inep e recebe $8=dre_id do
+// escopo autenticado. Quando $8 > 0 e 0020 existe, o filtro territorial usa o
+// ID diretamente; o nome não participa da decisão de autorização.
 const preenchimentoDreScopedSelectSQL = `
-	WITH latest_census AS (
+	WITH schema_mode AS (
+		SELECT EXISTS (
+			SELECT 1 FROM pg_attribute
+			WHERE attrelid = to_regclass('schools')
+			  AND attname = 'dre_id'
+			  AND NOT attisdropped
+		) AS canonical
+	),
+	latest_census AS (
 		SELECT DISTINCT ON (school_id)
 			school_id,
 			status
@@ -155,9 +177,22 @@ const preenchimentoDreScopedSelectSQL = `
 		ORDER BY school_id, updated_at DESC, id DESC
 	),
 	filtered_schools AS (
-		SELECT s.id, s.dre
+		SELECT
+			s.id,
+			s.dre,
+			CASE WHEN m.canonical THEN NULLIF(to_jsonb(s)->>'dre_id', '')::int ELSE NULL END AS dre_id,
+			m.canonical
 		FROM schools s
-		WHERE ($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))
+		CROSS JOIN schema_mode m
+		WHERE ($2 = '' OR CASE
+			WHEN m.canonical AND $8 > 0 THEN NULLIF(to_jsonb(s)->>'dre_id', '')::int = $8
+			WHEN m.canonical THEN EXISTS (
+				SELECT 1 FROM dres fd
+				WHERE fd.id = NULLIF(to_jsonb(s)->>'dre_id', '')::int
+				  AND UPPER(TRIM(fd.nome)) = UPPER(TRIM($2))
+			)
+			ELSE UPPER(TRIM(s.dre)) = UPPER(TRIM($2))
+		END)
 		  AND ($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))
 		  AND ($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))
 		  AND ($5 = '' OR UPPER(TRIM(s.municipio)) IN (
@@ -176,11 +211,12 @@ const preenchimentoDreScopedSelectSQL = `
 			COUNT(s.id) FILTER (WHERE cr.status = 'draft') AS draft
 		FROM dres d
 		LEFT JOIN filtered_schools s
-		  ON UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome))
+		  ON CASE WHEN s.canonical THEN s.dre_id = d.id
+		          ELSE UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome)) END
 		LEFT JOIN latest_census cr ON cr.school_id = s.id
 		WHERE d.ativa = TRUE
 		  AND NULLIF(TRIM(d.nome), '') IS NOT NULL
-		  AND ($2 = '' OR UPPER(TRIM(d.nome)) = UPPER(TRIM($2)))
+		  AND ($2 = '' OR CASE WHEN $8 > 0 THEN d.id = $8 ELSE UPPER(TRIM(d.nome)) = UPPER(TRIM($2)) END)
 		GROUP BY d.id, d.nome
 		HAVING (($3 = '' AND $4 = '' AND $5 = '' AND $6 = 0 AND $7 = '') OR COUNT(s.id) > 0)
 	),
@@ -192,10 +228,11 @@ const preenchimentoDreScopedSelectSQL = `
 			COUNT(s.id) FILTER (WHERE cr.status = 'draft') AS draft
 		FROM filtered_schools s
 		LEFT JOIN dres d
-		  ON d.ativa = TRUE
-		 AND UPPER(TRIM(d.nome)) = UPPER(TRIM(s.dre))
+		  ON CASE WHEN s.canonical THEN s.dre_id = d.id
+		          ELSE UPPER(TRIM(s.dre)) = UPPER(TRIM(d.nome)) END
 		LEFT JOIN latest_census cr ON cr.school_id = s.id
 		WHERE d.id IS NULL
+		  AND $8 = 0
 		  AND ($2 = '' OR UPPER(TRIM(COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado'))) = UPPER(TRIM($2)))
 		GROUP BY COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado')
 	)
@@ -211,6 +248,7 @@ const preenchimentoDreScopedSelectSQL = `
 func preenchimentoDreFiltersFromRequest(r *http.Request, now time.Time) preenchimentoDreFilters {
 	f := parsePreenchimentoDreFilters(r.URL.Query(), now)
 	shared := parseAnalyticsFilters(r)
+	f.DREID = shared.DREID
 	f.DRE = shared.DRE
 	f.Municipio = shared.Municipio
 	f.Zona = shared.Zona
@@ -229,6 +267,7 @@ func buildPreenchimentoDreScopedQuery(f preenchimentoDreFilters) (string, []any)
 		f.RegiaoIntegracao,
 		f.SchoolID,
 		f.CodigoINEP,
+		f.DREID,
 	}
 }
 

--- a/api/cmd/api/analytics_preenchimento_test.go
+++ b/api/cmd/api/analytics_preenchimento_test.go
@@ -37,7 +37,6 @@ func TestPreenchimentoParseFiltersValidYear(t *testing.T) {
 	if got.Year != 2025 {
 		t.Fatalf("year = %d; want 2025", got.Year)
 	}
-	// Espaços ao redor do year são tolerados.
 	got = parsePreenchimentoDreFilters(url.Values{"year": {" 2024 "}}, now)
 	if got.Year != 2024 {
 		t.Fatalf("year com espaços = %d; want 2024", got.Year)
@@ -84,9 +83,9 @@ func TestPreenchimentoParseFiltersStrings(t *testing.T) {
 	})
 }
 
-// TestPreenchimentoBuildQueryArgs garante que cada filtro global é posicionado
-// no argumento correto ($1=year, $2=dre, $3=municipio, $4=zona,
-// $5=regiao_integracao) e combinado por AND sobre schools s.
+// TestPreenchimentoBuildQueryArgs garante o contrato de cinco argumentos da
+// query-base usada pelos filtros administrativos por nome. O escopo DRE por ID
+// fica exclusivamente na variante scoped, que recebe $8=dre_id.
 func TestPreenchimentoBuildQueryArgs(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -149,15 +148,15 @@ func TestPreenchimentoBuildQueryArgs(t *testing.T) {
 	}
 }
 
-// TestPreenchimentoQueryShape valida o formato da query: parte de schools s, usa
-// LEFT JOIN, limita census_responses ao ano, conta completed e draft, agrupa por
-// DRE com fallback "Não informado", combina filtros por AND e usa DISTINCT ON
-// como salvaguarda contra múltiplos censos por escola/ano. Não pode exigir
-// status='completed' no WHERE geral nem census_id IS NOT NULL.
+// TestPreenchimentoQueryShape valida que a query preserva escolas sem censo e
+// múltiplos estados, mas em schema pós-0020 filtra e agrega DRE por
+// schools.dre_id -> dres.id. A comparação textual existe somente no ramo de
+// compatibilidade para bancos onde a coluna dre_id ainda não existe.
 func TestPreenchimentoQueryShape(t *testing.T) {
 	query := preenchimentoDreSelectSQL
 
 	mustContain := []string{
+		"schema_mode AS",
 		"FROM schools s",
 		"LEFT JOIN latest_census cr",
 		"FROM census_responses",
@@ -165,12 +164,15 @@ func TestPreenchimentoQueryShape(t *testing.T) {
 		"DISTINCT ON (school_id)",
 		"FILTER (WHERE cr.status = 'completed')",
 		"FILTER (WHERE cr.status = 'draft')",
-		"COALESCE(NULLIF(TRIM(s.dre), ''), 'Não informado')",
-		"($2 = '' OR UPPER(TRIM(s.dre)) = UPPER(TRIM($2)))",
+		"NULLIF(to_jsonb(s)->>'dre_id', '')::int",
+		"FROM dres fd",
+		"fd.id = NULLIF(to_jsonb(s)->>'dre_id', '')::int",
+		"ELSE UPPER(TRIM(s.dre)) = UPPER(TRIM($2))",
 		"($3 = '' OR UPPER(TRIM(s.municipio)) = UPPER(TRIM($3)))",
 		"($4 = '' OR UPPER(TRIM(s.zona)) = UPPER(TRIM($4)))",
 		"FROM reg_integracao",
 		"UPPER(TRIM(regiao_de_integracao)) = UPPER(TRIM($5))",
+		"CASE WHEN s.canonical THEN s.dre_id = d.id",
 	}
 	for _, fragment := range mustContain {
 		if !strings.Contains(query, fragment) {
@@ -178,12 +180,9 @@ func TestPreenchimentoQueryShape(t *testing.T) {
 		}
 	}
 
-	// O LEFT JOIN deve ser preservado: escolas sem censo continuam no recorte.
 	if strings.Contains(query, "INNER JOIN") {
 		t.Fatalf("query usa INNER JOIN; o LEFT JOIN deve ser preservado")
 	}
-	// O WHERE geral não pode restringir o universo a censos concluídos nem exigir
-	// census_id — isso eliminaria rascunhos e pendentes que precisamos contar.
 	if strings.Contains(query, "s.status = 'completed'") ||
 		strings.Contains(query, "AND status = 'completed'") {
 		t.Fatalf("query exige status='completed' no WHERE geral; rascunhos/pendentes seriam excluídos")
@@ -192,7 +191,6 @@ func TestPreenchimentoQueryShape(t *testing.T) {
 		t.Fatalf("query exige census_id IS NOT NULL; escolas sem censo seriam excluídas")
 	}
 
-	// Os filtros globais devem estar sob a mesma cláusula WHERE (combinados por AND).
 	if strings.Count(query, " AND ($") < 3 {
 		t.Fatalf("filtros globais não parecem combinados por AND: %s", query)
 	}
@@ -251,7 +249,6 @@ func TestPreenchimentoBuildRow(t *testing.T) {
 	})
 
 	t.Run("pending nunca fica negativo", func(t *testing.T) {
-		// Defensivo: se as contagens forem inconsistentes, pending não fica < 0.
 		row := buildPreenchimentoDreRow("X", 2, 2, 1)
 		if row.Pending != 0 {
 			t.Fatalf("pending = %d; want 0 (clamp em zero)", row.Pending)

--- a/api/cmd/api/dre_id_scope.go
+++ b/api/cmd/api/dre_id_scope.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// canonicalSchoolDREColumnSQL is intentionally schema-compatible with the
+// transitional CI database, which is still initialized only through migration
+// 0019 while #210 is in progress. Production databases that have migration 0020
+// take the canonical branch; the textual branch is reached only when dre_id does
+// not exist at all.
+const canonicalSchoolDREColumnSQL = `EXISTS (
+	SELECT 1
+	FROM pg_attribute
+	WHERE attrelid = to_regclass('schools')
+	  AND attname = 'dre_id'
+	  AND NOT attisdropped
+)`
+
+// schoolCanonicalDREIDExpr reads dre_id without making PostgreSQL parse a
+// reference to a column that may not exist in the pre-0020 transition schema.
+// Once 0020 is present this expression is the canonical relationship source.
+func schoolCanonicalDREIDExpr(alias string) string {
+	alias = strings.TrimSpace(alias)
+	return fmt.Sprintf(`NULLIF(to_jsonb(%s)->>'dre_id', '')::int`, alias)
+}
+
+// schoolDRENamePredicate returns a boolean SQL expression that resolves a DRE
+// through dres.id when the canonical column exists. The schools.dre comparison
+// is retained only as a temporary schema-compatibility branch for databases
+// that have not received migration 0020 yet.
+func schoolDRENamePredicate(alias, nameParam string) string {
+	alias = strings.TrimSpace(alias)
+	nameParam = strings.TrimSpace(nameParam)
+	return fmt.Sprintf(`(
+	CASE
+		WHEN %s THEN EXISTS (
+			SELECT 1
+			FROM dres dre_scope
+			WHERE dre_scope.id = %s
+			  AND UPPER(TRIM(dre_scope.nome)) = UPPER(TRIM(%s))
+		)
+		ELSE UPPER(TRIM(%s.dre)) = UPPER(TRIM(%s))
+	END
+)`, canonicalSchoolDREColumnSQL, schoolCanonicalDREIDExpr(alias), nameParam, alias, nameParam)
+}
+
+// schoolDREAuthorizationPredicate is stricter than the ordinary name filter:
+// on a canonical schema a DRE user's scope is compared directly by dres.id.
+// The name is accepted only for the pre-0020 transition schema.
+func schoolDREAuthorizationPredicate(alias, dreIDParam, dreNameParam string) string {
+	alias = strings.TrimSpace(alias)
+	return fmt.Sprintf(`(
+	CASE
+		WHEN %s THEN %s = %s
+		ELSE UPPER(TRIM(%s.dre)) = UPPER(TRIM(%s))
+	END
+)`, canonicalSchoolDREColumnSQL, schoolCanonicalDREIDExpr(alias), dreIDParam, alias, dreNameParam)
+}
+
+// schoolDRENameExpr keeps the public API contract textual while deriving that
+// name from the master DRE whenever the canonical relationship exists.
+func schoolDRENameExpr(alias string) string {
+	alias = strings.TrimSpace(alias)
+	return fmt.Sprintf(`(
+	CASE
+		WHEN %s THEN COALESCE(
+			(SELECT TRIM(dre_name.nome) FROM dres dre_name WHERE dre_name.id = %s),
+			'Não informado'
+		)
+		ELSE COALESCE(NULLIF(TRIM(%s.dre), ''), 'Não informado')
+	END
+)`, canonicalSchoolDREColumnSQL, schoolCanonicalDREIDExpr(alias), alias)
+}
+
+// schoolDREIDExpr exposes the canonical ID for authorization/BOLA checks while
+// remaining executable against the temporary pre-0020 CI schema.
+func schoolDREIDExpr(alias string) string {
+	alias = strings.TrimSpace(alias)
+	return fmt.Sprintf(`(
+	CASE
+		WHEN %s THEN COALESCE(%s, 0)
+		ELSE 0
+	END
+)`, canonicalSchoolDREColumnSQL, schoolCanonicalDREIDExpr(alias))
+}
+
+// analyticsDREPredicate is used by the shared analytics view, where only
+// school_id and the legacy textual dre projection are available. On canonical
+// schemas it re-resolves the school through schools.dre_id -> dres.id; the view's
+// textual dre field is ignored for filtering.
+func analyticsDREPredicate(schoolIDExpr, legacyDREExpr, nameParam string) string {
+	return fmt.Sprintf(`(
+	CASE
+		WHEN %s THEN EXISTS (
+			SELECT 1
+			FROM schools dre_school
+			JOIN dres dre_scope ON dre_scope.id = %s
+			WHERE dre_school.id = %s
+			  AND UPPER(TRIM(dre_scope.nome)) = UPPER(TRIM(%s))
+		)
+		ELSE UPPER(TRIM(%s)) = UPPER(TRIM(%s))
+	END
+)`, canonicalSchoolDREColumnSQL, schoolCanonicalDREIDExpr("dre_school"), schoolIDExpr, nameParam, legacyDREExpr, nameParam)
+}

--- a/api/cmd/api/dre_id_scope_test.go
+++ b/api/cmd/api/dre_id_scope_test.go
@@ -264,7 +264,7 @@ func TestDREIDScopePostgreSQLStress10000Relations(t *testing.T) {
 			'207S' || LPAD(g::text, 6, '0'),
 			'BELEM',
 			'Urbana',
-			CASE WHEN g <= 5000 THEN $1 ELSE $2 END
+			CASE WHEN g <= 5000 THEN $1::integer ELSE $2::integer END
 		FROM generate_series(1, 10000) g
 	`, dreA, dreB); err != nil {
 		t.Fatalf("seed 10k canonical schools: %v", err)

--- a/api/cmd/api/dre_id_scope_test.go
+++ b/api/cmd/api/dre_id_scope_test.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func setupDRE207Schema(t *testing.T) *sql.Tx {
+	t.Helper()
+	db := openDREIntegrationDB(t)
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin #207 transaction: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	schema := fmt.Sprintf("dre207_%d", time.Now().UnixNano())
+	if _, err := tx.Exec(`CREATE SCHEMA ` + schema); err != nil {
+		t.Fatalf("create #207 schema: %v", err)
+	}
+	if _, err := tx.Exec(`SET LOCAL search_path TO ` + schema + `, public`); err != nil {
+		t.Fatalf("set #207 search_path: %v", err)
+	}
+	if _, err := tx.Exec(`
+		CREATE TABLE dres (
+			id SERIAL PRIMARY KEY,
+			nome VARCHAR(255) UNIQUE NOT NULL,
+			ativa BOOLEAN NOT NULL DEFAULT true
+		);
+		CREATE TABLE schools (
+			id SERIAL PRIMARY KEY,
+			nome_escola VARCHAR(255) NOT NULL DEFAULT '',
+			codigo_inep VARCHAR(32),
+			municipio VARCHAR(128),
+			dre VARCHAR(100),
+			zona VARCHAR(64)
+		);
+		CREATE TABLE admin_users (
+			id SERIAL PRIMARY KEY,
+			username VARCHAR(64) UNIQUE NOT NULL,
+			password_hash VARCHAR(255) NOT NULL,
+			role VARCHAR(32) NOT NULL,
+			dre VARCHAR(128),
+			active BOOLEAN NOT NULL DEFAULT true
+		);
+		CREATE TABLE census_responses (
+			id SERIAL PRIMARY KEY,
+			school_id INTEGER NOT NULL REFERENCES schools(id),
+			year INTEGER NOT NULL,
+			status VARCHAR(32) NOT NULL,
+			data JSONB NOT NULL DEFAULT '{}'::jsonb,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			sheet_synced_at TIMESTAMPTZ
+		);
+		CREATE TABLE reg_integracao (
+			municipio VARCHAR(128) NOT NULL,
+			regiao_de_integracao VARCHAR(128) NOT NULL
+		);
+	`); err != nil {
+		t.Fatalf("create #207 base tables: %v", err)
+	}
+	if _, err := tx.Exec(canonicalMigrationSQL(t)); err != nil {
+		t.Fatalf("apply migration 0020 in #207 schema: %v", err)
+	}
+	return tx
+}
+
+func seedDRE207Fixture(t *testing.T, tx *sql.Tx) (dreA, dreB, schoolA1, schoolA2, schoolB int) {
+	t.Helper()
+	if err := tx.QueryRow(`INSERT INTO dres (nome, ativa) VALUES ('DRE ALPHA', true) RETURNING id`).Scan(&dreA); err != nil {
+		t.Fatalf("seed DRE A: %v", err)
+	}
+	if err := tx.QueryRow(`INSERT INTO dres (nome, ativa) VALUES ('DRE BETA', true) RETURNING id`).Scan(&dreB); err != nil {
+		t.Fatalf("seed DRE B: %v", err)
+	}
+	insertSchool := func(name, inep string, dreID int) int {
+		var id int
+		if err := tx.QueryRow(`
+			INSERT INTO schools (nome_escola, codigo_inep, municipio, zona, dre_id)
+			VALUES ($1, $2, 'BELEM', 'Urbana', $3)
+			RETURNING id
+		`, name, inep, dreID).Scan(&id); err != nil {
+			t.Fatalf("seed school %s: %v", inep, err)
+		}
+		return id
+	}
+	schoolA1 = insertSchool("Alpha 1", "20700001", dreA)
+	schoolA2 = insertSchool("Alpha 2", "20700002", dreA)
+	schoolB = insertSchool("Beta 1", "20700003", dreB)
+
+	if _, err := tx.Exec(`
+		INSERT INTO census_responses (school_id, year, status, data) VALUES
+			($1, 2026, 'completed', '{"total_alunos": 120}'::jsonb),
+			($2, 2026, 'draft',     '{"total_alunos": 999}'::jsonb),
+			($3, 2026, 'completed', '{"total_alunos": 80}'::jsonb)
+	`, schoolA1, schoolA2, schoolB); err != nil {
+		t.Fatalf("seed census #207: %v", err)
+	}
+	return
+}
+
+func corruptDRE207LegacyText(t *testing.T, tx *sql.Tx, dreA, dreB int) {
+	t.Helper()
+	// Simula dado textual stale/corrompido. A aplicação pós-0020 não pode usar
+	// esse texto para decidir escopo. O trigger é desabilitado apenas dentro do
+	// schema/transaction isolado do teste.
+	if _, err := tx.Exec(`ALTER TABLE schools DISABLE TRIGGER USER`); err != nil {
+		t.Fatalf("disable compatibility trigger: %v", err)
+	}
+	if _, err := tx.Exec(`
+		UPDATE schools
+		SET dre = CASE
+			WHEN dre_id = $1 THEN 'DRE BETA'
+			WHEN dre_id = $2 THEN 'DRE ALPHA'
+			ELSE dre
+		END
+	`, dreA, dreB); err != nil {
+		t.Fatalf("corrupt legacy text: %v", err)
+	}
+}
+
+func countSchoolsByCanonicalName207(t *testing.T, tx *sql.Tx, name string) int {
+	t.Helper()
+	var count int
+	query := `SELECT COUNT(*) FROM schools s WHERE ` + schoolDRENamePredicate("s", "$1")
+	if err := tx.QueryRow(query, name).Scan(&count); err != nil {
+		t.Fatalf("count canonical name %q: %v", name, err)
+	}
+	return count
+}
+
+func TestDREIDScopeCanonicalIgnoresStaleLegacyText(t *testing.T) {
+	tx := setupDRE207Schema(t)
+	dreA, dreB, schoolA1, _, _ := seedDRE207Fixture(t, tx)
+	corruptDRE207LegacyText(t, tx, dreA, dreB)
+
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE ALPHA"); got != 2 {
+		t.Fatalf("canonical ALPHA count=%d; want 2 despite stale text", got)
+	}
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE BETA"); got != 1 {
+		t.Fatalf("canonical BETA count=%d; want 1 despite stale text", got)
+	}
+
+	var displayed string
+	if err := tx.QueryRow(`SELECT `+schoolDRENameExpr("s")+` FROM schools s WHERE s.id=$1`, schoolA1).Scan(&displayed); err != nil {
+		t.Fatalf("canonical display name: %v", err)
+	}
+	if displayed != "DRE ALPHA" {
+		t.Fatalf("displayed DRE=%q; want master name DRE ALPHA", displayed)
+	}
+
+	var scopedCount int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM schools s WHERE `+schoolDREAuthorizationPredicate("s", "$1", "$2"), dreA, "DRE BETA").Scan(&scopedCount); err != nil {
+		t.Fatalf("canonical authorization predicate: %v", err)
+	}
+	if scopedCount != 2 {
+		t.Fatalf("ID scope count=%d; want 2; stale/wrong name must be ignored", scopedCount)
+	}
+
+	// Rename só altera dres.nome. O vínculo, contagens e filtros devem sobreviver
+	// mesmo com o texto legado deliberadamente errado.
+	if _, err := tx.Exec(`UPDATE dres SET nome='DRE ALPHA RENAMED' WHERE id=$1`, dreA); err != nil {
+		t.Fatalf("rename master DRE: %v", err)
+	}
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE ALPHA"); got != 0 {
+		t.Fatalf("old name still filters %d schools after rename", got)
+	}
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE ALPHA RENAMED"); got != 2 {
+		t.Fatalf("new name count=%d; want 2 after rename", got)
+	}
+
+	var summaryName string
+	var total, completed int
+	var totalStudents float64
+	var summaryID int
+	if err := tx.QueryRow(dreSummarySelectSQL, dreA, 2026).Scan(&summaryID, &summaryName, &total, &totalStudents, &completed); err != nil {
+		t.Fatalf("canonical DRE summary: %v", err)
+	}
+	if summaryID != dreA || summaryName != "DRE ALPHA RENAMED" || total != 2 || completed != 1 || totalStudents != 120 {
+		t.Fatalf("summary changed after rename: id=%d name=%q total=%d completed=%d students=%.0f", summaryID, summaryName, total, completed, totalStudents)
+	}
+
+	f := AnalyticsFilters{Year: 2026, DRE: "DRE ALPHA RENAMED"}
+	viewQuery := `
+		SELECT COUNT(*)
+		FROM (
+			SELECT cr.id AS census_id, cr.school_id, cr.status, cr.year,
+			       s.dre, s.municipio, s.zona, COALESCE(s.codigo_inep, '') AS codigo_inep
+			FROM census_responses cr
+			JOIN schools s ON s.id=cr.school_id
+		) analytics_view
+		WHERE ` + f.WhereSQL()
+	if err := tx.QueryRow(viewQuery, f.Args()...).Scan(&scopedCount); err != nil {
+		t.Fatalf("shared analytics canonical filter: %v", err)
+	}
+	if scopedCount != 1 {
+		t.Fatalf("completed analytics rows=%d; want 1 for renamed ALPHA", scopedCount)
+	}
+
+	// Simula claim/nome stale: DREID deve dominar no endpoint de preenchimento.
+	pf := preenchimentoDreFilters{Year: 2026, DREID: dreA, DRE: "NOME STALE DO TOKEN"}
+	rows, err := tx.Query(preenchimentoDreScopedSelectSQL,
+		pf.Year, pf.DRE, pf.Municipio, pf.Zona, pf.RegiaoIntegracao, pf.SchoolID, pf.CodigoINEP, pf.DREID)
+	if err != nil {
+		t.Fatalf("preenchimento canonical by ID: %v", err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		t.Fatalf("preenchimento did not return canonical DRE")
+	}
+	var rowName string
+	var rowTotal, rowCompleted, rowDraft int
+	if err := rows.Scan(&rowName, &rowTotal, &rowCompleted, &rowDraft); err != nil {
+		t.Fatalf("scan preenchimento canonical: %v", err)
+	}
+	if rowName != "DRE ALPHA RENAMED" || rowTotal != 2 || rowCompleted != 1 || rowDraft != 1 {
+		t.Fatalf("preenchimento mismatch: name=%q total=%d completed=%d draft=%d", rowName, rowTotal, rowCompleted, rowDraft)
+	}
+}
+
+func TestDREIDScopeRemapChangesScopeByID(t *testing.T) {
+	tx := setupDRE207Schema(t)
+	dreA, dreB, schoolA1, _, _ := seedDRE207Fixture(t, tx)
+	corruptDRE207LegacyText(t, tx, dreA, dreB)
+
+	// Trigger segue desabilitado: o texto permanece propositalmente stale. Só o
+	// ID muda, e isso deve ser suficiente para todos os filtros canônicos.
+	if _, err := tx.Exec(`UPDATE schools SET dre_id=$1, dre='DRE ALPHA' WHERE id=$2`, dreB, schoolA1); err != nil {
+		t.Fatalf("remap by dre_id: %v", err)
+	}
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE ALPHA"); got != 1 {
+		t.Fatalf("origin count after remap=%d; want 1", got)
+	}
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE BETA"); got != 2 {
+		t.Fatalf("destination count after remap=%d; want 2", got)
+	}
+	var targetID int
+	if err := tx.QueryRow(`SELECT `+schoolDREIDExpr("s")+` FROM schools s WHERE id=$1`, schoolA1).Scan(&targetID); err != nil {
+		t.Fatalf("read canonical remap ID: %v", err)
+	}
+	if targetID != dreB {
+		t.Fatalf("remapped dre_id=%d; want %d", targetID, dreB)
+	}
+}
+
+func TestDREIDScopePostgreSQLStress10000Relations(t *testing.T) {
+	tx := setupDRE207Schema(t)
+	var dreA, dreB int
+	if err := tx.QueryRow(`INSERT INTO dres (nome) VALUES ('DRE STRESS A') RETURNING id`).Scan(&dreA); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.QueryRow(`INSERT INTO dres (nome) VALUES ('DRE STRESS B') RETURNING id`).Scan(&dreB); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO schools (nome_escola, codigo_inep, municipio, zona, dre_id)
+		SELECT
+			'Stress ' || g,
+			'207S' || LPAD(g::text, 6, '0'),
+			'BELEM',
+			'Urbana',
+			CASE WHEN g <= 5000 THEN $1 ELSE $2 END
+		FROM generate_series(1, 10000) g
+	`, dreA, dreB); err != nil {
+		t.Fatalf("seed 10k canonical schools: %v", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE schools DISABLE TRIGGER USER`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`
+		UPDATE schools SET dre = CASE WHEN dre_id=$1 THEN 'DRE STRESS B' ELSE 'DRE STRESS A' END
+	`, dreA); err != nil {
+		t.Fatalf("invert 10k legacy names: %v", err)
+	}
+
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE STRESS A"); got != 5000 {
+		t.Fatalf("10k stress A=%d; want 5000", got)
+	}
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE STRESS B"); got != 5000 {
+		t.Fatalf("10k stress B=%d; want 5000", got)
+	}
+	if _, err := tx.Exec(`UPDATE dres SET nome='DRE STRESS A RENAMED' WHERE id=$1`, dreA); err != nil {
+		t.Fatal(err)
+	}
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE STRESS A RENAMED"); got != 5000 {
+		t.Fatalf("10k stress renamed A=%d; want 5000", got)
+	}
+	if got := countSchoolsByCanonicalName207(t, tx, "DRE STRESS A"); got != 0 {
+		t.Fatalf("10k stress old A name still matched %d rows", got)
+	}
+}
+
+func TestDREIDAuthorizationProperties20000Scenarios(t *testing.T) {
+	rng := rand.New(rand.NewSource(207))
+	for i := 0; i < 20000; i++ {
+		id := rng.Intn(5000) + 1
+		other := rng.Intn(5000) + 1
+		scope := AdminAccessScope{Role: RoleDRE, DREID: id, DRE: "texto deliberadamente irrelevante"}
+		if !scope.IsAuthorizedForDREID(id) {
+			t.Fatalf("scenario %d: same canonical ID denied: %d", i, id)
+		}
+		wantOther := other == id
+		if got := scope.IsAuthorizedForDREID(other); got != wantOther {
+			t.Fatalf("scenario %d: authorization(%d -> %d)=%v want %v", i, id, other, got, wantOther)
+		}
+		admin := AdminAccessScope{Role: RoleAdmin}
+		if !admin.IsAuthorizedForDREID(other) {
+			t.Fatalf("scenario %d: admin denied target %d", i, other)
+		}
+	}
+
+	invalid := []int{-100, -1, 0}
+	for _, id := range invalid {
+		if (AdminAccessScope{Role: RoleDRE, DREID: id}).IsAuthorizedForDREID(1) {
+			t.Fatalf("invalid scope DREID %d authorized", id)
+		}
+		if (AdminAccessScope{Role: RoleDRE, DREID: 1}).IsAuthorizedForDREID(id) {
+			t.Fatalf("invalid target DREID %d authorized", id)
+		}
+	}
+}

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -72,7 +72,7 @@ func main() {
 		if err := godotenv.Load(p); err == nil {
 			logger.Printf("Arquivo .env carregado com sucesso de: %s", p)
 			envLoaded = true
-			break // Para de procurar assim que encontrar e carregar um .env válido
+			break
 		}
 	}
 
@@ -83,10 +83,6 @@ func main() {
 	}
 
 	var cfg config
-
-	// Valida configuração de segurança crítica antes de subir o servidor.
-	// Aborta cedo (em vez de cair num segredo default inseguro) se o JWT
-	// não estiver corretamente configurado.
 	if err := validateSecurityConfig(); err != nil {
 		logger.Fatal("ERRO FATAL SEGURANÇA: ", err)
 	}
@@ -104,12 +100,9 @@ func main() {
 	if dsn == "" {
 		dsn = os.Getenv("DB_DSN")
 	}
-
 	if dsn == "" {
 		dbHost := os.Getenv("DB_HOST")
 		if dbHost != "" {
-			// sslmode configurável: padrão "disable" para o docker local sem TLS,
-			// mas permite exigir TLS (DB_SSLMODE=require) em produção.
 			sslmode := os.Getenv("DB_SSLMODE")
 			if sslmode == "" {
 				sslmode = "disable"
@@ -118,7 +111,6 @@ func main() {
 				os.Getenv("DB_HOST"), os.Getenv("DB_PORT"), os.Getenv("DB_USER"), os.Getenv("DB_PASSWORD"), os.Getenv("DB_NAME"), sslmode)
 		}
 	}
-
 	if dsn == "" {
 		logger.Fatal("ERRO FATAL: Variáveis de banco (DB_HOST ou DSN) não foram encontradas.")
 	}
@@ -132,7 +124,6 @@ func main() {
 	defer db.Close()
 	logger.Println("Banco conectado!")
 
-	// Migração: garante que a coluna sheet_synced_at existe (bancos antigos não a têm).
 	_, err = db.Exec(`ALTER TABLE census_responses ADD COLUMN IF NOT EXISTS sheet_synced_at TIMESTAMP DEFAULT NULL`)
 	if err != nil {
 		logger.Printf("AVISO: migração sheet_synced_at: %v", err)
@@ -140,15 +131,10 @@ func main() {
 		logger.Println("Migração sheet_synced_at OK")
 	}
 
-	// Aplica as migrations idempotentes embarcadas no binário via
-	// go:embed (api/cmd/api/migrations/*.sql). Todas devem usar
-	// CREATE OR REPLACE / IF NOT EXISTS e poder rodar várias vezes
-	// sem efeito colateral.
 	if err = applyMigrations(db, logger); err != nil {
 		logger.Printf("AVISO: applyMigrations: %v", err)
 	}
 
-	// ... (Resto do seu código permanece igual)
 	sheetsService, err := services.NewSheetsService()
 	if err != nil {
 		logger.Println("AVISO: SheetsService erro:", err)
@@ -171,8 +157,6 @@ func main() {
 		drive:  driveService,
 	}
 
-	// Job de retry: a cada 10 minutos re-sincroniza censos completed que
-	// não chegaram à planilha (goroutine falhou silenciosamente antes).
 	go app.sheetSyncRetryJob()
 
 	srv := &http.Server{
@@ -193,55 +177,34 @@ func openDB(cfg config) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	db.SetMaxOpenConns(25)
 	db.SetMaxIdleConns(5)
 	db.SetConnMaxLifetime(5 * time.Minute)
 	db.SetConnMaxIdleTime(2 * time.Minute)
-
 	if err = db.Ping(); err != nil {
 		return nil, err
 	}
 	return db, nil
 }
 
-// applyMigrations executa, em ordem alfabética, todos os arquivos .sql
-// embarcados em migrationsFS (api/cmd/api/migrations/*.sql). Cada arquivo
-// deve ser idempotente (CREATE OR REPLACE VIEW, IF NOT EXISTS, etc.) —
-// não há tabela de controle de versão nesta fase.
-//
-// Como o conteúdo está embarcado no binário via go:embed, o resultado é
-// independente do working directory do processo — funciona igual no
-// docker local, no Railway e em qualquer outro ambiente.
-//
-// Erros ao aplicar uma migration individual são logados com detalhe e
-// não derrubam o servidor: o startup segue, e o operador vê no log
-// qual arquivo falhou e por quê.
 func applyMigrations(db *sql.DB, logger *log.Logger) error {
 	entries, err := fs.ReadDir(migrationsFS, "migrations")
 	if err != nil {
 		return fmt.Errorf("applyMigrations: ler embed migrations/: %w", err)
 	}
-
 	files := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if filepath.Ext(e.Name()) != ".sql" {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".sql" {
 			continue
 		}
 		files = append(files, e.Name())
 	}
 	sort.Strings(files)
-
 	if len(files) == 0 {
 		logger.Println("applyMigrations: nenhum .sql embarcado, pulando.")
 		return nil
 	}
-
 	logger.Printf("applyMigrations: %d migration(s) encontrada(s): %v", len(files), files)
-
 	for _, name := range files {
 		content, err := fs.ReadFile(migrationsFS, "migrations/"+name)
 		if err != nil {
@@ -311,9 +274,6 @@ func (app *application) routes() http.Handler {
 		r.Get("/health", app.HealthCheck)
 		r.Get("/census/status", app.CensusStatus)
 
-		// Endpoints públicos do formulário. Ficam atrás do gate opcional de
-		// X-API-Key (requirePublicAPIKey): inerte até PUBLIC_API_KEY ser
-		// definido no servidor, então não quebra nada em produção.
 		r.Group(func(pub chi.Router) {
 			pub.Use(app.requirePublicAPIKey)
 			pub.Get("/locations", app.GetLocations)
@@ -324,19 +284,17 @@ func (app *application) routes() http.Handler {
 			pub.With(app.requireCensusSubmissions).Post("/upload", app.uploadPhoto)
 		})
 
-		// Admin: login público + rotas protegidas por JWT e estado runtime.
 		r.Post("/admin/login", app.AdminLoginRuntime)
 		r.Group(func(protected chi.Router) {
 			protected.Use(app.requireRuntimeAdminAuth)
-			protected.Get("/admin/me", app.AdminMe)
-			protected.Get("/admin/dashboard", app.AdminDashboard)
+			protected.Get("/admin/me", app.AdminMeCanonical)
+			protected.Get("/admin/dashboard", app.AdminDashboardCanonical)
 			protected.Get("/admin/sheet-metrics", app.AdminSheetMetrics)
 			protected.Get("/admin/indicadores-metrics", app.AdminIndicadoresMetrics)
-			protected.Get("/admin/census", app.AdminGetCensus)
-			protected.Get("/admin/census/{id}", app.AdminGetCensusByID)
+			protected.Get("/admin/census", app.AdminGetCensusCanonical)
+			protected.Get("/admin/census/{id}", app.AdminGetCensusByIDCanonical)
 			protected.Post("/admin/sync-sheets", app.AdminSyncSheets)
 
-			// Gestão de DREs (exclusivo role=admin)
 			protected.Post("/admin/dres", app.AdminCreateDRE)
 			protected.Get("/admin/dres", app.AdminListDREs)
 			protected.Put("/admin/dres/{id}", app.AdminUpdateDRE)
@@ -344,31 +302,21 @@ func (app *application) routes() http.Handler {
 			protected.Post("/admin/dres/{id}/schools", app.AdminAssignSchoolsToDRE)
 			protected.Patch("/admin/schools/{id}/dre", app.AdminMoveSchoolToDRE)
 
-			// Gestão de Usuários Administrativos (exclusivo role=admin)
 			protected.Post("/admin/users", app.AdminCreateUser)
 			protected.Get("/admin/users", app.AdminListUsers)
 			protected.Patch("/admin/users/{id}/status", app.AdminUpdateUserStatus)
 			protected.Post("/admin/users/{id}/reset-password", app.AdminResetUserPassword)
 
-			// Fase 1 — camada analítica baseada em PostgreSQL.
-			// Endpoints adicionais; não substituem sheet-metrics nem indicadores-metrics.
 			protected.Get("/admin/analytics/overview", app.AdminAnalyticsOverview)
-
-			// Fase 2A — backend analítico da Caracterização da Rede.
-			// Adicionais; a UI segue consumindo sheet-metrics até a Fase 2B.
 			protected.Get("/admin/analytics/caracterizacao/perfil", app.AdminAnalyticsCaracterizacaoPerfil)
 			protected.Get("/admin/analytics/caracterizacao/dre", app.AdminAnalyticsCaracterizacaoDRE)
 			protected.Get("/admin/analytics/caracterizacao/oferta-funcionamento", app.AdminAnalyticsCaracterizacaoOfertaFuncionamento)
 			protected.Get("/admin/analytics/caracterizacao/infraestrutura-educacional", app.AdminAnalyticsCaracterizacaoInfraEducacional)
-
-			// Frente 1 — Pessoal e Gestão Escolar + Tecnologia
 			protected.Get("/admin/analytics/pessoal-gestao/estrutura", app.AdminAnalyticsPessoalEstrutura)
 			protected.Get("/admin/analytics/pessoal-gestao/coordenacao", app.AdminAnalyticsPessoalCoordenacao)
 			protected.Get("/admin/analytics/pessoal-gestao/quadro-pessoal", app.AdminAnalyticsPessoalQuadro)
 			protected.Get("/admin/analytics/tecnologia/infraestrutura", app.AdminAnalyticsTecnologiaInfra)
 			protected.Get("/admin/analytics/tecnologia/uso-pedagogico", app.AdminAnalyticsTecnologiaUso)
-
-			// Frente 2 — Infraestrutura/Segurança + Merenda + Serviços Terceirizados.
 			protected.Get("/admin/analytics/infraestrutura/condicoes", app.AdminAnalyticsInfraCondicoes)
 			protected.Get("/admin/analytics/infraestrutura/seguranca", app.AdminAnalyticsInfraSeguranca)
 			protected.Get("/admin/analytics/infraestrutura/energia", app.AdminAnalyticsInfraEnergia)
@@ -381,31 +329,18 @@ func (app *application) routes() http.Handler {
 			protected.Get("/admin/analytics/servicos-terceirizados/portaria", app.AdminAnalyticsServicosPortaria)
 			protected.Get("/admin/analytics/servicos-terceirizados/manipuladores-alimentos", app.AdminAnalyticsServicosManipuladoresAlimentos)
 			protected.Get("/admin/analytics/escolas/saude-operacional", app.AdminAnalyticsSaudeOperacionalEscolas)
-
-			// tabelas escola-a-escola para todas as abas analíticas
 			protected.Get("/admin/analytics/infraestrutura/escolas", app.AdminAnalyticsInfraEscolas)
 			protected.Get("/admin/analytics/merenda/escolas", app.AdminAnalyticsMerendaEscolas)
 			protected.Get("/admin/analytics/servicos-terceirizados/escolas", app.AdminAnalyticsServicosTerceirizadosEscolas)
 			protected.Get("/admin/analytics/pessoal-gestao/escolas", app.AdminAnalyticsPessoalEscolas)
 			protected.Get("/admin/analytics/tecnologia/escolas", app.AdminAnalyticsTecnologiaEscolas)
 			protected.Get("/admin/analytics/caracterizacao/escolas", app.AdminAnalyticsCaracterizacaoEscolas)
-
-			// Gestão Financeira e Governança — repasses PRODEP (PR técnico 2).
 			protected.Get("/admin/analytics/financeiro-governanca/prodep", app.AdminAnalyticsFinanceiroGovernancaProdep)
 			protected.Get("/admin/analytics/financeiro-governanca/institucional", app.AdminAnalyticsFinanceiroGovernancaInstitucional)
 			protected.Get("/admin/analytics/financeiro-governanca/indice-escolas", app.AdminAnalyticsGovernancaIndiceEscolas)
-
-			// Perfil dos Alunos e Resultados — IDEB 2023 (IDEB-04, lê ideb_resultados).
 			protected.Get("/admin/analytics/perfil-alunos-resultados/ideb", app.AdminAnalyticsPerfilAlunosResultadosIDEB)
-
-			// Andamento do preenchimento do censo por DRE.
 			protected.Get("/admin/analytics/preenchimento/dre", app.AdminAnalyticsPreenchimentoDre)
-
-			// Filtros globais do dashboard.
 			protected.Get("/admin/analytics/filtros/opcoes", app.AdminAnalyticsFiltrosOpcoes)
-
-			// Relatórios gerenciais por aba (XLSX). Camada extensível; o
-			// report_id é resolvido contra reportsCatalog.
 			protected.Get("/admin/reports/{report_id}", app.AdminGetReport)
 		})
 	})


### PR DESCRIPTION
Implementa a #207 sobre a develop pós-#206.

Closes #207
Parent epic: #203

Principais mudanças:
- AdminAccessScope passa a transportar dre_id canônico;
- runtime auth propaga dre_id atual do banco em toda request;
- filtros compartilhados resolvem school_id -> schools.dre_id -> dres.id/nome em schema pós-0020;
- filtros de opções e nomes de escola derivam DRE da entidade mestre;
- preenchimento por DRE e resumo usam vínculo canônico e sobrevivem a rename/texto legado stale;
- rotas ativas de /admin/me, dashboard e census usam handlers canônicos por ID;
- BOLA de /admin/census/{id} falha fechado por dre_id em schema pós-0020;
- compatibilidade textual só é usada quando a coluna dre_id ainda não existe, preservando o CI pré-0020 enquanto #210 do Ed está em andamento;
- testes #207 corrompem propositalmente schools.dre para provar que o texto não determina escopo em banco migrado;
- stress específico: 10.000 relações PostgreSQL + 20.000 cenários de autorização por ID.

O PR permanece draft até go vet, suíte completa, PostgreSQL stress e race detector ficarem integralmente verdes. A #209 do Ed permanece isolada; nenhum arquivo da task dele foi alterado.