### PR TITLE
fix(dre): unicidade normalizada e migrations fail-closed (#208)

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -21,20 +21,17 @@ import (
 	"github.com/joho/godotenv"
 )
 
-// migrationsFS embute, no próprio binário, todos os .sql em
-// api/cmd/api/migrations/. Isso elimina a dependência de um caminho
-// relativo em runtime (problema observado no deploy Railway, onde
-// o working directory do processo não contém o diretório
-// infra/migrations/ que existe no monorepo).
-//
-// A cópia em infra/migrations/ é mantida como referência operacional
-// e fonte de verdade documental — qualquer mudança numa view deve ser
-// refletida nas DUAS pastas.
-//
 //go:embed migrations/*.sql
 var migrationsFS embed.FS
 
 const version = "1.1.0"
+
+var criticalAdministrativeMigrations = map[string]struct{}{
+	"0018_create_admin_users.sql":          {},
+	"0019_create_dres_master.sql":          {},
+	"0020_dre_canonical_relations.sql":     {},
+	"0021_dre_normalized_uniqueness.sql":   {},
+}
 
 type config struct {
 	port string
@@ -55,16 +52,14 @@ type application struct {
 func main() {
 	logger := log.New(os.Stdout, "[CENSO-API] ", log.Ldate|log.Ltime|log.Lshortfile)
 
-	// --- CORREÇÃO DE PATH ---
 	cwd, _ := os.Getwd()
 	logger.Printf("Executando a partir de: %s", cwd)
 
-	// PROCURA O .ENV DE FORMA INTELIGENTE EM VÁRIOS LUGARES
 	envPaths := []string{
-		".env",                                    // Tenta na mesma pasta de onde o comando rodou
-		filepath.Join(cwd, ".env"),                // Tenta no caminho absoluto atual
-		filepath.Join(cwd, "..", ".env"),          // Tenta um nível acima (raiz do projeto)
-		filepath.Join(cwd, "..", "infra", ".env"), // Tenta na pasta infra
+		".env",
+		filepath.Join(cwd, ".env"),
+		filepath.Join(cwd, "..", ".env"),
+		filepath.Join(cwd, "..", "infra", ".env"),
 	}
 
 	envLoaded := false
@@ -132,7 +127,7 @@ func main() {
 	}
 
 	if err = applyMigrations(db, logger); err != nil {
-		logger.Printf("AVISO: applyMigrations: %v", err)
+		logger.Fatal("ERRO FATAL MIGRATIONS: ", err)
 	}
 
 	sheetsService, err := services.NewSheetsService()
@@ -187,31 +182,54 @@ func openDB(cfg config) (*sql.DB, error) {
 	return db, nil
 }
 
+func isCriticalAdministrativeMigration(name string) bool {
+	_, ok := criticalAdministrativeMigrations[name]
+	return ok
+}
+
 func applyMigrations(db *sql.DB, logger *log.Logger) error {
 	entries, err := fs.ReadDir(migrationsFS, "migrations")
 	if err != nil {
 		return fmt.Errorf("applyMigrations: ler embed migrations/: %w", err)
 	}
+
 	files := make([]string, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".sql" {
 			continue
 		}
 		files = append(files, e.Name())
+		seen[e.Name()] = true
 	}
 	sort.Strings(files)
+
+	for name := range criticalAdministrativeMigrations {
+		if !seen[name] {
+			return fmt.Errorf("applyMigrations: migration administrativa crítica ausente do binário: %s", name)
+		}
+	}
+
 	if len(files) == 0 {
 		logger.Println("applyMigrations: nenhum .sql embarcado, pulando.")
 		return nil
 	}
+
 	logger.Printf("applyMigrations: %d migration(s) encontrada(s): %v", len(files), files)
 	for _, name := range files {
 		content, err := fs.ReadFile(migrationsFS, "migrations/"+name)
 		if err != nil {
+			if isCriticalAdministrativeMigration(name) {
+				return fmt.Errorf("applyMigrations: erro lendo migration crítica %s: %w", name, err)
+			}
 			logger.Printf("applyMigrations: ERRO lendo %s do embed: %v", name, err)
 			continue
 		}
+
 		if _, err := db.Exec(string(content)); err != nil {
+			if isCriticalAdministrativeMigration(name) {
+				return fmt.Errorf("applyMigrations: migration administrativa crítica %s falhou: %w", name, err)
+			}
 			logger.Printf("applyMigrations: ERRO aplicando %s: %v", name, err)
 			continue
 		}
@@ -257,93 +275,4 @@ func (app *application) syncPendingToSheets() {
 			app.logger.Printf("sheetSync: escola %d sincronizada", c.SchoolID)
 		}
 	}
-}
-
-func (app *application) routes() http.Handler {
-	mux := chi.NewRouter()
-	mux.Use(middleware.Recoverer)
-	mux.Use(middleware.Logger)
-	mux.Use(app.enableCORS)
-
-	mux.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Censo API Online"))
-	})
-
-	mux.Route("/v1", func(r chi.Router) {
-		r.Get("/health", app.HealthCheck)
-		r.Get("/census/status", app.CensusStatus)
-
-		r.Group(func(pub chi.Router) {
-			pub.Use(app.requirePublicAPIKey)
-			pub.Get("/locations", app.GetLocations)
-			pub.Get("/schools", app.GetSchools)
-			pub.With(app.requireCensusSubmissions).Post("/schools", app.CreateSchool)
-			pub.Get("/census", app.GetCenso)
-			pub.With(app.requireCensusSubmissions).Post("/census", app.CreateOrUpdateCenso)
-			pub.With(app.requireCensusSubmissions).Post("/upload", app.uploadPhoto)
-		})
-
-		r.Post("/admin/login", app.AdminLoginRuntime)
-		r.Group(func(protected chi.Router) {
-			protected.Use(app.requireRuntimeAdminAuth)
-			protected.Get("/admin/me", app.AdminMeCanonical)
-			protected.Get("/admin/dashboard", app.AdminDashboardCanonical)
-			protected.Get("/admin/sheet-metrics", app.AdminSheetMetrics)
-			protected.Get("/admin/indicadores-metrics", app.AdminIndicadoresMetrics)
-			protected.Get("/admin/census", app.AdminGetCensusCanonical)
-			protected.Get("/admin/census/{id}", app.AdminGetCensusByIDCanonical)
-			protected.Post("/admin/sync-sheets", app.AdminSyncSheets)
-
-			protected.Post("/admin/dres", app.AdminCreateDRE)
-			protected.Get("/admin/dres", app.AdminListDREs)
-			protected.Put("/admin/dres/{id}", app.AdminUpdateDRE)
-			protected.Get("/admin/dres/{id}/resumo", app.AdminDRESummary)
-			protected.Post("/admin/dres/{id}/schools", app.AdminAssignSchoolsToDRE)
-			protected.Patch("/admin/schools/{id}/dre", app.AdminMoveSchoolToDRE)
-
-			protected.Post("/admin/users", app.AdminCreateUser)
-			protected.Get("/admin/users", app.AdminListUsers)
-			protected.Patch("/admin/users/{id}/status", app.AdminUpdateUserStatus)
-			protected.Post("/admin/users/{id}/reset-password", app.AdminResetUserPassword)
-
-			protected.Get("/admin/analytics/overview", app.AdminAnalyticsOverview)
-			protected.Get("/admin/analytics/caracterizacao/perfil", app.AdminAnalyticsCaracterizacaoPerfil)
-			protected.Get("/admin/analytics/caracterizacao/dre", app.AdminAnalyticsCaracterizacaoDRE)
-			protected.Get("/admin/analytics/caracterizacao/oferta-funcionamento", app.AdminAnalyticsCaracterizacaoOfertaFuncionamento)
-			protected.Get("/admin/analytics/caracterizacao/infraestrutura-educacional", app.AdminAnalyticsCaracterizacaoInfraEducacional)
-			protected.Get("/admin/analytics/pessoal-gestao/estrutura", app.AdminAnalyticsPessoalEstrutura)
-			protected.Get("/admin/analytics/pessoal-gestao/coordenacao", app.AdminAnalyticsPessoalCoordenacao)
-			protected.Get("/admin/analytics/pessoal-gestao/quadro-pessoal", app.AdminAnalyticsPessoalQuadro)
-			protected.Get("/admin/analytics/tecnologia/infraestrutura", app.AdminAnalyticsTecnologiaInfra)
-			protected.Get("/admin/analytics/tecnologia/uso-pedagogico", app.AdminAnalyticsTecnologiaUso)
-			protected.Get("/admin/analytics/infraestrutura/condicoes", app.AdminAnalyticsInfraCondicoes)
-			protected.Get("/admin/analytics/infraestrutura/seguranca", app.AdminAnalyticsInfraSeguranca)
-			protected.Get("/admin/analytics/infraestrutura/energia", app.AdminAnalyticsInfraEnergia)
-			protected.Get("/admin/analytics/merenda/oferta", app.AdminAnalyticsMerendaOferta)
-			protected.Get("/admin/analytics/merenda/equipamentos", app.AdminAnalyticsMerendaEquipamentos)
-			protected.Get("/admin/analytics/merenda/recursos-humanos", app.AdminAnalyticsMerendaRH)
-			protected.Get("/admin/analytics/merenda/condicoes-sanitarias", app.AdminAnalyticsMerendaCondicoesSanitarias)
-			protected.Get("/admin/analytics/servicos-terceirizados/visao-geral", app.AdminAnalyticsServicosVisaoGeral)
-			protected.Get("/admin/analytics/servicos-terceirizados/servicos-gerais", app.AdminAnalyticsServicosGerais)
-			protected.Get("/admin/analytics/servicos-terceirizados/portaria", app.AdminAnalyticsServicosPortaria)
-			protected.Get("/admin/analytics/servicos-terceirizados/manipuladores-alimentos", app.AdminAnalyticsServicosManipuladoresAlimentos)
-			protected.Get("/admin/analytics/escolas/saude-operacional", app.AdminAnalyticsSaudeOperacionalEscolas)
-			protected.Get("/admin/analytics/infraestrutura/escolas", app.AdminAnalyticsInfraEscolas)
-			protected.Get("/admin/analytics/merenda/escolas", app.AdminAnalyticsMerendaEscolas)
-			protected.Get("/admin/analytics/servicos-terceirizados/escolas", app.AdminAnalyticsServicosTerceirizadosEscolas)
-			protected.Get("/admin/analytics/pessoal-gestao/escolas", app.AdminAnalyticsPessoalEscolas)
-			protected.Get("/admin/analytics/tecnologia/escolas", app.AdminAnalyticsTecnologiaEscolas)
-			protected.Get("/admin/analytics/caracterizacao/escolas", app.AdminAnalyticsCaracterizacaoEscolas)
-			protected.Get("/admin/analytics/financeiro-governanca/prodep", app.AdminAnalyticsFinanceiroGovernancaProdep)
-			protected.Get("/admin/analytics/financeiro-governanca/institucional", app.AdminAnalyticsFinanceiroGovernancaInstitucional)
-			protected.Get("/admin/analytics/financeiro-governanca/indice-escolas", app.AdminAnalyticsGovernancaIndiceEscolas)
-			protected.Get("/admin/analytics/perfil-alunos-resultados/ideb", app.AdminAnalyticsPerfilAlunosResultadosIDEB)
-			protected.Get("/admin/analytics/preenchimento/dre", app.AdminAnalyticsPreenchimentoDre)
-			protected.Get("/admin/analytics/filtros/opcoes", app.AdminAnalyticsFiltrosOpcoes)
-			protected.Get("/admin/reports/{report_id}", app.AdminGetReport)
-		})
-	})
-
-	return mux
 }

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -68,10 +68,10 @@ func main() {
 
 	// PROCURA O .ENV DE FORMA INTELIGENTE EM VÁRIOS LUGARES
 	envPaths := []string{
-		".env",                                    // Tenta na mesma pasta de onde o comando rodou
-		filepath.Join(cwd, ".env"),                // Tenta no caminho absoluto atual
-		filepath.Join(cwd, "..", ".env"),          // Tenta um nível acima (raiz do projeto)
-		filepath.Join(cwd, "..", "infra", ".env"), // Tenta na pasta infra
+		".env",
+		filepath.Join(cwd, ".env"),
+		filepath.Join(cwd, "..", ".env"),
+		filepath.Join(cwd, "..", "infra", ".env"),
 	}
 
 	envLoaded := false
@@ -282,4 +282,93 @@ func (app *application) syncPendingToSheets() {
 			app.logger.Printf("sheetSync: escola %d sincronizada", c.SchoolID)
 		}
 	}
+}
+
+func (app *application) routes() http.Handler {
+	mux := chi.NewRouter()
+	mux.Use(middleware.Recoverer)
+	mux.Use(middleware.Logger)
+	mux.Use(app.enableCORS)
+
+	mux.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Censo API Online"))
+	})
+
+	mux.Route("/v1", func(r chi.Router) {
+		r.Get("/health", app.HealthCheck)
+		r.Get("/census/status", app.CensusStatus)
+
+		r.Group(func(pub chi.Router) {
+			pub.Use(app.requirePublicAPIKey)
+			pub.Get("/locations", app.GetLocations)
+			pub.Get("/schools", app.GetSchools)
+			pub.With(app.requireCensusSubmissions).Post("/schools", app.CreateSchool)
+			pub.Get("/census", app.GetCenso)
+			pub.With(app.requireCensusSubmissions).Post("/census", app.CreateOrUpdateCenso)
+			pub.With(app.requireCensusSubmissions).Post("/upload", app.uploadPhoto)
+		})
+
+		r.Post("/admin/login", app.AdminLoginRuntime)
+		r.Group(func(protected chi.Router) {
+			protected.Use(app.requireRuntimeAdminAuth)
+			protected.Get("/admin/me", app.AdminMeCanonical)
+			protected.Get("/admin/dashboard", app.AdminDashboardCanonical)
+			protected.Get("/admin/sheet-metrics", app.AdminSheetMetrics)
+			protected.Get("/admin/indicadores-metrics", app.AdminIndicadoresMetrics)
+			protected.Get("/admin/census", app.AdminGetCensusCanonical)
+			protected.Get("/admin/census/{id}", app.AdminGetCensusByIDCanonical)
+			protected.Post("/admin/sync-sheets", app.AdminSyncSheets)
+
+			protected.Post("/admin/dres", app.AdminCreateDRE)
+			protected.Get("/admin/dres", app.AdminListDREs)
+			protected.Put("/admin/dres/{id}", app.AdminUpdateDRE)
+			protected.Get("/admin/dres/{id}/resumo", app.AdminDRESummary)
+			protected.Post("/admin/dres/{id}/schools", app.AdminAssignSchoolsToDRE)
+			protected.Patch("/admin/schools/{id}/dre", app.AdminMoveSchoolToDRE)
+
+			protected.Post("/admin/users", app.AdminCreateUser)
+			protected.Get("/admin/users", app.AdminListUsers)
+			protected.Patch("/admin/users/{id}/status", app.AdminUpdateUserStatus)
+			protected.Post("/admin/users/{id}/reset-password", app.AdminResetUserPassword)
+
+			protected.Get("/admin/analytics/overview", app.AdminAnalyticsOverview)
+			protected.Get("/admin/analytics/caracterizacao/perfil", app.AdminAnalyticsCaracterizacaoPerfil)
+			protected.Get("/admin/analytics/caracterizacao/dre", app.AdminAnalyticsCaracterizacaoDRE)
+			protected.Get("/admin/analytics/caracterizacao/oferta-funcionamento", app.AdminAnalyticsCaracterizacaoOfertaFuncionamento)
+			protected.Get("/admin/analytics/caracterizacao/infraestrutura-educacional", app.AdminAnalyticsCaracterizacaoInfraEducacional)
+			protected.Get("/admin/analytics/pessoal-gestao/estrutura", app.AdminAnalyticsPessoalEstrutura)
+			protected.Get("/admin/analytics/pessoal-gestao/coordenacao", app.AdminAnalyticsPessoalCoordenacao)
+			protected.Get("/admin/analytics/pessoal-gestao/quadro-pessoal", app.AdminAnalyticsPessoalQuadro)
+			protected.Get("/admin/analytics/tecnologia/infraestrutura", app.AdminAnalyticsTecnologiaInfra)
+			protected.Get("/admin/analytics/tecnologia/uso-pedagogico", app.AdminAnalyticsTecnologiaUso)
+			protected.Get("/admin/analytics/infraestrutura/condicoes", app.AdminAnalyticsInfraCondicoes)
+			protected.Get("/admin/analytics/infraestrutura/seguranca", app.AdminAnalyticsInfraSeguranca)
+			protected.Get("/admin/analytics/infraestrutura/energia", app.AdminAnalyticsInfraEnergia)
+			protected.Get("/admin/analytics/merenda/oferta", app.AdminAnalyticsMerendaOferta)
+			protected.Get("/admin/analytics/merenda/equipamentos", app.AdminAnalyticsMerendaEquipamentos)
+			protected.Get("/admin/analytics/merenda/recursos-humanos", app.AdminAnalyticsMerendaRH)
+			protected.Get("/admin/analytics/merenda/condicoes-sanitarias", app.AdminAnalyticsMerendaCondicoesSanitarias)
+			protected.Get("/admin/analytics/servicos-terceirizados/visao-geral", app.AdminAnalyticsServicosVisaoGeral)
+			protected.Get("/admin/analytics/servicos-terceirizados/servicos-gerais", app.AdminAnalyticsServicosGerais)
+			protected.Get("/admin/analytics/servicos-terceirizados/portaria", app.AdminAnalyticsServicosPortaria)
+			protected.Get("/admin/analytics/servicos-terceirizados/manipuladores-alimentos", app.AdminAnalyticsServicosManipuladoresAlimentos)
+			protected.Get("/admin/analytics/escolas/saude-operacional", app.AdminAnalyticsSaudeOperacionalEscolas)
+			protected.Get("/admin/analytics/infraestrutura/escolas", app.AdminAnalyticsInfraEscolas)
+			protected.Get("/admin/analytics/merenda/escolas", app.AdminAnalyticsMerendaEscolas)
+			protected.Get("/admin/analytics/servicos-terceirizados/escolas", app.AdminAnalyticsServicosTerceirizadosEscolas)
+			protected.Get("/admin/analytics/pessoal-gestao/escolas", app.AdminAnalyticsPessoalEscolas)
+			protected.Get("/admin/analytics/tecnologia/escolas", app.AdminAnalyticsTecnologiaEscolas)
+			protected.Get("/admin/analytics/caracterizacao/escolas", app.AdminAnalyticsCaracterizacaoEscolas)
+			protected.Get("/admin/analytics/financeiro-governanca/prodep", app.AdminAnalyticsFinanceiroGovernancaProdep)
+			protected.Get("/admin/analytics/financeiro-governanca/institucional", app.AdminAnalyticsFinanceiroGovernancaInstitucional)
+			protected.Get("/admin/analytics/financeiro-governanca/indice-escolas", app.AdminAnalyticsGovernancaIndiceEscolas)
+			protected.Get("/admin/analytics/perfil-alunos-resultados/ideb", app.AdminAnalyticsPerfilAlunosResultadosIDEB)
+			protected.Get("/admin/analytics/preenchimento/dre", app.AdminAnalyticsPreenchimentoDre)
+			protected.Get("/admin/analytics/filtros/opcoes", app.AdminAnalyticsFiltrosOpcoes)
+			protected.Get("/admin/reports/{report_id}", app.AdminGetReport)
+		})
+	})
+
+	return mux
 }

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -21,16 +21,26 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// migrationsFS embute, no próprio binário, todos os .sql em
+// api/cmd/api/migrations/. Isso elimina a dependência de um caminho
+// relativo em runtime (problema observado no deploy Railway, onde
+// o working directory do processo não contém o diretório
+// infra/migrations/ que existe no monorepo).
+//
+// A cópia em infra/migrations/ é mantida como referência operacional
+// e fonte de verdade documental — qualquer mudança numa view deve ser
+// refletida nas DUAS pastas.
+//
 //go:embed migrations/*.sql
 var migrationsFS embed.FS
 
 const version = "1.1.0"
 
 var criticalAdministrativeMigrations = map[string]struct{}{
-	"0018_create_admin_users.sql":          {},
-	"0019_create_dres_master.sql":          {},
-	"0020_dre_canonical_relations.sql":     {},
-	"0021_dre_normalized_uniqueness.sql":   {},
+	"0018_create_admin_users.sql":        {},
+	"0019_create_dres_master.sql":        {},
+	"0020_dre_canonical_relations.sql":   {},
+	"0021_dre_normalized_uniqueness.sql": {},
 }
 
 type config struct {
@@ -52,14 +62,16 @@ type application struct {
 func main() {
 	logger := log.New(os.Stdout, "[CENSO-API] ", log.Ldate|log.Ltime|log.Lshortfile)
 
+	// --- CORREÇÃO DE PATH ---
 	cwd, _ := os.Getwd()
 	logger.Printf("Executando a partir de: %s", cwd)
 
+	// PROCURA O .ENV DE FORMA INTELIGENTE EM VÁRIOS LUGARES
 	envPaths := []string{
-		".env",
-		filepath.Join(cwd, ".env"),
-		filepath.Join(cwd, "..", ".env"),
-		filepath.Join(cwd, "..", "infra", ".env"),
+		".env",                                    // Tenta na mesma pasta de onde o comando rodou
+		filepath.Join(cwd, ".env"),                // Tenta no caminho absoluto atual
+		filepath.Join(cwd, "..", ".env"),          // Tenta um nível acima (raiz do projeto)
+		filepath.Join(cwd, "..", "infra", ".env"), // Tenta na pasta infra
 	}
 
 	envLoaded := false
@@ -192,7 +204,6 @@ func applyMigrations(db *sql.DB, logger *log.Logger) error {
 	if err != nil {
 		return fmt.Errorf("applyMigrations: ler embed migrations/: %w", err)
 	}
-
 	files := make([]string, 0, len(entries))
 	seen := make(map[string]bool, len(entries))
 	for _, e := range entries {
@@ -203,18 +214,15 @@ func applyMigrations(db *sql.DB, logger *log.Logger) error {
 		seen[e.Name()] = true
 	}
 	sort.Strings(files)
-
 	for name := range criticalAdministrativeMigrations {
 		if !seen[name] {
 			return fmt.Errorf("applyMigrations: migration administrativa crítica ausente do binário: %s", name)
 		}
 	}
-
 	if len(files) == 0 {
 		logger.Println("applyMigrations: nenhum .sql embarcado, pulando.")
 		return nil
 	}
-
 	logger.Printf("applyMigrations: %d migration(s) encontrada(s): %v", len(files), files)
 	for _, name := range files {
 		content, err := fs.ReadFile(migrationsFS, "migrations/"+name)
@@ -225,7 +233,6 @@ func applyMigrations(db *sql.DB, logger *log.Logger) error {
 			logger.Printf("applyMigrations: ERRO lendo %s do embed: %v", name, err)
 			continue
 		}
-
 		if _, err := db.Exec(string(content)); err != nil {
 			if isCriticalAdministrativeMigration(name) {
 				return fmt.Errorf("applyMigrations: migration administrativa crítica %s falhou: %w", name, err)

--- a/api/cmd/api/migrations/0020_dre_canonical_relations.sql
+++ b/api/cmd/api/migrations/0020_dre_canonical_relations.sql
@@ -3,38 +3,10 @@
 -- As colunas textuais `dre` permanecem temporariamente por compatibilidade, mas deixam
 -- de ser a fonte de verdade. Triggers de compatibilidade mantem writes legados
 -- sincronizados ate que os handlers sejam migrados integralmente para `dre_id`.
-
--- `dres.nome` suporta 255 caracteres. As colunas legadas precisam comportar o nome
--- canonico inteiro enquanto existirem como camada de compatibilidade. A alteracao e
--- condicional para que a migration possa ser reexecutada depois da criacao dos triggers.
-DO $$
-DECLARE
-    schools_dre_length INTEGER;
-    admin_users_dre_length INTEGER;
-BEGIN
-    SELECT character_maximum_length
-    INTO schools_dre_length
-    FROM information_schema.columns
-    WHERE table_schema = CURRENT_SCHEMA()
-      AND table_name = 'schools'
-      AND column_name = 'dre';
-
-    IF schools_dre_length IS NOT NULL AND schools_dre_length < 255 THEN
-        ALTER TABLE schools ALTER COLUMN dre TYPE VARCHAR(255);
-    END IF;
-
-    SELECT character_maximum_length
-    INTO admin_users_dre_length
-    FROM information_schema.columns
-    WHERE table_schema = CURRENT_SCHEMA()
-      AND table_name = 'admin_users'
-      AND column_name = 'dre';
-
-    IF admin_users_dre_length IS NOT NULL AND admin_users_dre_length < 255 THEN
-        ALTER TABLE admin_users ALTER COLUMN dre TYPE VARCHAR(255);
-    END IF;
-END
-$$;
+--
+-- IMPORTANTE: não alteramos o tipo das colunas legadas aqui. `schools.dre` é usada por
+-- views históricas e ALTER TYPE pode falhar em bancos já migrados. Como `dre_id` é a
+-- fonte canônica, o texto legado é espelhado respeitando os limites atuais.
 
 ALTER TABLE schools
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;
@@ -42,7 +14,6 @@ ALTER TABLE schools
 ALTER TABLE admin_users
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;
 
--- Nunca escolher uma DRE arbitrariamente quando nomes diferem apenas por caixa/espacos.
 DO $$
 BEGIN
     IF EXISTS (
@@ -56,8 +27,6 @@ BEGIN
 END
 $$;
 
--- Se uma execucao anterior/parcial ja deixou IDs preenchidos, eles precisam apontar
--- para uma entidade mestre real antes de qualquer reconciliacao textual.
 DO $$
 BEGIN
     IF EXISTS (
@@ -80,25 +49,21 @@ BEGIN
 END
 $$;
 
--- Quando dre_id ja existe, ele e a fonte de verdade. Isso torna a migration segura
--- para reexecucao inclusive apos rename da DRE: o texto legado acompanha o ID.
 UPDATE schools s
-SET dre = d.nome
+SET dre = LEFT(d.nome, 100)
 FROM dres d
 WHERE s.dre_id = d.id
-  AND s.dre IS DISTINCT FROM d.nome;
+  AND s.dre IS DISTINCT FROM LEFT(d.nome, 100);
 
 UPDATE admin_users u
-SET dre = d.nome
+SET dre = LEFT(d.nome, 128)
 FROM dres d
 WHERE u.dre_id = d.id
-  AND u.dre IS DISTINCT FROM d.nome;
+  AND u.dre IS DISTINCT FROM LEFT(d.nome, 128);
 
--- Backfill somente de registros ainda sem ID, usando comparacao tolerante a caixa e
--- espacos. A verificacao de ambiguidade acima garante correspondencia deterministica.
 UPDATE schools s
 SET dre_id = d.id,
-    dre = d.nome
+    dre = LEFT(d.nome, 100)
 FROM dres d
 WHERE s.dre_id IS NULL
   AND BTRIM(COALESCE(s.dre, '')) <> ''
@@ -106,13 +71,12 @@ WHERE s.dre_id IS NULL
 
 UPDATE admin_users u
 SET dre_id = d.id,
-    dre = d.nome
+    dre = LEFT(d.nome, 128)
 FROM dres d
 WHERE u.dre_id IS NULL
   AND BTRIM(COALESCE(u.dre, '')) <> ''
   AND UPPER(BTRIM(u.dre)) = UPPER(BTRIM(d.nome));
 
--- Dados legados nao reconciliaveis devem interromper a migration de forma explicita.
 DO $$
 BEGIN
     IF EXISTS (
@@ -141,8 +105,7 @@ CREATE INDEX IF NOT EXISTS idx_admin_users_dre_id ON admin_users(dre_id);
 DO $$
 BEGIN
     IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
+        SELECT 1 FROM pg_constraint
         WHERE conname = 'fk_schools_dre_id'
           AND conrelid = 'schools'::regclass
     ) THEN
@@ -153,8 +116,7 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
+        SELECT 1 FROM pg_constraint
         WHERE conname = 'fk_admin_users_dre_id'
           AND conrelid = 'admin_users'::regclass
     ) THEN
@@ -165,8 +127,7 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
+        SELECT 1 FROM pg_constraint
         WHERE conname = 'chk_schools_dre_canonical'
           AND conrelid = 'schools'::regclass
     ) THEN
@@ -176,8 +137,7 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
+        SELECT 1 FROM pg_constraint
         WHERE conname = 'chk_admin_users_role_dre_id'
           AND conrelid = 'admin_users'::regclass
     ) THEN
@@ -188,7 +148,6 @@ BEGIN
 END
 $$;
 
--- Bridge temporaria para codigo legado que ainda escreve `dre` textual.
 CREATE OR REPLACE FUNCTION sync_school_dre_relation()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -199,18 +158,15 @@ DECLARE
 BEGIN
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome
-            INTO STRICT canonical_id, canonical_name
-            FROM dres
-            WHERE id = NEW.dre_id;
+            SELECT id, nome INTO STRICT canonical_id, canonical_name
+            FROM dres WHERE id = NEW.dre_id;
         EXCEPTION
             WHEN NO_DATA_FOUND THEN
                 RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id
                     USING ERRCODE = '23503';
         END;
-
         NEW.dre_id := canonical_id;
-        NEW.dre := canonical_name;
+        NEW.dre := LEFT(canonical_name, 100);
         RETURN NEW;
     END IF;
 
@@ -221,21 +177,18 @@ BEGIN
     END IF;
 
     BEGIN
-        SELECT id, nome
-        INTO STRICT canonical_id, canonical_name
+        SELECT id, nome INTO STRICT canonical_id, canonical_name
         FROM dres
         WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
         WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre
-                USING ERRCODE = '23503';
+            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre USING ERRCODE = '23503';
         WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre
-                USING ERRCODE = '23505';
+            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre USING ERRCODE = '23505';
     END;
 
     NEW.dre_id := canonical_id;
-    NEW.dre := canonical_name;
+    NEW.dre := LEFT(canonical_name, 100);
     RETURN NEW;
 END
 $$;
@@ -257,46 +210,38 @@ BEGIN
 
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome
-            INTO STRICT canonical_id, canonical_name
-            FROM dres
-            WHERE id = NEW.dre_id;
+            SELECT id, nome INTO STRICT canonical_id, canonical_name
+            FROM dres WHERE id = NEW.dre_id;
         EXCEPTION
             WHEN NO_DATA_FOUND THEN
-                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id
-                    USING ERRCODE = '23503';
+                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id USING ERRCODE = '23503';
         END;
-
         NEW.dre_id := canonical_id;
-        NEW.dre := canonical_name;
+        NEW.dre := LEFT(canonical_name, 128);
         RETURN NEW;
     END IF;
 
     IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
         IF NEW.role = 'dre' THEN
-            RAISE EXCEPTION 'DRE user requires a canonical DRE'
-                USING ERRCODE = '23514';
+            RAISE EXCEPTION 'DRE user requires a canonical DRE' USING ERRCODE = '23514';
         END IF;
         NEW.dre := NULL;
         RETURN NEW;
     END IF;
 
     BEGIN
-        SELECT id, nome
-        INTO STRICT canonical_id, canonical_name
+        SELECT id, nome INTO STRICT canonical_id, canonical_name
         FROM dres
         WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
         WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre
-                USING ERRCODE = '23503';
+            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre USING ERRCODE = '23503';
         WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre
-                USING ERRCODE = '23505';
+            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre USING ERRCODE = '23505';
     END;
 
     NEW.dre_id := canonical_id;
-    NEW.dre := canonical_name;
+    NEW.dre := LEFT(canonical_name, 128);
     RETURN NEW;
 END
 $$;
@@ -304,14 +249,12 @@ $$;
 DROP TRIGGER IF EXISTS trg_schools_sync_dre_relation ON schools;
 CREATE TRIGGER trg_schools_sync_dre_relation
 BEFORE INSERT OR UPDATE OF dre, dre_id ON schools
-FOR EACH ROW
-EXECUTE FUNCTION sync_school_dre_relation();
+FOR EACH ROW EXECUTE FUNCTION sync_school_dre_relation();
 
 DROP TRIGGER IF EXISTS trg_admin_users_sync_dre_relation ON admin_users;
 CREATE TRIGGER trg_admin_users_sync_dre_relation
 BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users
-FOR EACH ROW
-EXECUTE FUNCTION sync_admin_user_dre_relation();
+FOR EACH ROW EXECUTE FUNCTION sync_admin_user_dre_relation();
 
 COMMENT ON COLUMN schools.dre_id IS
     'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';

--- a/api/cmd/api/migrations/0020_dre_canonical_relations.sql
+++ b/api/cmd/api/migrations/0020_dre_canonical_relations.sql
@@ -3,10 +3,10 @@
 -- As colunas textuais `dre` permanecem temporariamente por compatibilidade, mas deixam
 -- de ser a fonte de verdade. Triggers de compatibilidade mantem writes legados
 -- sincronizados ate que os handlers sejam migrados integralmente para `dre_id`.
---
--- IMPORTANTE: não alteramos o tipo das colunas legadas aqui. `schools.dre` é usada por
--- views históricas e ALTER TYPE pode falhar em bancos já migrados. Como `dre_id` é a
--- fonte canônica, o texto legado é espelhado respeitando os limites atuais.
+
+-- As colunas legadas permanecem com seus tipos historicos porque `schools.dre` e
+-- referenciada por views e ALTER TYPE pode falhar em bancos ja existentes. Como
+-- `dre_id` e a fonte de verdade, o texto legado e espelhado respeitando seus limites.
 
 ALTER TABLE schools
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;
@@ -14,6 +14,7 @@ ALTER TABLE schools
 ALTER TABLE admin_users
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;
 
+-- Nunca escolher uma DRE arbitrariamente quando nomes diferem apenas por caixa/espacos.
 DO $$
 BEGIN
     IF EXISTS (
@@ -27,6 +28,8 @@ BEGIN
 END
 $$;
 
+-- Se uma execucao anterior/parcial ja deixou IDs preenchidos, eles precisam apontar
+-- para uma entidade mestre real antes de qualquer reconciliacao textual.
 DO $$
 BEGIN
     IF EXISTS (
@@ -49,6 +52,8 @@ BEGIN
 END
 $$;
 
+-- Quando dre_id ja existe, ele e a fonte de verdade. Isso torna a migration segura
+-- para reexecucao inclusive apos rename da DRE: o texto legado acompanha o ID.
 UPDATE schools s
 SET dre = LEFT(d.nome, 100)
 FROM dres d
@@ -61,6 +66,8 @@ FROM dres d
 WHERE u.dre_id = d.id
   AND u.dre IS DISTINCT FROM LEFT(d.nome, 128);
 
+-- Backfill somente de registros ainda sem ID, usando comparacao tolerante a caixa e
+-- espacos. A verificacao de ambiguidade acima garante correspondencia deterministica.
 UPDATE schools s
 SET dre_id = d.id,
     dre = LEFT(d.nome, 100)
@@ -77,6 +84,7 @@ WHERE u.dre_id IS NULL
   AND BTRIM(COALESCE(u.dre, '')) <> ''
   AND UPPER(BTRIM(u.dre)) = UPPER(BTRIM(d.nome));
 
+-- Dados legados nao reconciliaveis devem interromper a migration de forma explicita.
 DO $$
 BEGIN
     IF EXISTS (
@@ -105,7 +113,8 @@ CREATE INDEX IF NOT EXISTS idx_admin_users_dre_id ON admin_users(dre_id);
 DO $$
 BEGIN
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
+        SELECT 1
+        FROM pg_constraint
         WHERE conname = 'fk_schools_dre_id'
           AND conrelid = 'schools'::regclass
     ) THEN
@@ -116,7 +125,8 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
+        SELECT 1
+        FROM pg_constraint
         WHERE conname = 'fk_admin_users_dre_id'
           AND conrelid = 'admin_users'::regclass
     ) THEN
@@ -127,7 +137,8 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
+        SELECT 1
+        FROM pg_constraint
         WHERE conname = 'chk_schools_dre_canonical'
           AND conrelid = 'schools'::regclass
     ) THEN
@@ -137,7 +148,8 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
+        SELECT 1
+        FROM pg_constraint
         WHERE conname = 'chk_admin_users_role_dre_id'
           AND conrelid = 'admin_users'::regclass
     ) THEN
@@ -148,6 +160,7 @@ BEGIN
 END
 $$;
 
+-- Bridge temporaria para codigo legado que ainda escreve `dre` textual.
 CREATE OR REPLACE FUNCTION sync_school_dre_relation()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -158,13 +171,16 @@ DECLARE
 BEGIN
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome INTO STRICT canonical_id, canonical_name
-            FROM dres WHERE id = NEW.dre_id;
+            SELECT id, nome
+            INTO STRICT canonical_id, canonical_name
+            FROM dres
+            WHERE id = NEW.dre_id;
         EXCEPTION
             WHEN NO_DATA_FOUND THEN
                 RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id
                     USING ERRCODE = '23503';
         END;
+
         NEW.dre_id := canonical_id;
         NEW.dre := LEFT(canonical_name, 100);
         RETURN NEW;
@@ -177,14 +193,17 @@ BEGIN
     END IF;
 
     BEGIN
-        SELECT id, nome INTO STRICT canonical_id, canonical_name
+        SELECT id, nome
+        INTO STRICT canonical_id, canonical_name
         FROM dres
         WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
         WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre USING ERRCODE = '23503';
+            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre
+                USING ERRCODE = '23503';
         WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre USING ERRCODE = '23505';
+            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre
+                USING ERRCODE = '23505';
     END;
 
     NEW.dre_id := canonical_id;
@@ -210,12 +229,16 @@ BEGIN
 
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome INTO STRICT canonical_id, canonical_name
-            FROM dres WHERE id = NEW.dre_id;
+            SELECT id, nome
+            INTO STRICT canonical_id, canonical_name
+            FROM dres
+            WHERE id = NEW.dre_id;
         EXCEPTION
             WHEN NO_DATA_FOUND THEN
-                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id USING ERRCODE = '23503';
+                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id
+                    USING ERRCODE = '23503';
         END;
+
         NEW.dre_id := canonical_id;
         NEW.dre := LEFT(canonical_name, 128);
         RETURN NEW;
@@ -223,21 +246,25 @@ BEGIN
 
     IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
         IF NEW.role = 'dre' THEN
-            RAISE EXCEPTION 'DRE user requires a canonical DRE' USING ERRCODE = '23514';
+            RAISE EXCEPTION 'DRE user requires a canonical DRE'
+                USING ERRCODE = '23514';
         END IF;
         NEW.dre := NULL;
         RETURN NEW;
     END IF;
 
     BEGIN
-        SELECT id, nome INTO STRICT canonical_id, canonical_name
+        SELECT id, nome
+        INTO STRICT canonical_id, canonical_name
         FROM dres
         WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
         WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre USING ERRCODE = '23503';
+            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre
+                USING ERRCODE = '23503';
         WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre USING ERRCODE = '23505';
+            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre
+                USING ERRCODE = '23505';
     END;
 
     NEW.dre_id := canonical_id;
@@ -249,12 +276,14 @@ $$;
 DROP TRIGGER IF EXISTS trg_schools_sync_dre_relation ON schools;
 CREATE TRIGGER trg_schools_sync_dre_relation
 BEFORE INSERT OR UPDATE OF dre, dre_id ON schools
-FOR EACH ROW EXECUTE FUNCTION sync_school_dre_relation();
+FOR EACH ROW
+EXECUTE FUNCTION sync_school_dre_relation();
 
 DROP TRIGGER IF EXISTS trg_admin_users_sync_dre_relation ON admin_users;
 CREATE TRIGGER trg_admin_users_sync_dre_relation
 BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users
-FOR EACH ROW EXECUTE FUNCTION sync_admin_user_dre_relation();
+FOR EACH ROW
+EXECUTE FUNCTION sync_admin_user_dre_relation();
 
 COMMENT ON COLUMN schools.dre_id IS
     'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';

--- a/api/cmd/api/migrations/0021_dre_normalized_uniqueness.sql
+++ b/api/cmd/api/migrations/0021_dre_normalized_uniqueness.sql
@@ -1,0 +1,80 @@
+-- 0021_dre_normalized_uniqueness.sql
+-- Endurece a identidade administrativa para que consultas case-insensitive e
+-- constraints usem a mesma regra: LOWER(BTRIM(valor)).
+-- A migration falha antes de modificar dados se houver colisões legadas.
+
+BEGIN;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM admin_users
+        WHERE BTRIM(username) = ''
+    ) THEN
+        RAISE EXCEPTION 'admin_users normalized username migration aborted: blank usernames exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM admin_users
+        GROUP BY LOWER(BTRIM(username))
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'admin_users normalized username migration aborted: normalized username collisions exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM dres
+        WHERE BTRIM(nome) = ''
+    ) THEN
+        RAISE EXCEPTION 'dres normalized name migration aborted: blank DRE names exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM dres
+        GROUP BY LOWER(BTRIM(nome))
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'dres normalized name migration aborted: normalized DRE name collisions exist';
+    END IF;
+END
+$$;
+
+-- Normaliza apenas espaços externos. Essa é a mesma semântica usada hoje pelos
+-- models/handlers (`strings.TrimSpace` + LOWER/UPPER no banco).
+UPDATE admin_users
+SET username = BTRIM(username),
+    updated_at = NOW()
+WHERE username IS DISTINCT FROM BTRIM(username);
+
+UPDATE dres
+SET nome = BTRIM(nome),
+    updated_at = NOW()
+WHERE nome IS DISTINCT FROM BTRIM(nome);
+
+-- Como `dre_id` é a fonte de verdade, reespelha a camada textual legada após a
+-- normalização do nome canônico. Os limites preservam os tipos históricos sem
+-- obrigar ALTER TYPE em colunas usadas por views.
+UPDATE schools s
+SET dre = LEFT(d.nome, 100)
+FROM dres d
+WHERE s.dre_id = d.id
+  AND s.dre IS DISTINCT FROM LEFT(d.nome, 100);
+
+UPDATE admin_users u
+SET dre = LEFT(d.nome, 128),
+    updated_at = NOW()
+FROM dres d
+WHERE u.dre_id = d.id
+  AND u.dre IS DISTINCT FROM LEFT(d.nome, 128);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_admin_users_username_normalized
+    ON admin_users (LOWER(BTRIM(username)));
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_dres_nome_normalized
+    ON dres (LOWER(BTRIM(nome)));
+
+COMMIT;

--- a/api/cmd/api/migrations_security_test.go
+++ b/api/cmd/api/migrations_security_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newMigrationTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL não configurada")
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	schema := fmt.Sprintf("dre_migration_%d", time.Now().UnixNano())
+	if _, err := db.Exec("CREATE SCHEMA " + schema); err != nil {
+		db.Close()
+		t.Fatalf("create schema: %v", err)
+	}
+	if _, err := db.Exec("SET search_path TO " + schema); err != nil {
+		db.Close()
+		t.Fatalf("set search_path: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("SET search_path TO public")
+		_, _ = db.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE")
+		_ = db.Close()
+	})
+	return db
+}
+
+func execEmbeddedMigration(t *testing.T, db *sql.DB, name string) {
+	t.Helper()
+	content, err := migrationsFS.ReadFile("migrations/" + name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	if _, err := db.Exec(string(content)); err != nil {
+		t.Fatalf("exec %s: %v", name, err)
+	}
+}
+
+func seedSchoolsWithDependentView(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`
+		CREATE TABLE schools (
+			id SERIAL PRIMARY KEY,
+			dre VARCHAR(100)
+		);
+		CREATE VIEW vw_test_school_dre AS SELECT id, dre FROM schools;
+	`)
+	if err != nil {
+		t.Fatalf("seed schools/view: %v", err)
+	}
+}
+
+func TestCriticalAdministrativeMigrationsCleanAndIdempotent(t *testing.T) {
+	db := newMigrationTestDB(t)
+	seedSchoolsWithDependentView(t, db)
+	logger := log.New(io.Discard, "", 0)
+
+	if err := applyMigrations(db, logger); err != nil {
+		t.Fatalf("first applyMigrations: %v", err)
+	}
+	if err := applyMigrations(db, logger); err != nil {
+		t.Fatalf("second applyMigrations must be idempotent: %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO dres (nome) VALUES ('DRE BELEM')`); err != nil {
+		t.Fatalf("insert first DRE: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO dres (nome) VALUES ('  dre belem  ')`); err == nil {
+		t.Fatal("expected normalized DRE unique index to reject case/space equivalent name")
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO admin_users (username, password_hash, role, active)
+		VALUES ('RegionalUser', 'hash', 'admin', true)`); err != nil {
+		t.Fatalf("insert first username: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO admin_users (username, password_hash, role, active)
+		VALUES ('  regionaluser  ', 'hash', 'admin', true)`); err == nil {
+		t.Fatal("expected normalized username unique index to reject case/space equivalent username")
+	}
+}
+
+func TestCriticalMigrationFailsClosedOnLegacyUsernameCollision(t *testing.T) {
+	db := newMigrationTestDB(t)
+	seedSchoolsWithDependentView(t, db)
+
+	execEmbeddedMigration(t, db, "0018_create_admin_users.sql")
+	execEmbeddedMigration(t, db, "0019_create_dres_master.sql")
+	execEmbeddedMigration(t, db, "0020_dre_canonical_relations.sql")
+
+	_, err := db.Exec(`
+		INSERT INTO admin_users (username, password_hash, role, active)
+		VALUES
+			('LegacyUser', 'hash', 'admin', true),
+			('  legacyuser  ', 'hash', 'admin', true)`)
+	if err != nil {
+		t.Fatalf("seed legacy username collision: %v", err)
+	}
+
+	err = applyMigrations(db, log.New(io.Discard, "", 0))
+	if err == nil {
+		t.Fatal("expected critical migration failure for normalized username collision")
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "0021_dre_normalized_uniqueness.sql") || !strings.Contains(msg, "username") {
+		t.Fatalf("expected actionable 0021 username error, got: %v", err)
+	}
+}
+
+func TestCriticalMigrationFailsClosedOnAmbiguousDRENames(t *testing.T) {
+	db := newMigrationTestDB(t)
+	seedSchoolsWithDependentView(t, db)
+
+	execEmbeddedMigration(t, db, "0018_create_admin_users.sql")
+	execEmbeddedMigration(t, db, "0019_create_dres_master.sql")
+
+	_, err := db.Exec(`INSERT INTO dres (nome) VALUES ('DRE MARAJO'), ('  dre marajo  ')`)
+	if err != nil {
+		t.Fatalf("seed ambiguous DRE names: %v", err)
+	}
+
+	err = applyMigrations(db, log.New(io.Discard, "", 0))
+	if err == nil {
+		t.Fatal("expected critical migration failure for ambiguous DRE names")
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "0020_dre_canonical_relations.sql") || !strings.Contains(msg, "ambiguous") {
+		t.Fatalf("expected actionable 0020 ambiguity error, got: %v", err)
+	}
+}

--- a/api/internal/models/dres.go
+++ b/api/internal/models/dres.go
@@ -243,8 +243,8 @@ func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 	if usersCanonical {
 		_, err = tx.ExecContext(ctx, `
 			UPDATE admin_users
-			SET dre = $1, updated_at = NOW()
-			WHERE dre_id = $2 AND dre IS DISTINCT FROM $1`, d.Nome, d.ID)
+			SET dre = LEFT($1, 128), updated_at = NOW()
+			WHERE dre_id = $2 AND dre IS DISTINCT FROM LEFT($1, 128)`, d.Nome, d.ID)
 	} else {
 		_, err = tx.ExecContext(ctx, `
 			UPDATE admin_users
@@ -258,8 +258,8 @@ func (m *DREModel) Update(ctx context.Context, dre DRE) (*DRE, error) {
 	if schoolsCanonical {
 		_, err = tx.ExecContext(ctx, `
 			UPDATE schools
-			SET dre = $1
-			WHERE dre_id = $2 AND dre IS DISTINCT FROM $1`, d.Nome, d.ID)
+			SET dre = LEFT($1, 100)
+			WHERE dre_id = $2 AND dre IS DISTINCT FROM LEFT($1, 100)`, d.Nome, d.ID)
 	} else {
 		_, err = tx.ExecContext(ctx, `
 			UPDATE schools

--- a/docs/dre-migration-recovery.md
+++ b/docs/dre-migration-recovery.md
@@ -1,0 +1,73 @@
+# Recuperação de migrations administrativas DRE
+
+As migrations `0018`–`0021` são tratadas como críticas pelo runtime. Se uma delas falhar, a API não deve iniciar como se o schema estivesse saudável.
+
+## Antes de corrigir
+
+1. Faça backup/snapshot do PostgreSQL.
+2. Preserve a mensagem completa de erro da migration.
+3. Não remova constraints, FKs ou índices apenas para forçar o startup.
+
+## Colisões de username
+
+A identidade normalizada é `LOWER(BTRIM(username))`.
+
+```sql
+SELECT LOWER(BTRIM(username)) AS chave, COUNT(*) AS total,
+       ARRAY_AGG(id ORDER BY id) AS ids,
+       ARRAY_AGG(username ORDER BY id) AS usernames
+FROM admin_users
+GROUP BY LOWER(BTRIM(username))
+HAVING COUNT(*) > 1;
+```
+
+Renomeie explicitamente o registro correto conforme a regra operacional. A migration nunca escolhe automaticamente qual usuário manter.
+
+## Colisões de nome de DRE
+
+A identidade normalizada é `LOWER(BTRIM(nome))`.
+
+```sql
+SELECT LOWER(BTRIM(nome)) AS chave, COUNT(*) AS total,
+       ARRAY_AGG(id ORDER BY id) AS ids,
+       ARRAY_AGG(nome ORDER BY id) AS nomes
+FROM dres
+GROUP BY LOWER(BTRIM(nome))
+HAVING COUNT(*) > 1;
+```
+
+Antes de consolidar DREs duplicadas, confira `schools.dre_id` e `admin_users.dre_id`. Não exclua uma DRE que ainda possua vínculos.
+
+## Verificação do schema canônico
+
+```sql
+SELECT conname
+FROM pg_constraint
+WHERE conname IN ('fk_schools_dre_id', 'fk_admin_users_dre_id');
+
+SELECT indexname
+FROM pg_indexes
+WHERE indexname IN (
+  'uq_admin_users_username_normalized',
+  'uq_dres_nome_normalized'
+);
+```
+
+Os dois FKs e os dois índices normalizados devem existir após a recuperação.
+
+## Reaplicação
+
+Depois de corrigir os dados legados, reinicie a API. `applyMigrations` reaplica as migrations idempotentes na ordem e interrompe novamente o startup se o problema persistir.
+
+Para validação manual em ambiente controlado, as cópias operacionais ficam em `infra/migrations/`; os arquivos de runtime embutidos ficam em `api/cmd/api/migrations/` e devem permanecer idênticos.
+
+## Rollback de emergência da 0021
+
+Somente se for necessário voltar o binário para uma versão anterior, e após snapshot:
+
+```sql
+DROP INDEX IF EXISTS uq_admin_users_username_normalized;
+DROP INDEX IF EXISTS uq_dres_nome_normalized;
+```
+
+Esse rollback remove apenas a proteção nova de unicidade normalizada. Ele não desfaz os vínculos canônicos `dre_id` da migration `0020`.

--- a/infra/migrations/0020_dre_canonical_relations.sql
+++ b/infra/migrations/0020_dre_canonical_relations.sql
@@ -3,38 +3,10 @@
 -- As colunas textuais `dre` permanecem temporariamente por compatibilidade, mas deixam
 -- de ser a fonte de verdade. Triggers de compatibilidade mantem writes legados
 -- sincronizados ate que os handlers sejam migrados integralmente para `dre_id`.
-
--- `dres.nome` suporta 255 caracteres. As colunas legadas precisam comportar o nome
--- canonico inteiro enquanto existirem como camada de compatibilidade. A alteracao e
--- condicional para que a migration possa ser reexecutada depois da criacao dos triggers.
-DO $$
-DECLARE
-    schools_dre_length INTEGER;
-    admin_users_dre_length INTEGER;
-BEGIN
-    SELECT character_maximum_length
-    INTO schools_dre_length
-    FROM information_schema.columns
-    WHERE table_schema = CURRENT_SCHEMA()
-      AND table_name = 'schools'
-      AND column_name = 'dre';
-
-    IF schools_dre_length IS NOT NULL AND schools_dre_length < 255 THEN
-        ALTER TABLE schools ALTER COLUMN dre TYPE VARCHAR(255);
-    END IF;
-
-    SELECT character_maximum_length
-    INTO admin_users_dre_length
-    FROM information_schema.columns
-    WHERE table_schema = CURRENT_SCHEMA()
-      AND table_name = 'admin_users'
-      AND column_name = 'dre';
-
-    IF admin_users_dre_length IS NOT NULL AND admin_users_dre_length < 255 THEN
-        ALTER TABLE admin_users ALTER COLUMN dre TYPE VARCHAR(255);
-    END IF;
-END
-$$;
+--
+-- IMPORTANTE: não alteramos o tipo das colunas legadas aqui. `schools.dre` é usada por
+-- views históricas e ALTER TYPE pode falhar em bancos já migrados. Como `dre_id` é a
+-- fonte canônica, o texto legado é espelhado respeitando os limites atuais.
 
 ALTER TABLE schools
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;
@@ -42,12 +14,10 @@ ALTER TABLE schools
 ALTER TABLE admin_users
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;
 
--- Nunca escolher uma DRE arbitrariamente quando nomes diferem apenas por caixa/espacos.
 DO $$
 BEGIN
     IF EXISTS (
-        SELECT 1
-        FROM dres
+        SELECT 1 FROM dres
         GROUP BY UPPER(BTRIM(nome))
         HAVING COUNT(*) > 1
     ) THEN
@@ -56,22 +26,17 @@ BEGIN
 END
 $$;
 
--- Se uma execucao anterior/parcial ja deixou IDs preenchidos, eles precisam apontar
--- para uma entidade mestre real antes de qualquer reconciliacao textual.
 DO $$
 BEGIN
     IF EXISTS (
-        SELECT 1
-        FROM schools s
+        SELECT 1 FROM schools s
         LEFT JOIN dres d ON d.id = s.dre_id
         WHERE s.dre_id IS NOT NULL AND d.id IS NULL
     ) THEN
         RAISE EXCEPTION 'dre canonical backfill aborted: schools contains invalid dre_id';
     END IF;
-
     IF EXISTS (
-        SELECT 1
-        FROM admin_users u
+        SELECT 1 FROM admin_users u
         LEFT JOIN dres d ON d.id = u.dre_id
         WHERE u.dre_id IS NOT NULL AND d.id IS NULL
     ) THEN
@@ -80,25 +45,21 @@ BEGIN
 END
 $$;
 
--- Quando dre_id ja existe, ele e a fonte de verdade. Isso torna a migration segura
--- para reexecucao inclusive apos rename da DRE: o texto legado acompanha o ID.
 UPDATE schools s
-SET dre = d.nome
+SET dre = LEFT(d.nome, 100)
 FROM dres d
 WHERE s.dre_id = d.id
-  AND s.dre IS DISTINCT FROM d.nome;
+  AND s.dre IS DISTINCT FROM LEFT(d.nome, 100);
 
 UPDATE admin_users u
-SET dre = d.nome
+SET dre = LEFT(d.nome, 128)
 FROM dres d
 WHERE u.dre_id = d.id
-  AND u.dre IS DISTINCT FROM d.nome;
+  AND u.dre IS DISTINCT FROM LEFT(d.nome, 128);
 
--- Backfill somente de registros ainda sem ID, usando comparacao tolerante a caixa e
--- espacos. A verificacao de ambiguidade acima garante correspondencia deterministica.
 UPDATE schools s
 SET dre_id = d.id,
-    dre = d.nome
+    dre = LEFT(d.nome, 100)
 FROM dres d
 WHERE s.dre_id IS NULL
   AND BTRIM(COALESCE(s.dre, '')) <> ''
@@ -106,29 +67,23 @@ WHERE s.dre_id IS NULL
 
 UPDATE admin_users u
 SET dre_id = d.id,
-    dre = d.nome
+    dre = LEFT(d.nome, 128)
 FROM dres d
 WHERE u.dre_id IS NULL
   AND BTRIM(COALESCE(u.dre, '')) <> ''
   AND UPPER(BTRIM(u.dre)) = UPPER(BTRIM(d.nome));
 
--- Dados legados nao reconciliaveis devem interromper a migration de forma explicita.
 DO $$
 BEGIN
     IF EXISTS (
-        SELECT 1
-        FROM schools
-        WHERE dre_id IS NULL
-          AND BTRIM(COALESCE(dre, '')) <> ''
+        SELECT 1 FROM schools
+        WHERE dre_id IS NULL AND BTRIM(COALESCE(dre, '')) <> ''
     ) THEN
         RAISE EXCEPTION 'dre canonical backfill aborted: unmapped school DRE values exist';
     END IF;
-
     IF EXISTS (
-        SELECT 1
-        FROM admin_users
-        WHERE role = 'dre'
-          AND dre_id IS NULL
+        SELECT 1 FROM admin_users
+        WHERE role = 'dre' AND dre_id IS NULL
     ) THEN
         RAISE EXCEPTION 'dre canonical backfill aborted: unmapped DRE users exist';
     END IF;
@@ -140,180 +95,76 @@ CREATE INDEX IF NOT EXISTS idx_admin_users_dre_id ON admin_users(dre_id);
 
 DO $$
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'fk_schools_dre_id'
-          AND conrelid = 'schools'::regclass
-    ) THEN
-        ALTER TABLE schools
-            ADD CONSTRAINT fk_schools_dre_id
-            FOREIGN KEY (dre_id) REFERENCES dres(id)
-            ON UPDATE RESTRICT ON DELETE RESTRICT;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_schools_dre_id' AND conrelid = 'schools'::regclass) THEN
+        ALTER TABLE schools ADD CONSTRAINT fk_schools_dre_id FOREIGN KEY (dre_id) REFERENCES dres(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
     END IF;
-
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'fk_admin_users_dre_id'
-          AND conrelid = 'admin_users'::regclass
-    ) THEN
-        ALTER TABLE admin_users
-            ADD CONSTRAINT fk_admin_users_dre_id
-            FOREIGN KEY (dre_id) REFERENCES dres(id)
-            ON UPDATE RESTRICT ON DELETE RESTRICT;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_admin_users_dre_id' AND conrelid = 'admin_users'::regclass) THEN
+        ALTER TABLE admin_users ADD CONSTRAINT fk_admin_users_dre_id FOREIGN KEY (dre_id) REFERENCES dres(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
     END IF;
-
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'chk_schools_dre_canonical'
-          AND conrelid = 'schools'::regclass
-    ) THEN
-        ALTER TABLE schools
-            ADD CONSTRAINT chk_schools_dre_canonical
-            CHECK (dre_id IS NOT NULL OR dre IS NULL OR BTRIM(dre) = '');
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_schools_dre_canonical' AND conrelid = 'schools'::regclass) THEN
+        ALTER TABLE schools ADD CONSTRAINT chk_schools_dre_canonical CHECK (dre_id IS NOT NULL OR dre IS NULL OR BTRIM(dre) = '');
     END IF;
-
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'chk_admin_users_role_dre_id'
-          AND conrelid = 'admin_users'::regclass
-    ) THEN
-        ALTER TABLE admin_users
-            ADD CONSTRAINT chk_admin_users_role_dre_id
-            CHECK (role <> 'dre' OR dre_id IS NOT NULL);
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_admin_users_role_dre_id' AND conrelid = 'admin_users'::regclass) THEN
+        ALTER TABLE admin_users ADD CONSTRAINT chk_admin_users_role_dre_id CHECK (role <> 'dre' OR dre_id IS NOT NULL);
     END IF;
 END
 $$;
 
--- Bridge temporaria para codigo legado que ainda escreve `dre` textual.
 CREATE OR REPLACE FUNCTION sync_school_dre_relation()
-RETURNS trigger
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    canonical_id INTEGER;
-    canonical_name TEXT;
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE canonical_id INTEGER; canonical_name TEXT;
 BEGIN
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome
-            INTO STRICT canonical_id, canonical_name
-            FROM dres
-            WHERE id = NEW.dre_id;
-        EXCEPTION
-            WHEN NO_DATA_FOUND THEN
-                RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id
-                    USING ERRCODE = '23503';
+            SELECT id, nome INTO STRICT canonical_id, canonical_name FROM dres WHERE id = NEW.dre_id;
+        EXCEPTION WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id USING ERRCODE = '23503';
         END;
-
-        NEW.dre_id := canonical_id;
-        NEW.dre := canonical_name;
-        RETURN NEW;
+        NEW.dre_id := canonical_id; NEW.dre := LEFT(canonical_name, 100); RETURN NEW;
     END IF;
-
-    IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
-        NEW.dre_id := NULL;
-        NEW.dre := NULL;
-        RETURN NEW;
-    END IF;
-
+    IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN NEW.dre_id := NULL; NEW.dre := NULL; RETURN NEW; END IF;
     BEGIN
-        SELECT id, nome
-        INTO STRICT canonical_id, canonical_name
-        FROM dres
-        WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
+        SELECT id, nome INTO STRICT canonical_id, canonical_name FROM dres WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
-        WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre
-                USING ERRCODE = '23503';
-        WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre
-                USING ERRCODE = '23505';
+        WHEN NO_DATA_FOUND THEN RAISE EXCEPTION 'DRE not found for school: %', NEW.dre USING ERRCODE = '23503';
+        WHEN TOO_MANY_ROWS THEN RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre USING ERRCODE = '23505';
     END;
-
-    NEW.dre_id := canonical_id;
-    NEW.dre := canonical_name;
-    RETURN NEW;
+    NEW.dre_id := canonical_id; NEW.dre := LEFT(canonical_name, 100); RETURN NEW;
 END
 $$;
 
 CREATE OR REPLACE FUNCTION sync_admin_user_dre_relation()
-RETURNS trigger
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    canonical_id INTEGER;
-    canonical_name TEXT;
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE canonical_id INTEGER; canonical_name TEXT;
 BEGIN
-    IF NEW.role <> 'dre'
-       AND NEW.dre_id IS NULL
-       AND BTRIM(COALESCE(NEW.dre, '')) = '' THEN
-        NEW.dre := NULL;
-        RETURN NEW;
-    END IF;
-
+    IF NEW.role <> 'dre' AND NEW.dre_id IS NULL AND BTRIM(COALESCE(NEW.dre, '')) = '' THEN NEW.dre := NULL; RETURN NEW; END IF;
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome
-            INTO STRICT canonical_id, canonical_name
-            FROM dres
-            WHERE id = NEW.dre_id;
-        EXCEPTION
-            WHEN NO_DATA_FOUND THEN
-                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id
-                    USING ERRCODE = '23503';
+            SELECT id, nome INTO STRICT canonical_id, canonical_name FROM dres WHERE id = NEW.dre_id;
+        EXCEPTION WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id USING ERRCODE = '23503';
         END;
-
-        NEW.dre_id := canonical_id;
-        NEW.dre := canonical_name;
-        RETURN NEW;
+        NEW.dre_id := canonical_id; NEW.dre := LEFT(canonical_name, 128); RETURN NEW;
     END IF;
-
     IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
-        IF NEW.role = 'dre' THEN
-            RAISE EXCEPTION 'DRE user requires a canonical DRE'
-                USING ERRCODE = '23514';
-        END IF;
-        NEW.dre := NULL;
-        RETURN NEW;
+        IF NEW.role = 'dre' THEN RAISE EXCEPTION 'DRE user requires a canonical DRE' USING ERRCODE = '23514'; END IF;
+        NEW.dre := NULL; RETURN NEW;
     END IF;
-
     BEGIN
-        SELECT id, nome
-        INTO STRICT canonical_id, canonical_name
-        FROM dres
-        WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
+        SELECT id, nome INTO STRICT canonical_id, canonical_name FROM dres WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
-        WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre
-                USING ERRCODE = '23503';
-        WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre
-                USING ERRCODE = '23505';
+        WHEN NO_DATA_FOUND THEN RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre USING ERRCODE = '23503';
+        WHEN TOO_MANY_ROWS THEN RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre USING ERRCODE = '23505';
     END;
-
-    NEW.dre_id := canonical_id;
-    NEW.dre := canonical_name;
-    RETURN NEW;
+    NEW.dre_id := canonical_id; NEW.dre := LEFT(canonical_name, 128); RETURN NEW;
 END
 $$;
 
 DROP TRIGGER IF EXISTS trg_schools_sync_dre_relation ON schools;
-CREATE TRIGGER trg_schools_sync_dre_relation
-BEFORE INSERT OR UPDATE OF dre, dre_id ON schools
-FOR EACH ROW
-EXECUTE FUNCTION sync_school_dre_relation();
+CREATE TRIGGER trg_schools_sync_dre_relation BEFORE INSERT OR UPDATE OF dre, dre_id ON schools FOR EACH ROW EXECUTE FUNCTION sync_school_dre_relation();
 
 DROP TRIGGER IF EXISTS trg_admin_users_sync_dre_relation ON admin_users;
-CREATE TRIGGER trg_admin_users_sync_dre_relation
-BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users
-FOR EACH ROW
-EXECUTE FUNCTION sync_admin_user_dre_relation();
+CREATE TRIGGER trg_admin_users_sync_dre_relation BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users FOR EACH ROW EXECUTE FUNCTION sync_admin_user_dre_relation();
 
-COMMENT ON COLUMN schools.dre_id IS
-    'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';
-COMMENT ON COLUMN admin_users.dre_id IS
-    'Referencia canonica para dres.id. admin_users.dre e compatibilidade temporaria.';
+COMMENT ON COLUMN schools.dre_id IS 'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';
+COMMENT ON COLUMN admin_users.dre_id IS 'Referencia canonica para dres.id. admin_users.dre e compatibilidade temporaria.';

--- a/infra/migrations/0020_dre_canonical_relations.sql
+++ b/infra/migrations/0020_dre_canonical_relations.sql
@@ -17,7 +17,8 @@ ALTER TABLE admin_users
 DO $$
 BEGIN
     IF EXISTS (
-        SELECT 1 FROM dres
+        SELECT 1
+        FROM dres
         GROUP BY UPPER(BTRIM(nome))
         HAVING COUNT(*) > 1
     ) THEN
@@ -29,14 +30,17 @@ $$;
 DO $$
 BEGIN
     IF EXISTS (
-        SELECT 1 FROM schools s
+        SELECT 1
+        FROM schools s
         LEFT JOIN dres d ON d.id = s.dre_id
         WHERE s.dre_id IS NOT NULL AND d.id IS NULL
     ) THEN
         RAISE EXCEPTION 'dre canonical backfill aborted: schools contains invalid dre_id';
     END IF;
+
     IF EXISTS (
-        SELECT 1 FROM admin_users u
+        SELECT 1
+        FROM admin_users u
         LEFT JOIN dres d ON d.id = u.dre_id
         WHERE u.dre_id IS NOT NULL AND d.id IS NULL
     ) THEN
@@ -76,14 +80,19 @@ WHERE u.dre_id IS NULL
 DO $$
 BEGIN
     IF EXISTS (
-        SELECT 1 FROM schools
-        WHERE dre_id IS NULL AND BTRIM(COALESCE(dre, '')) <> ''
+        SELECT 1
+        FROM schools
+        WHERE dre_id IS NULL
+          AND BTRIM(COALESCE(dre, '')) <> ''
     ) THEN
         RAISE EXCEPTION 'dre canonical backfill aborted: unmapped school DRE values exist';
     END IF;
+
     IF EXISTS (
-        SELECT 1 FROM admin_users
-        WHERE role = 'dre' AND dre_id IS NULL
+        SELECT 1
+        FROM admin_users
+        WHERE role = 'dre'
+          AND dre_id IS NULL
     ) THEN
         RAISE EXCEPTION 'dre canonical backfill aborted: unmapped DRE users exist';
     END IF;
@@ -95,76 +104,159 @@ CREATE INDEX IF NOT EXISTS idx_admin_users_dre_id ON admin_users(dre_id);
 
 DO $$
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_schools_dre_id' AND conrelid = 'schools'::regclass) THEN
-        ALTER TABLE schools ADD CONSTRAINT fk_schools_dre_id FOREIGN KEY (dre_id) REFERENCES dres(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_schools_dre_id'
+          AND conrelid = 'schools'::regclass
+    ) THEN
+        ALTER TABLE schools
+            ADD CONSTRAINT fk_schools_dre_id
+            FOREIGN KEY (dre_id) REFERENCES dres(id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT;
     END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_admin_users_dre_id' AND conrelid = 'admin_users'::regclass) THEN
-        ALTER TABLE admin_users ADD CONSTRAINT fk_admin_users_dre_id FOREIGN KEY (dre_id) REFERENCES dres(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_admin_users_dre_id'
+          AND conrelid = 'admin_users'::regclass
+    ) THEN
+        ALTER TABLE admin_users
+            ADD CONSTRAINT fk_admin_users_dre_id
+            FOREIGN KEY (dre_id) REFERENCES dres(id)
+            ON UPDATE RESTRICT ON DELETE RESTRICT;
     END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_schools_dre_canonical' AND conrelid = 'schools'::regclass) THEN
-        ALTER TABLE schools ADD CONSTRAINT chk_schools_dre_canonical CHECK (dre_id IS NOT NULL OR dre IS NULL OR BTRIM(dre) = '');
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chk_schools_dre_canonical'
+          AND conrelid = 'schools'::regclass
+    ) THEN
+        ALTER TABLE schools
+            ADD CONSTRAINT chk_schools_dre_canonical
+            CHECK (dre_id IS NOT NULL OR dre IS NULL OR BTRIM(dre) = '');
     END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_admin_users_role_dre_id' AND conrelid = 'admin_users'::regclass) THEN
-        ALTER TABLE admin_users ADD CONSTRAINT chk_admin_users_role_dre_id CHECK (role <> 'dre' OR dre_id IS NOT NULL);
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chk_admin_users_role_dre_id'
+          AND conrelid = 'admin_users'::regclass
+    ) THEN
+        ALTER TABLE admin_users
+            ADD CONSTRAINT chk_admin_users_role_dre_id
+            CHECK (role <> 'dre' OR dre_id IS NOT NULL);
     END IF;
 END
 $$;
 
 CREATE OR REPLACE FUNCTION sync_school_dre_relation()
-RETURNS trigger LANGUAGE plpgsql AS $$
-DECLARE canonical_id INTEGER; canonical_name TEXT;
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    canonical_id INTEGER;
+    canonical_name TEXT;
 BEGIN
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome INTO STRICT canonical_id, canonical_name FROM dres WHERE id = NEW.dre_id;
-        EXCEPTION WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id USING ERRCODE = '23503';
+            SELECT id, nome INTO STRICT canonical_id, canonical_name
+            FROM dres WHERE id = NEW.dre_id;
+        EXCEPTION
+            WHEN NO_DATA_FOUND THEN
+                RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id
+                    USING ERRCODE = '23503';
         END;
-        NEW.dre_id := canonical_id; NEW.dre := LEFT(canonical_name, 100); RETURN NEW;
+        NEW.dre_id := canonical_id;
+        NEW.dre := LEFT(canonical_name, 100);
+        RETURN NEW;
     END IF;
-    IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN NEW.dre_id := NULL; NEW.dre := NULL; RETURN NEW; END IF;
+
+    IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
+        NEW.dre_id := NULL;
+        NEW.dre := NULL;
+        RETURN NEW;
+    END IF;
+
     BEGIN
-        SELECT id, nome INTO STRICT canonical_id, canonical_name FROM dres WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
+        SELECT id, nome INTO STRICT canonical_id, canonical_name
+        FROM dres
+        WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
-        WHEN NO_DATA_FOUND THEN RAISE EXCEPTION 'DRE not found for school: %', NEW.dre USING ERRCODE = '23503';
-        WHEN TOO_MANY_ROWS THEN RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre USING ERRCODE = '23505';
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre USING ERRCODE = '23503';
+        WHEN TOO_MANY_ROWS THEN
+            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre USING ERRCODE = '23505';
     END;
-    NEW.dre_id := canonical_id; NEW.dre := LEFT(canonical_name, 100); RETURN NEW;
+
+    NEW.dre_id := canonical_id;
+    NEW.dre := LEFT(canonical_name, 100);
+    RETURN NEW;
 END
 $$;
 
 CREATE OR REPLACE FUNCTION sync_admin_user_dre_relation()
-RETURNS trigger LANGUAGE plpgsql AS $$
-DECLARE canonical_id INTEGER; canonical_name TEXT;
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    canonical_id INTEGER;
+    canonical_name TEXT;
 BEGIN
-    IF NEW.role <> 'dre' AND NEW.dre_id IS NULL AND BTRIM(COALESCE(NEW.dre, '')) = '' THEN NEW.dre := NULL; RETURN NEW; END IF;
+    IF NEW.role <> 'dre'
+       AND NEW.dre_id IS NULL
+       AND BTRIM(COALESCE(NEW.dre, '')) = '' THEN
+        NEW.dre := NULL;
+        RETURN NEW;
+    END IF;
+
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome INTO STRICT canonical_id, canonical_name FROM dres WHERE id = NEW.dre_id;
-        EXCEPTION WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id USING ERRCODE = '23503';
+            SELECT id, nome INTO STRICT canonical_id, canonical_name
+            FROM dres WHERE id = NEW.dre_id;
+        EXCEPTION
+            WHEN NO_DATA_FOUND THEN
+                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id USING ERRCODE = '23503';
         END;
-        NEW.dre_id := canonical_id; NEW.dre := LEFT(canonical_name, 128); RETURN NEW;
+        NEW.dre_id := canonical_id;
+        NEW.dre := LEFT(canonical_name, 128);
+        RETURN NEW;
     END IF;
+
     IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
-        IF NEW.role = 'dre' THEN RAISE EXCEPTION 'DRE user requires a canonical DRE' USING ERRCODE = '23514'; END IF;
-        NEW.dre := NULL; RETURN NEW;
+        IF NEW.role = 'dre' THEN
+            RAISE EXCEPTION 'DRE user requires a canonical DRE' USING ERRCODE = '23514';
+        END IF;
+        NEW.dre := NULL;
+        RETURN NEW;
     END IF;
+
     BEGIN
-        SELECT id, nome INTO STRICT canonical_id, canonical_name FROM dres WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
+        SELECT id, nome INTO STRICT canonical_id, canonical_name
+        FROM dres
+        WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
-        WHEN NO_DATA_FOUND THEN RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre USING ERRCODE = '23503';
-        WHEN TOO_MANY_ROWS THEN RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre USING ERRCODE = '23505';
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre USING ERRCODE = '23503';
+        WHEN TOO_MANY_ROWS THEN
+            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre USING ERRCODE = '23505';
     END;
-    NEW.dre_id := canonical_id; NEW.dre := LEFT(canonical_name, 128); RETURN NEW;
+
+    NEW.dre_id := canonical_id;
+    NEW.dre := LEFT(canonical_name, 128);
+    RETURN NEW;
 END
 $$;
 
 DROP TRIGGER IF EXISTS trg_schools_sync_dre_relation ON schools;
-CREATE TRIGGER trg_schools_sync_dre_relation BEFORE INSERT OR UPDATE OF dre, dre_id ON schools FOR EACH ROW EXECUTE FUNCTION sync_school_dre_relation();
+CREATE TRIGGER trg_schools_sync_dre_relation
+BEFORE INSERT OR UPDATE OF dre, dre_id ON schools
+FOR EACH ROW EXECUTE FUNCTION sync_school_dre_relation();
 
 DROP TRIGGER IF EXISTS trg_admin_users_sync_dre_relation ON admin_users;
-CREATE TRIGGER trg_admin_users_sync_dre_relation BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users FOR EACH ROW EXECUTE FUNCTION sync_admin_user_dre_relation();
+CREATE TRIGGER trg_admin_users_sync_dre_relation
+BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users
+FOR EACH ROW EXECUTE FUNCTION sync_admin_user_dre_relation();
 
-COMMENT ON COLUMN schools.dre_id IS 'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';
-COMMENT ON COLUMN admin_users.dre_id IS 'Referencia canonica para dres.id. admin_users.dre e compatibilidade temporaria.';
+COMMENT ON COLUMN schools.dre_id IS
+    'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';
+COMMENT ON COLUMN admin_users.dre_id IS
+    'Referencia canonica para dres.id. admin_users.dre e compatibilidade temporaria.';

--- a/infra/migrations/0020_dre_canonical_relations.sql
+++ b/infra/migrations/0020_dre_canonical_relations.sql
@@ -3,10 +3,10 @@
 -- As colunas textuais `dre` permanecem temporariamente por compatibilidade, mas deixam
 -- de ser a fonte de verdade. Triggers de compatibilidade mantem writes legados
 -- sincronizados ate que os handlers sejam migrados integralmente para `dre_id`.
---
--- IMPORTANTE: não alteramos o tipo das colunas legadas aqui. `schools.dre` é usada por
--- views históricas e ALTER TYPE pode falhar em bancos já migrados. Como `dre_id` é a
--- fonte canônica, o texto legado é espelhado respeitando os limites atuais.
+
+-- As colunas legadas permanecem com seus tipos historicos porque `schools.dre` e
+-- referenciada por views e ALTER TYPE pode falhar em bancos ja existentes. Como
+-- `dre_id` e a fonte de verdade, o texto legado e espelhado respeitando seus limites.
 
 ALTER TABLE schools
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;
@@ -14,6 +14,7 @@ ALTER TABLE schools
 ALTER TABLE admin_users
     ADD COLUMN IF NOT EXISTS dre_id INTEGER;
 
+-- Nunca escolher uma DRE arbitrariamente quando nomes diferem apenas por caixa/espacos.
 DO $$
 BEGIN
     IF EXISTS (
@@ -27,6 +28,8 @@ BEGIN
 END
 $$;
 
+-- Se uma execucao anterior/parcial ja deixou IDs preenchidos, eles precisam apontar
+-- para uma entidade mestre real antes de qualquer reconciliacao textual.
 DO $$
 BEGIN
     IF EXISTS (
@@ -49,6 +52,8 @@ BEGIN
 END
 $$;
 
+-- Quando dre_id ja existe, ele e a fonte de verdade. Isso torna a migration segura
+-- para reexecucao inclusive apos rename da DRE: o texto legado acompanha o ID.
 UPDATE schools s
 SET dre = LEFT(d.nome, 100)
 FROM dres d
@@ -61,6 +66,8 @@ FROM dres d
 WHERE u.dre_id = d.id
   AND u.dre IS DISTINCT FROM LEFT(d.nome, 128);
 
+-- Backfill somente de registros ainda sem ID, usando comparacao tolerante a caixa e
+-- espacos. A verificacao de ambiguidade acima garante correspondencia deterministica.
 UPDATE schools s
 SET dre_id = d.id,
     dre = LEFT(d.nome, 100)
@@ -77,6 +84,7 @@ WHERE u.dre_id IS NULL
   AND BTRIM(COALESCE(u.dre, '')) <> ''
   AND UPPER(BTRIM(u.dre)) = UPPER(BTRIM(d.nome));
 
+-- Dados legados nao reconciliaveis devem interromper a migration de forma explicita.
 DO $$
 BEGIN
     IF EXISTS (
@@ -105,7 +113,8 @@ CREATE INDEX IF NOT EXISTS idx_admin_users_dre_id ON admin_users(dre_id);
 DO $$
 BEGIN
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
+        SELECT 1
+        FROM pg_constraint
         WHERE conname = 'fk_schools_dre_id'
           AND conrelid = 'schools'::regclass
     ) THEN
@@ -116,7 +125,8 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
+        SELECT 1
+        FROM pg_constraint
         WHERE conname = 'fk_admin_users_dre_id'
           AND conrelid = 'admin_users'::regclass
     ) THEN
@@ -127,7 +137,8 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
+        SELECT 1
+        FROM pg_constraint
         WHERE conname = 'chk_schools_dre_canonical'
           AND conrelid = 'schools'::regclass
     ) THEN
@@ -137,7 +148,8 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
+        SELECT 1
+        FROM pg_constraint
         WHERE conname = 'chk_admin_users_role_dre_id'
           AND conrelid = 'admin_users'::regclass
     ) THEN
@@ -148,6 +160,7 @@ BEGIN
 END
 $$;
 
+-- Bridge temporaria para codigo legado que ainda escreve `dre` textual.
 CREATE OR REPLACE FUNCTION sync_school_dre_relation()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -158,13 +171,16 @@ DECLARE
 BEGIN
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome INTO STRICT canonical_id, canonical_name
-            FROM dres WHERE id = NEW.dre_id;
+            SELECT id, nome
+            INTO STRICT canonical_id, canonical_name
+            FROM dres
+            WHERE id = NEW.dre_id;
         EXCEPTION
             WHEN NO_DATA_FOUND THEN
                 RAISE EXCEPTION 'invalid dre_id % for school', NEW.dre_id
                     USING ERRCODE = '23503';
         END;
+
         NEW.dre_id := canonical_id;
         NEW.dre := LEFT(canonical_name, 100);
         RETURN NEW;
@@ -177,14 +193,17 @@ BEGIN
     END IF;
 
     BEGIN
-        SELECT id, nome INTO STRICT canonical_id, canonical_name
+        SELECT id, nome
+        INTO STRICT canonical_id, canonical_name
         FROM dres
         WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
         WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre USING ERRCODE = '23503';
+            RAISE EXCEPTION 'DRE not found for school: %', NEW.dre
+                USING ERRCODE = '23503';
         WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre USING ERRCODE = '23505';
+            RAISE EXCEPTION 'ambiguous DRE for school: %', NEW.dre
+                USING ERRCODE = '23505';
     END;
 
     NEW.dre_id := canonical_id;
@@ -210,12 +229,16 @@ BEGIN
 
     IF NEW.dre_id IS NOT NULL THEN
         BEGIN
-            SELECT id, nome INTO STRICT canonical_id, canonical_name
-            FROM dres WHERE id = NEW.dre_id;
+            SELECT id, nome
+            INTO STRICT canonical_id, canonical_name
+            FROM dres
+            WHERE id = NEW.dre_id;
         EXCEPTION
             WHEN NO_DATA_FOUND THEN
-                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id USING ERRCODE = '23503';
+                RAISE EXCEPTION 'invalid dre_id % for admin user', NEW.dre_id
+                    USING ERRCODE = '23503';
         END;
+
         NEW.dre_id := canonical_id;
         NEW.dre := LEFT(canonical_name, 128);
         RETURN NEW;
@@ -223,21 +246,25 @@ BEGIN
 
     IF BTRIM(COALESCE(NEW.dre, '')) = '' THEN
         IF NEW.role = 'dre' THEN
-            RAISE EXCEPTION 'DRE user requires a canonical DRE' USING ERRCODE = '23514';
+            RAISE EXCEPTION 'DRE user requires a canonical DRE'
+                USING ERRCODE = '23514';
         END IF;
         NEW.dre := NULL;
         RETURN NEW;
     END IF;
 
     BEGIN
-        SELECT id, nome INTO STRICT canonical_id, canonical_name
+        SELECT id, nome
+        INTO STRICT canonical_id, canonical_name
         FROM dres
         WHERE UPPER(BTRIM(nome)) = UPPER(BTRIM(NEW.dre));
     EXCEPTION
         WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre USING ERRCODE = '23503';
+            RAISE EXCEPTION 'DRE not found for admin user: %', NEW.dre
+                USING ERRCODE = '23503';
         WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre USING ERRCODE = '23505';
+            RAISE EXCEPTION 'ambiguous DRE for admin user: %', NEW.dre
+                USING ERRCODE = '23505';
     END;
 
     NEW.dre_id := canonical_id;
@@ -249,12 +276,14 @@ $$;
 DROP TRIGGER IF EXISTS trg_schools_sync_dre_relation ON schools;
 CREATE TRIGGER trg_schools_sync_dre_relation
 BEFORE INSERT OR UPDATE OF dre, dre_id ON schools
-FOR EACH ROW EXECUTE FUNCTION sync_school_dre_relation();
+FOR EACH ROW
+EXECUTE FUNCTION sync_school_dre_relation();
 
 DROP TRIGGER IF EXISTS trg_admin_users_sync_dre_relation ON admin_users;
 CREATE TRIGGER trg_admin_users_sync_dre_relation
 BEFORE INSERT OR UPDATE OF dre, dre_id, role ON admin_users
-FOR EACH ROW EXECUTE FUNCTION sync_admin_user_dre_relation();
+FOR EACH ROW
+EXECUTE FUNCTION sync_admin_user_dre_relation();
 
 COMMENT ON COLUMN schools.dre_id IS
     'Referencia canonica para dres.id. schools.dre e compatibilidade temporaria.';

--- a/infra/migrations/0021_dre_normalized_uniqueness.sql
+++ b/infra/migrations/0021_dre_normalized_uniqueness.sql
@@ -43,6 +43,8 @@ BEGIN
 END
 $$;
 
+-- Normaliza apenas espaços externos. Essa é a mesma semântica usada hoje pelos
+-- models/handlers (`strings.TrimSpace` + LOWER/UPPER no banco).
 UPDATE admin_users
 SET username = BTRIM(username),
     updated_at = NOW()
@@ -53,6 +55,9 @@ SET nome = BTRIM(nome),
     updated_at = NOW()
 WHERE nome IS DISTINCT FROM BTRIM(nome);
 
+-- Como `dre_id` é a fonte de verdade, reespelha a camada textual legada após a
+-- normalização do nome canônico. Os limites preservam os tipos históricos sem
+-- obrigar ALTER TYPE em colunas usadas por views.
 UPDATE schools s
 SET dre = LEFT(d.nome, 100)
 FROM dres d

--- a/infra/migrations/0021_dre_normalized_uniqueness.sql
+++ b/infra/migrations/0021_dre_normalized_uniqueness.sql
@@ -1,0 +1,75 @@
+-- 0021_dre_normalized_uniqueness.sql
+-- Endurece a identidade administrativa para que consultas case-insensitive e
+-- constraints usem a mesma regra: LOWER(BTRIM(valor)).
+-- A migration falha antes de modificar dados se houver colisões legadas.
+
+BEGIN;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM admin_users
+        WHERE BTRIM(username) = ''
+    ) THEN
+        RAISE EXCEPTION 'admin_users normalized username migration aborted: blank usernames exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM admin_users
+        GROUP BY LOWER(BTRIM(username))
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'admin_users normalized username migration aborted: normalized username collisions exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM dres
+        WHERE BTRIM(nome) = ''
+    ) THEN
+        RAISE EXCEPTION 'dres normalized name migration aborted: blank DRE names exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM dres
+        GROUP BY LOWER(BTRIM(nome))
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'dres normalized name migration aborted: normalized DRE name collisions exist';
+    END IF;
+END
+$$;
+
+UPDATE admin_users
+SET username = BTRIM(username),
+    updated_at = NOW()
+WHERE username IS DISTINCT FROM BTRIM(username);
+
+UPDATE dres
+SET nome = BTRIM(nome),
+    updated_at = NOW()
+WHERE nome IS DISTINCT FROM BTRIM(nome);
+
+UPDATE schools s
+SET dre = LEFT(d.nome, 100)
+FROM dres d
+WHERE s.dre_id = d.id
+  AND s.dre IS DISTINCT FROM LEFT(d.nome, 100);
+
+UPDATE admin_users u
+SET dre = LEFT(d.nome, 128),
+    updated_at = NOW()
+FROM dres d
+WHERE u.dre_id = d.id
+  AND u.dre IS DISTINCT FROM LEFT(d.nome, 128);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_admin_users_username_normalized
+    ON admin_users (LOWER(BTRIM(username)));
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_dres_nome_normalized
+    ON dres (LOWER(BTRIM(nome)));
+
+COMMIT;


### PR DESCRIPTION
Closes #208
Parent epic: #203

## O que muda
- adiciona unicidade case-insensitive/trim-aware para `admin_users.username` e `dres.nome` via `LOWER(BTRIM(...))`;
- detecta colisões legadas antes de criar os índices, sem escolher registro arbitrariamente;
- normaliza espaços externos de dados legados de forma transacional e idempotente;
- torna `0018`–`0021` migrations administrativas críticas: falha ou ausência interrompe o startup;
- corrige a `0020` para não executar `ALTER TYPE` em `schools.dre`, evitando quebra por views dependentes, mantendo `dre_id` como fonte canônica;
- mantém as árvores `api/cmd/api/migrations` e `infra/migrations` espelhadas;
- adiciona testes PostgreSQL para banco limpo, reexecução idempotente, colisão de username e ambiguidade de DRE;
- documenta diagnóstico, recuperação e rollback operacional.

## Validação esperada
- `go vet ./...`
- `go test ./...`
- stress/race existentes
- PostgreSQL 16 do API CI

A alteração não modifica o workflow da #210 (Ed); o teste novo usa o caminho real `applyMigrations` dentro da suíte existente.