### PR TITLE
chore(ci): preparar proteção obrigatória da develop (#236)

### DIFF
--- a/docs/ci-dre-critical-gates.md
+++ b/docs/ci-dre-critical-gates.md
@@ -6,7 +6,7 @@ Todos rodam contra PostgreSQL 16 real efêmero e não dependem de estado externo
 ## API CI (`.github/workflows/api-ci.yml`)
 
 1. **DRE critical migrations gate**
-   - Aplica a cadeia administrativa crítica em ordem (`0014` → `0018` → `0019` → `0020` → `0021`) com `ON_ERROR_STOP=1`.
+   - Aplica a cadeia administrativa crítica em ordem (`0014` → `0018` → `0019` → `0020` → `0021` → `0024`) com `ON_ERROR_STOP=1`.
    - Roda `applyMigrations` (loader real de runtime) e os testes de fail-closed/idempotência em schemas isolados.
    - Falha de migration administrativa crítica — inclusive futura — torna o CI vermelho.
 
@@ -23,20 +23,27 @@ Todos rodam contra PostgreSQL 16 real efêmero e não dependem de estado externo
 
 4. **Web build & lint**
    - `npm ci` (lockfile) + `npm run lint` + `npm run build`.
-   - Roda em todo pull request para `develop`, para que o contexto requerido
-     exista também quando a alteração não tocar `web/**`.
+   - Roda em todo pull request para `develop`, para que o contexto requerido exista também quando a alteração não tocar `web/**`.
 
 ## Proteção obrigatória da `develop`
 
-No estado verificado em 2026-09-04, `develop` não está protegida e a conta que
-preparou esta alteração tem permissão de *push*, mas não de administração do
-repositório; por isso não é possível aplicar esta configuração pela API.
-O owner deve criar uma regra de proteção/ruleset para `develop` antes de encerrar
-#203 com as opções: pull request obrigatório, branch atualizada antes do merge,
-checks obrigatórios e bloqueio de merge quando falharem, sem force-push e sem
-deleção da branch. Os contextos exatos a selecionar são:
+Auditoria refeita em **2026-09-08**:
 
-- `DRE critical migrations gate`
-- `DRE lifecycle & auth gate`
-- `API integration gate`
-- `Web build & lint`
+- o repositório possui **zero repository rulesets** ativos;
+- o endpoint de branch protection exige permissão administrativa e a integração GitHub usada na auditoria não possui essa permissão (`403 Resource not accessible by integration`);
+- portanto a proteção precisa ser aplicada por um owner/admin do repositório antes de considerar #236 concluída.
+
+A regra de proteção/ruleset da `develop` deve exigir:
+
+- pull request obrigatório para alteração da branch;
+- branch atualizada antes do merge, quando aplicável;
+- bloqueio de merge se qualquer check obrigatório falhar;
+- bloqueio de force-push;
+- bloqueio de deleção da branch;
+- os seguintes contextos obrigatórios:
+  - `DRE critical migrations gate`
+  - `DRE lifecycle & auth gate`
+  - `API integration gate`
+  - `Web build & lint`
+
+Após aplicar a regra, validar em um PR para `develop` que os quatro checks aparecem como obrigatórios e que um check vermelho impede o merge.


### PR DESCRIPTION
## Contexto
Entrega da #236 (LUCAS-11), com auditoria atualizada dos gates DRE e correção da documentação para refletir a migration `0024_admin_users_auth_version.sql`, que já faz parte do workflow real.

## Mudanças
- documenta a cadeia crítica real `0014 → 0018 → 0019 → 0020 → 0021 → 0024`;
- registra auditoria de 08/09/2026: zero repository rulesets ativos;
- registra que branch protection exige permissão administrativa não exposta pela integração atual;
- fixa os quatro contextos que devem ser required checks na `develop`;
- define critérios de validação após o owner/admin aplicar o ruleset.

## Validação deste PR
Este PR é propositalmente direcionado à `develop` para disparar e validar os quatro gates que deverão ser obrigatórios:
- DRE critical migrations gate
- DRE lifecycle & auth gate
- API integration gate
- Web build & lint

## Importante
A issue #236 **não deve ser fechada apenas pelo merge deste PR**. O aceite final exige que um owner/admin aplique efetivamente branch protection/ruleset na `develop` e que a proteção seja revalidada depois.