### PR TITLE
fix(admin): remover referências hardcoded a 'IDEB 2023' em labels e m…

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -274,7 +274,7 @@ const NAV_INDICATORS: NavItem[] = [
   {
     id: "alunos", label: "Perfil dos Alunos e Resultados", Icon: Activity,
     subItems: [
-      { label: "Resumo IDEB 2023", anchor: "sec-alunos-resumo" },
+      { label: "Resumo IDEB", anchor: "sec-alunos-resumo" },
       { label: "Resultado por Etapa", anchor: "sec-alunos-etapa" },
       { label: "Distribuição por Faixas", anchor: "sec-alunos-faixas" },
       { label: "Ranking por Escola", anchor: "sec-alunos-ranking" },

--- a/web/src/components/admin/PresentationMode.tsx
+++ b/web/src/components/admin/PresentationMode.tsx
@@ -200,7 +200,7 @@ const SLIDES: PresentationSlide[] = [
     contentId: "servicos-governanca-aviso",
   },
 
-  ...createSlides("alunos", "Perfil dos Alunos e Resultados", "Resumo IDEB 2023", [
+  ...createSlides("alunos", "Perfil dos Alunos e Resultados", "Resumo IDEB", [
     ["alunos-resumo-cards", "Indicadores gerais"],
   ]),
   ...createSlides("alunos", "Perfil dos Alunos e Resultados", "Resultado por Etapa", [

--- a/web/src/components/admin/shared/types.ts
+++ b/web/src/components/admin/shared/types.ts
@@ -553,7 +553,7 @@ export interface FiltrosOpcoes {
   escolas: FiltrosEscolaItem[];
 }
 
-// ── Perfil dos Alunos e Resultados — IDEB 2023 (IDEB-05) ────────────────────
+// ── Perfil dos Alunos e Resultados — IDEB (IDEB-05) ─────────────────────────
 // Payload de GET /v1/admin/analytics/perfil-alunos-resultados/ideb.
 // Espelha exatamente o contrato definido em
 // api/cmd/api/analytics_perfil_alunos_ideb.go. IDEB ausente é `null`


### PR DESCRIPTION
O que foi feito

Removidas 3 referências hardcoded a "2023" no frontend que impediam que o label "Resumo IDEB" acompanhasse o ano dinamicamente:
- web/src/components/admin/shared/types.ts:556 — comentário de seção atualizado
- web/src/components/admin/PresentationMode.tsx:203 — label do modo apresentação
- web/src/app/admin/page.tsx:277 — sub-aba no menu lateral


Por que as tasks backend e frontend já estavam praticamente resolvidas:

Backend (#224): O endpoint GET /v1/admin/analytics/perfil-alunos-resultados/ideb já aceita ?ano=2025 e filtra todas as queries por ir.ano = $1. Os metadados são gerados dinamicamente. O MarshalJSON normaliza textos que continham "2023". Existem 17 testes unitários cobrindo parsing, validação e escopo DRE. As migrations 0017, 0022 e 0023 já suportam a estrutura multi-anual.


Frontend (#225): O componente AbaPerfilAlunos.tsx já era 100% ano-agnóstico — usa anoRef = resumo.ano_referencia em todos os textos. O filtro global já envia ?ano= ao endpoint. O cache usa a URL completa como chave, evitando contaminação entre anos. Cards, tabelas, gráficos e rankings já consumiam dados dinâmicos.


Validação:
- npm run lint — 0 erros
- npm run build — sucesso
- Dados IDEB 2025 confirmados no banco (1.160 registros)
- Teste manual: seleção 2023/2025, título dinâmico, menu lateral sem ano fixo, metadados dinâmicos