### PR TITLE
fix(auth): revogação definitiva de sessão DRE (#241)

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -20,6 +20,13 @@ concurrency:
 # Nenhum check depende de estado externo; todos usam PostgreSQL 16 efêmero.
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Gate 1 — Migrations administrativas críticas.
+  # Exercita o caminho real de runtime: o loader aplica o fs embed em ordem
+  # (applyMigrations) e os testes de fail-closed/idempotência rodam em schemas
+  # isolados determinísticos. O passo psql com ON_ERROR_STOP converte qualquer
+  # falha de migration crítica (inclusive futuras) em CI vermelho.
+  # ---------------------------------------------------------------------------
   migration-gate:
     name: DRE critical migrations gate
     runs-on: ubuntu-latest
@@ -64,6 +71,9 @@ jobs:
           PGPASSWORD: postgres
         run: |
           set -euo pipefail
+          # Base analítica + cadeia administrativa crítica na MESMA ordem do runtime.
+          # ON_ERROR_STOP=1 faz qualquer falha de migration (inclusive futura)
+          # reprovar o workflow imediatamente.
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/init.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0014_reg_integracao.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0018_create_admin_users.sql
@@ -80,6 +90,11 @@ jobs:
           '^(TestCriticalAdministrativeMigrationsCleanAndIdempotent|TestCriticalMigrationFailsClosedOnLegacyUsernameCollision|TestCriticalMigrationFailsClosedOnAmbiguousDRENames|TestDRECanonicalRelationsMigration.*|TestDRESessionRevocationMigrationIsCritical)$'
           -count=1
 
+  # ---------------------------------------------------------------------------
+  # Gate 2 — Lifecycle DRE + autenticação (check identificável; cobre #209/#241).
+  # Os testes criam schemas isolados, portanto o job só exige PostgreSQL 16
+  # real e é determinístico (nenhuma dependência de schema/estado externo).
+  # ---------------------------------------------------------------------------
   dre-lifecycle-auth:
     name: DRE lifecycle & auth gate
     runs-on: ubuntu-latest
@@ -126,6 +141,11 @@ jobs:
           '^(TestDRELifecycle|TestDRECreateWithAtivaFalsePersists|TestInactiveDRE|TestDREInactiveUserCannotAuthenticate|TestRenamePreserves|TestAdminMeReflects|TestDuplicate.*ByCaseIsRejected|TestDREEntityAbsentInDresNotValidatedBySchoolsText|TestDREUserDeactivation|TestDREDeactivationViaUpdate|TestRuntimeDRE|TestRuntimeEnvAdmin|TestRuntimeLegacyDRE|TestRuntimeTransitionSchema)'
           -count=1
 
+  # ---------------------------------------------------------------------------
+  # Gate 3 — Suíte completa de integração (vet + go test + stress/race).
+  # Schema de integração compartilhado via init.sql + cadeia administrativa
+  # crítica em ordem (0014/0018/0019/0020/0021/0024/0025) para espelhar o runtime.
+  # ---------------------------------------------------------------------------
   integration:
     name: API integration gate
     runs-on: ubuntu-latest
@@ -170,6 +190,12 @@ jobs:
           PGPASSWORD: postgres
         run: |
           set -euo pipefail
+          # infra/init.sql contém o schema/base analítica. A cadeia administrativa
+          # é aplicada integralmente no banco compartilhado da suíte para que
+          # go test, stress e race exercitem exatamente o schema pós-0025.
+          # Fixtures de integração devem criar dres e relacionar schools por
+          # dre_id; TestDREIntegrationSchemaIsCanonicalPost0021 falha se este
+          # passo parar em 0019.
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/init.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0014_reg_integracao.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0018_create_admin_users.sql

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -13,20 +13,13 @@ concurrency:
   cancel-in-progress: true
 
 # Checks obrigatórios antes do merge (documentação curta do PR):
-# - DRE critical migrations gate: migrations administrativas 0018-0021 em ordem,
+# - DRE critical migrations gate: migrations administrativas 0018-0025 em ordem,
 #   aplicadas contra PostgreSQL 16 real. Falha de migration crítica => CI vermelho.
-# - DRE lifecycle & auth gate: contratos de lifecycle DRE e autenticação/#209.
+# - DRE lifecycle & auth gate: contratos de lifecycle DRE e autenticação/#209/#241.
 # - API integration gate: go vet, go test ./..., stress/race atuais + build web lint.
 # Nenhum check depende de estado externo; todos usam PostgreSQL 16 efêmero.
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Gate 1 — Migrations administrativas críticas.
-  # Exercita o caminho real de runtime: o loader aplica o fs embed em ordem
-  # (applyMigrations) e os testes de fail-closed/idempotência rodam em schemas
-  # isolados determinísticos. O passo psql com ON_ERROR_STOP converte qualquer
-  # falha de migration crítica (inclusive futuras) em CI vermelho.
-  # ---------------------------------------------------------------------------
   migration-gate:
     name: DRE critical migrations gate
     runs-on: ubuntu-latest
@@ -71,9 +64,6 @@ jobs:
           PGPASSWORD: postgres
         run: |
           set -euo pipefail
-          # Base analítica + cadeia administrativa crítica na MESMA ordem do runtime.
-          # ON_ERROR_STOP=1 faz qualquer falha de migration (inclusive futura)
-          # reprovar o workflow imediatamente.
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/init.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0014_reg_integracao.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0018_create_admin_users.sql
@@ -81,19 +71,15 @@ jobs:
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0020_dre_canonical_relations.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0021_dre_normalized_uniqueness.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0024_admin_users_auth_version.sql
+          psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0025_dre_session_revocation.sql
 
       - name: Migration gate tests (applyMigrations ordem/idempotência + fail-closed)
         working-directory: api
         run: >-
           go test ./cmd/api -run
-          '^(TestCriticalAdministrativeMigrationsCleanAndIdempotent|TestCriticalMigrationFailsClosedOnLegacyUsernameCollision|TestCriticalMigrationFailsClosedOnAmbiguousDRENames|TestDRECanonicalRelationsMigration.*)$'
+          '^(TestCriticalAdministrativeMigrationsCleanAndIdempotent|TestCriticalMigrationFailsClosedOnLegacyUsernameCollision|TestCriticalMigrationFailsClosedOnAmbiguousDRENames|TestDRECanonicalRelationsMigration.*|TestDRESessionRevocationMigrationIsCritical)$'
           -count=1
 
-  # ---------------------------------------------------------------------------
-  # Gate 2 — Lifecycle DRE + autenticação (check identificável; cobre #209).
-  # Os testes criam schemas isolados, portanto o job só exige PostgreSQL 16
-  # real e é determinístico (nenhuma dependência de schema/estado externo).
-  # ---------------------------------------------------------------------------
   dre-lifecycle-auth:
     name: DRE lifecycle & auth gate
     runs-on: ubuntu-latest
@@ -133,18 +119,13 @@ jobs:
         working-directory: api
         run: go mod download
 
-      - name: DRE lifecycle & auth contracts (#209)
+      - name: DRE lifecycle & auth contracts (#209/#241)
         working-directory: api
         run: >-
           go test ./cmd/api -run
-          '^(TestDRELifecycle|TestDRECreateWithAtivaFalsePersists|TestInactiveDRE|TestDREInactiveUserCannotAuthenticate|TestRenamePreserves|TestAdminMeReflects|TestDuplicate.*ByCaseIsRejected|TestDREEntityAbsentInDresNotValidatedBySchoolsText|TestRuntimeDRE|TestRuntimeEnvAdmin|TestRuntimeLegacyDRE|TestRuntimeTransitionSchema)'
+          '^(TestDRELifecycle|TestDRECreateWithAtivaFalsePersists|TestInactiveDRE|TestDREInactiveUserCannotAuthenticate|TestRenamePreserves|TestAdminMeReflects|TestDuplicate.*ByCaseIsRejected|TestDREEntityAbsentInDresNotValidatedBySchoolsText|TestDREUserDeactivation|TestDREDeactivationViaUpdate|TestRuntimeDRE|TestRuntimeEnvAdmin|TestRuntimeLegacyDRE|TestRuntimeTransitionSchema)'
           -count=1
 
-  # ---------------------------------------------------------------------------
-  # Gate 3 — Suíte completa de integração (vet + go test + stress/race).
-  # Schema de integração compartilhado via init.sql + cadeia administrativa
-  # crítica em ordem (0014/0018/0019/0020/0021) para espelhar o runtime.
-  # ---------------------------------------------------------------------------
   integration:
     name: API integration gate
     runs-on: ubuntu-latest
@@ -189,12 +170,6 @@ jobs:
           PGPASSWORD: postgres
         run: |
           set -euo pipefail
-          # infra/init.sql contém o schema/base analítica. A cadeia administrativa
-          # é aplicada integralmente no banco compartilhado da suíte para que
-          # go test, stress e race exercitem exatamente o schema pós-0021.
-          # Fixtures de integração devem criar dres e relacionar schools por
-          # dre_id; TestDREIntegrationSchemaIsCanonicalPost0021 falha se este
-          # passo parar em 0019.
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/init.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0014_reg_integracao.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0018_create_admin_users.sql
@@ -202,6 +177,7 @@ jobs:
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0020_dre_canonical_relations.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0021_dre_normalized_uniqueness.sql
           psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0024_admin_users_auth_version.sql
+          psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 -f api/cmd/api/migrations/0025_dre_session_revocation.sql
 
       - name: Vet
         working-directory: api

--- a/api/cmd/api/dre_runtime_auth_revocation_test.go
+++ b/api/cmd/api/dre_runtime_auth_revocation_test.go
@@ -32,7 +32,14 @@ func setupRuntimeAuthTest(t *testing.T) (*application, http.Handler, models.Mode
 	t.Setenv("TRUSTED_PROXY_COUNT", "0")
 	resetRuntimeLoginLimiter()
 
-	_, m := setupDRELifecycleTestDB(t, true)
+	db, m := setupDRELifecycleTestDB(t, true)
+	revocationMigration, err := migrationsFS.ReadFile("migrations/0025_dre_session_revocation.sql")
+	if err != nil {
+		t.Fatalf("read DRE session revocation migration: %v", err)
+	}
+	if _, err := db.Exec(string(revocationMigration)); err != nil {
+		t.Fatalf("apply DRE session revocation migration: %v", err)
+	}
 	app := &application{models: m}
 	return app, app.routes(), m
 }
@@ -139,8 +146,6 @@ func TestRuntimeDRETokenStableIdentityAndMeTracksCurrentDatabaseState(t *testing
 		t.Fatalf("rename username fixture: %v", err)
 	}
 
-	// O JWT continua contendo snapshots antigos. O resultado correto só pode vir
-	// de uma resolução runtime por identidade estável.
 	staleClaims, err := parseRuntimeAdminToken(token)
 	if err != nil {
 		t.Fatalf("parse stale token: %v", err)
@@ -165,36 +170,41 @@ func TestRuntimeDREImmediateRevocationForUserAndDREStatus(t *testing.T) {
 	password := "runtime-status-password"
 	dre, user := createRuntimeDREUser(t, m, "DRE STATUS", "status.user", password)
 
-	_, token := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.2:5002")
-	if token == "" {
+	_, tokenA := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.2:5002")
+	if tokenA == "" {
 		t.Fatalf("expected initial token")
 	}
-	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
+	if rr := runtimeMeRequest(handler, tokenA); rr.Code != http.StatusOK {
 		t.Fatalf("baseline request failed: %d %s", rr.Code, rr.Body.String())
 	}
 
 	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, false); err != nil {
 		t.Fatalf("deactivate user: %v", err)
 	}
-	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
+	if rr := runtimeMeRequest(handler, tokenA); rr.Code != http.StatusUnauthorized {
 		t.Fatalf("same token survived user deactivation: status=%d body=%s", rr.Code, rr.Body.String())
 	}
 
 	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, true); err != nil {
 		t.Fatalf("reactivate user: %v", err)
 	}
-	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
-		t.Fatalf("same token did not recover after user reactivation: %d %s", rr.Code, rr.Body.String())
+	if rr := runtimeMeRequest(handler, tokenA); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("old token resurrected after user reactivation: %d %s", rr.Code, rr.Body.String())
+	}
+
+	loginB, tokenB := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.3:5003")
+	if loginB.Code != http.StatusOK || tokenB == "" {
+		t.Fatalf("reactivated user did not accept new login: status=%d body=%s", loginB.Code, loginB.Body.String())
 	}
 
 	if err := m.DREs.SetActive(ctx, dre.ID, false); err != nil {
 		t.Fatalf("deactivate DRE: %v", err)
 	}
-	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
+	if rr := runtimeMeRequest(handler, tokenB); rr.Code != http.StatusUnauthorized {
 		t.Fatalf("same token survived DRE deactivation: status=%d body=%s", rr.Code, rr.Body.String())
 	}
 
-	loginInactive, inactiveToken := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.3:5003")
+	loginInactive, inactiveToken := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.4:5004")
 	if loginInactive.Code != http.StatusUnauthorized || inactiveToken != "" {
 		t.Fatalf("inactive DRE accepted login: status=%d body=%s", loginInactive.Code, loginInactive.Body.String())
 	}
@@ -202,12 +212,15 @@ func TestRuntimeDREImmediateRevocationForUserAndDREStatus(t *testing.T) {
 	if err := m.DREs.SetActive(ctx, dre.ID, true); err != nil {
 		t.Fatalf("reactivate DRE: %v", err)
 	}
-	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
-		t.Fatalf("same old token did not recover after DRE reactivation: %d %s", rr.Code, rr.Body.String())
+	if rr := runtimeMeRequest(handler, tokenB); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("old token resurrected after DRE reactivation: %d %s", rr.Code, rr.Body.String())
 	}
-	loginActive, newToken := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.4:5004")
-	if loginActive.Code != http.StatusOK || newToken == "" {
-		t.Fatalf("reactivated DRE did not accept login: status=%d body=%s", loginActive.Code, loginActive.Body.String())
+	loginC, tokenC := runtimeLoginRequest(t, handler, user.Username, password, "10.20.30.5:5005")
+	if loginC.Code != http.StatusOK || tokenC == "" {
+		t.Fatalf("reactivated DRE did not accept new login: status=%d body=%s", loginC.Code, loginC.Body.String())
+	}
+	if rr := runtimeMeRequest(handler, tokenC); rr.Code != http.StatusOK {
+		t.Fatalf("fresh token after DRE reactivation failed: %d %s", rr.Code, rr.Body.String())
 	}
 }
 
@@ -414,7 +427,6 @@ func TestRuntimeDREAuthorizationStress6000RequestsWithStaleClaims(t *testing.T) 
 		t.Fatalf("authorized calls=%d want=6000", calls)
 	}
 
-	// O snapshot original continuou propositalmente stale durante todo o stress.
 	parsed, err := parseRuntimeAdminToken(token)
 	if err != nil {
 		t.Fatalf("parse stress token: %v", err)
@@ -424,27 +436,14 @@ func TestRuntimeDREAuthorizationStress6000RequestsWithStaleClaims(t *testing.T) 
 	}
 }
 
-// TestRuntimeDREPasswordResetRevokesPriorTokensImmediately cobre os 10 passos obrigatórios da feature:
-// 1. login DRE e emissão de token A;
-// 2. token A acessa /v1/admin/me com 200;
-// 3. admin redefine senha;
-// 4. token A passa a receber 401 imediatamente;
-// 5. senha antiga não autentica;
-// 6. nova senha autentica e gera token B;
-// 7. token B funciona;
-// 8. reset subsequente invalida B;
-// 9. desativação/reativação existente continua com comportamento esperado;
-// 10. rename de DRE não invalida sessão por engano.
 func TestRuntimeDREPasswordResetRevokesPriorTokensImmediately(t *testing.T) {
 	app, handler, m := setupRuntimeAuthTest(t)
 	_ = app
 	ctx := context.Background()
 
-	// 0. Setup: DRE e Usuário DRE
 	initialPassword := "initial-password-123"
 	dre, user := createRuntimeDREUser(t, m, "DRE REVOGACAO TESTE", "user.reset.test", initialPassword)
 
-	// 1. login DRE e emissão de token A
 	loginA, tokenA := runtimeLoginRequest(t, handler, user.Username, initialPassword, "10.80.1.1:7001")
 	if loginA.Code != http.StatusOK || tokenA == "" {
 		t.Fatalf("passo 1 falhou: login A retornou code=%d body=%s", loginA.Code, loginA.Body.String())
@@ -458,31 +457,26 @@ func TestRuntimeDREPasswordResetRevokesPriorTokensImmediately(t *testing.T) {
 		t.Fatalf("passo 1 auth_version esperado 1, obteve %d", claimsA.AuthVersion)
 	}
 
-	// 2. token A acessa /v1/admin/me com 200
 	meA := runtimeMeRequest(handler, tokenA)
 	if meA.Code != http.StatusOK {
 		t.Fatalf("passo 2 falhou: token A /me status=%d body=%s", meA.Code, meA.Body.String())
 	}
 
-	// 3. admin redefine senha (via UpdatePasswordByID / endpoint)
 	newPassword1 := "new-password-step3-456"
 	if err := m.AdminUsers.UpdatePasswordByID(ctx, user.ID, newPassword1); err != nil {
 		t.Fatalf("passo 3 falhou: reset de senha: %v", err)
 	}
 
-	// 4. token A passa a receber 401 imediatamente (sem depender do TTL)
 	meAAfterReset := runtimeMeRequest(handler, tokenA)
 	if meAAfterReset.Code != http.StatusUnauthorized {
 		t.Fatalf("passo 4 falhou: token A deveria receber 401 apos reset, mas recebeu %d body=%s", meAAfterReset.Code, meAAfterReset.Body.String())
 	}
 
-	// 5. senha antiga não autentica
 	loginOld, _ := runtimeLoginRequest(t, handler, user.Username, initialPassword, "10.80.1.2:7002")
 	if loginOld.Code != http.StatusUnauthorized {
 		t.Fatalf("passo 5 falhou: senha antiga deveria receber 401, recebeu %d body=%s", loginOld.Code, loginOld.Body.String())
 	}
 
-	// 6. nova senha autentica e gera token B
 	loginB, tokenB := runtimeLoginRequest(t, handler, user.Username, newPassword1, "10.80.1.3:7003")
 	if loginB.Code != http.StatusOK || tokenB == "" {
 		t.Fatalf("passo 6 falhou: nova senha nao autenticou: code=%d body=%s", loginB.Code, loginB.Body.String())
@@ -496,13 +490,11 @@ func TestRuntimeDREPasswordResetRevokesPriorTokensImmediately(t *testing.T) {
 		t.Fatalf("passo 6 auth_version esperado 2, obteve %d", claimsB.AuthVersion)
 	}
 
-	// 7. token B funciona
 	meB := runtimeMeRequest(handler, tokenB)
 	if meB.Code != http.StatusOK {
 		t.Fatalf("passo 7 falhou: token B /me status=%d body=%s", meB.Code, meB.Body.String())
 	}
 
-	// 8. reset subsequente invalida B
 	newPassword2 := "third-password-step8-789"
 	if err := m.AdminUsers.UpdatePasswordByID(ctx, user.ID, newPassword2); err != nil {
 		t.Fatalf("passo 8 falhou: reset subsequente: %v", err)
@@ -512,7 +504,6 @@ func TestRuntimeDREPasswordResetRevokesPriorTokensImmediately(t *testing.T) {
 		t.Fatalf("passo 8 falhou: token B deveria receber 401 apos 2o reset, mas recebeu %d body=%s", meBAfterReset2.Code, meBAfterReset2.Body.String())
 	}
 
-	// Emitir token C com a senha do passo 8
 	loginC, tokenC := runtimeLoginRequest(t, handler, user.Username, newPassword2, "10.80.1.4:7004")
 	if loginC.Code != http.StatusOK || tokenC == "" {
 		t.Fatalf("login C falhou: code=%d body=%s", loginC.Code, loginC.Body.String())
@@ -521,7 +512,6 @@ func TestRuntimeDREPasswordResetRevokesPriorTokensImmediately(t *testing.T) {
 		t.Fatalf("token C baseline /me falhou: %d %s", rr.Code, rr.Body.String())
 	}
 
-	// 9. desativação/reativação existente continua com comportamento esperado
 	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, false); err != nil {
 		t.Fatalf("passo 9 desativar usuario: %v", err)
 	}
@@ -531,20 +521,24 @@ func TestRuntimeDREPasswordResetRevokesPriorTokensImmediately(t *testing.T) {
 	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, true); err != nil {
 		t.Fatalf("passo 9 reativar usuario: %v", err)
 	}
-	if rr := runtimeMeRequest(handler, tokenC); rr.Code != http.StatusOK {
-		t.Fatalf("passo 9 falhou: token C nao recuperou apos reativacao do usuario: status=%d", rr.Code)
+	if rr := runtimeMeRequest(handler, tokenC); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("passo 9 falhou: token C ressuscitou apos reativacao do usuario: status=%d", rr.Code)
 	}
 
-	// 10. rename de DRE não invalida sessão por engano
+	loginD, tokenD := runtimeLoginRequest(t, handler, user.Username, newPassword2, "10.80.1.5:7005")
+	if loginD.Code != http.StatusOK || tokenD == "" {
+		t.Fatalf("novo login apos reativacao falhou: code=%d body=%s", loginD.Code, loginD.Body.String())
+	}
+
 	dre.Nome = "DRE REVOGACAO RENOMEADA"
 	if _, err := m.DREs.Update(ctx, *dre); err != nil {
 		t.Fatalf("passo 10 renomear DRE: %v", err)
 	}
-	meCAfterRename := runtimeMeRequest(handler, tokenC)
-	if meCAfterRename.Code != http.StatusOK {
-		t.Fatalf("passo 10 falhou: rename da DRE invalidou sessao por engano: status=%d body=%s", meCAfterRename.Code, meCAfterRename.Body.String())
+	meDAfterRename := runtimeMeRequest(handler, tokenD)
+	if meDAfterRename.Code != http.StatusOK {
+		t.Fatalf("passo 10 falhou: rename da DRE invalidou sessao por engano: status=%d body=%s", meDAfterRename.Code, meDAfterRename.Body.String())
 	}
-	mePayload := decodeRuntimeMe(t, meCAfterRename)
+	mePayload := decodeRuntimeMe(t, meDAfterRename)
 	if mePayload.Data.DRE == nil || *mePayload.Data.DRE != "DRE REVOGACAO RENOMEADA" {
 		t.Fatalf("passo 10 falhou: DRE renomeada nao refletida no /me: %+v", mePayload.Data)
 	}
@@ -555,7 +549,6 @@ func TestRuntimeLegacyDRETokenRevokedWhenPasswordIsReset(t *testing.T) {
 	ctx := context.Background()
 	dre, user := createRuntimeDREUser(t, m, "DRE LEGACY RESET", "legacy.reset.user", "legacy-pass-123")
 
-	// Token legado emitido sem claim auth_version (versão 0)
 	legacy := adminClaims{
 		Username: user.Username,
 		Role:     RoleDRE,
@@ -572,17 +565,14 @@ func TestRuntimeLegacyDRETokenRevokedWhenPasswordIsReset(t *testing.T) {
 		t.Fatalf("sign legacy token: %v", err)
 	}
 
-	// Token legado com auth_version no banco == 1 deve funcionar na janela de transição
 	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusOK {
 		t.Fatalf("legacy token should be accepted before password reset, got %d body=%s", rr.Code, rr.Body.String())
 	}
 
-	// Ao redefinir a senha do usuário, auth_version incrementa para 2
 	if err := m.AdminUsers.UpdatePasswordByID(ctx, user.ID, "new-legacy-pass-456"); err != nil {
 		t.Fatalf("update password: %v", err)
 	}
 
-	// Token legado agora DEVE ser revogado imediatamente (401)
 	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
 		t.Fatalf("legacy token survived password reset: got %d body=%s", rr.Code, rr.Body.String())
 	}

--- a/api/cmd/api/dre_runtime_auth_scope_test.go
+++ b/api/cmd/api/dre_runtime_auth_scope_test.go
@@ -265,10 +265,18 @@ func TestRuntimeAuth401Vs403Consistency(t *testing.T) {
 		t.Fatalf("reactivate DRE: %v", err)
 	}
 
-	// Autorização: admin CRUD exige role=admin; o token DRE não pode promover
-	// role nem acessar CRUD. O 403 é emitido pelo guard de role no handler.
+	loginFresh, freshToken := runtimeLoginRequest(t, handler, "status.code", "code-password", "10.70.4.2:6005")
+	if loginFresh.Code != http.StatusOK || freshToken == "" {
+		t.Fatalf("fresh login after reactivation failed: code=%d body=%s", loginFresh.Code, loginFresh.Body.String())
+	}
+	if rr := runtimeMeRequest(handler, token); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked token resurrected after reactivation: got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Autorização: admin CRUD exige role=admin; um token DRE válido não pode
+	// promover role nem acessar CRUD. O 403 é emitido pelo guard de role.
 	req := httptest.NewRequest(http.MethodPost, "/v1/admin/dres", strings.NewReader(`{"nome":"DRE X"}`))
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+freshToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusForbidden {

--- a/api/cmd/api/dre_session_revocation_migration.go
+++ b/api/cmd/api/dre_session_revocation_migration.go
@@ -1,0 +1,8 @@
+package main
+
+// A revogação definitiva de sessões é requisito de segurança do Perfil DRE.
+// Registrá-la como migration administrativa crítica faz o startup falhar
+// fechado caso o SQL esteja ausente ou não possa ser aplicado.
+func init() {
+	criticalAdministrativeMigrations["0025_dre_session_revocation.sql"] = struct{}{}
+}

--- a/api/cmd/api/dre_session_revocation_test.go
+++ b/api/cmd/api/dre_session_revocation_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"censo-api/internal/models"
+)
+
+func requireAuthVersion(t *testing.T, m models.Models, userID, want int) *models.AdminUser {
+	t.Helper()
+	u, err := m.AdminUsers.GetByID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("GetByID(%d): %v", userID, err)
+	}
+	if u.AuthVersion != want {
+		t.Fatalf("user %d auth_version=%d; want %d", userID, u.AuthVersion, want)
+	}
+	return u
+}
+
+func TestDRESessionRevocationMigrationIsCritical(t *testing.T) {
+	if !isCriticalAdministrativeMigration("0025_dre_session_revocation.sql") {
+		t.Fatal("0025_dre_session_revocation.sql must fail closed as a critical administrative migration")
+	}
+}
+
+func TestDREUserDeactivationRevokesPermanentlyAndIsIdempotent(t *testing.T) {
+	_, handler, m := setupRuntimeAuthTest(t)
+	ctx := context.Background()
+	password := "user-deactivation-password"
+	_, user := createRuntimeDREUser(t, m, "DRE USER REVOCATION", "user.revocation", password)
+
+	loginA, tokenA := runtimeLoginRequest(t, handler, user.Username, password, "10.90.1.1:8001")
+	if loginA.Code != http.StatusOK || tokenA == "" {
+		t.Fatalf("initial login failed: code=%d body=%s", loginA.Code, loginA.Body.String())
+	}
+	claimsA, err := parseRuntimeAdminToken(tokenA)
+	if err != nil {
+		t.Fatalf("parse initial token: %v", err)
+	}
+	if claimsA.AuthVersion != 1 {
+		t.Fatalf("initial auth_version=%d; want 1", claimsA.AuthVersion)
+	}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- m.AdminUsers.SetActiveByID(ctx, user.ID, false)
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent deactivate: %v", err)
+		}
+	}
+
+	afterDeactivate := requireAuthVersion(t, m, user.ID, 2)
+	if afterDeactivate.Active {
+		t.Fatal("user remained active after deactivation")
+	}
+	if rr := runtimeMeRequest(handler, tokenA); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("token A survived deactivation: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, true); err != nil {
+		t.Fatalf("reactivate user: %v", err)
+	}
+	if err := m.AdminUsers.SetActiveByID(ctx, user.ID, true); err != nil {
+		t.Fatalf("repeat reactivation: %v", err)
+	}
+	reactivated := requireAuthVersion(t, m, user.ID, 2)
+	if !reactivated.Active {
+		t.Fatal("user did not reactivate")
+	}
+	if rr := runtimeMeRequest(handler, tokenA); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("token A resurrected after reactivation: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	loginB, tokenB := runtimeLoginRequest(t, handler, user.Username, password, "10.90.1.2:8002")
+	if loginB.Code != http.StatusOK || tokenB == "" {
+		t.Fatalf("new login after reactivation failed: code=%d body=%s", loginB.Code, loginB.Body.String())
+	}
+	claimsB, err := parseRuntimeAdminToken(tokenB)
+	if err != nil {
+		t.Fatalf("parse fresh token: %v", err)
+	}
+	if claimsB.AuthVersion != 2 {
+		t.Fatalf("fresh token auth_version=%d; want 2", claimsB.AuthVersion)
+	}
+	if rr := runtimeMeRequest(handler, tokenB); rr.Code != http.StatusOK {
+		t.Fatalf("fresh token rejected: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDREDeactivationViaUpdateRevokesOnlyLinkedUsersAndNeverResurrects(t *testing.T) {
+	_, handler, m := setupRuntimeAuthTest(t)
+	ctx := context.Background()
+	passwordA := "dre-update-password-a"
+	passwordB := "dre-update-password-b"
+
+	dreA, userA1 := createRuntimeDREUser(t, m, "DRE UPDATE A", "update.a1", passwordA)
+	userA2, err := m.AdminUsers.CreateForDREID(ctx, "update.a2", "dre-update-password-a2", RoleDRE, dreA.ID)
+	if err != nil {
+		t.Fatalf("create second DRE A user: %v", err)
+	}
+	_, userB := createRuntimeDREUser(t, m, "DRE UPDATE B", "update.b", passwordB)
+
+	loginA, tokenA := runtimeLoginRequest(t, handler, userA1.Username, passwordA, "10.90.2.1:8101")
+	if loginA.Code != http.StatusOK || tokenA == "" {
+		t.Fatalf("login DRE A failed: code=%d body=%s", loginA.Code, loginA.Body.String())
+	}
+	loginB, tokenB := runtimeLoginRequest(t, handler, userB.Username, passwordB, "10.90.2.2:8102")
+	if loginB.Code != http.StatusOK || tokenB == "" {
+		t.Fatalf("login DRE B failed: code=%d body=%s", loginB.Code, loginB.Body.String())
+	}
+
+	requireAuthVersion(t, m, userA1.ID, 1)
+	requireAuthVersion(t, m, userA2.ID, 1)
+	requireAuthVersion(t, m, userB.ID, 1)
+
+	dreA.Ativa = false
+	if _, err := m.DREs.Update(ctx, *dreA); err != nil {
+		t.Fatalf("deactivate DRE A via Update: %v", err)
+	}
+	requireAuthVersion(t, m, userA1.ID, 2)
+	requireAuthVersion(t, m, userA2.ID, 2)
+	requireAuthVersion(t, m, userB.ID, 1)
+	if rr := runtimeMeRequest(handler, tokenA); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("DRE A token survived deactivation: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if rr := runtimeMeRequest(handler, tokenB); rr.Code != http.StatusOK {
+		t.Fatalf("unrelated DRE B token was revoked: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	if _, err := m.DREs.Update(ctx, *dreA); err != nil {
+		t.Fatalf("repeat DRE A deactivation: %v", err)
+	}
+	requireAuthVersion(t, m, userA1.ID, 2)
+	requireAuthVersion(t, m, userA2.ID, 2)
+
+	dreA.Ativa = true
+	if _, err := m.DREs.Update(ctx, *dreA); err != nil {
+		t.Fatalf("reactivate DRE A via Update: %v", err)
+	}
+	requireAuthVersion(t, m, userA1.ID, 2)
+	requireAuthVersion(t, m, userA2.ID, 2)
+	if rr := runtimeMeRequest(handler, tokenA); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("old DRE A token resurrected after reactivation: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	loginFresh, tokenFresh := runtimeLoginRequest(t, handler, userA1.Username, passwordA, "10.90.2.3:8103")
+	if loginFresh.Code != http.StatusOK || tokenFresh == "" {
+		t.Fatalf("fresh DRE A login after reactivation failed: code=%d body=%s", loginFresh.Code, loginFresh.Body.String())
+	}
+	claimsFresh, err := parseRuntimeAdminToken(tokenFresh)
+	if err != nil {
+		t.Fatalf("parse fresh DRE A token: %v", err)
+	}
+	if claimsFresh.AuthVersion != 2 {
+		t.Fatalf("fresh DRE A token auth_version=%d; want 2", claimsFresh.AuthVersion)
+	}
+	if rr := runtimeMeRequest(handler, tokenFresh); rr.Code != http.StatusOK {
+		t.Fatalf("fresh DRE A token rejected: code=%d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/api/cmd/api/migrations/0025_dre_session_revocation.sql
+++ b/api/cmd/api/migrations/0025_dre_session_revocation.sql
@@ -1,0 +1,47 @@
+-- 0025_dre_session_revocation.sql
+-- Revoga definitivamente sessões JWT quando um usuário DRE ou a própria DRE
+-- é desativada. A revogação é baseada em auth_version, portanto reativar a
+-- conta/regional não ressuscita tokens emitidos antes da desativação.
+--
+-- A lógica fica no banco para cobrir todos os caminhos de escrita existentes
+-- (AdminUserModel.SetActive*, DREModel.SetActive e DREModel.Update) dentro da
+-- mesma transação que altera o status.
+
+CREATE OR REPLACE FUNCTION revoke_admin_user_session_on_deactivation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.active IS TRUE AND NEW.active IS FALSE THEN
+        NEW.auth_version := COALESCE(OLD.auth_version, 1) + 1;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_admin_users_revoke_session_on_deactivation ON admin_users;
+CREATE TRIGGER trg_admin_users_revoke_session_on_deactivation
+BEFORE UPDATE OF active ON admin_users
+FOR EACH ROW
+EXECUTE FUNCTION revoke_admin_user_session_on_deactivation();
+
+CREATE OR REPLACE FUNCTION revoke_dre_sessions_on_deactivation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.ativa IS TRUE AND NEW.ativa IS FALSE THEN
+        UPDATE admin_users
+        SET auth_version = COALESCE(auth_version, 1) + 1,
+            updated_at = NOW()
+        WHERE dre_id = NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_dres_revoke_sessions_on_deactivation ON dres;
+CREATE TRIGGER trg_dres_revoke_sessions_on_deactivation
+AFTER UPDATE OF ativa ON dres
+FOR EACH ROW
+EXECUTE FUNCTION revoke_dre_sessions_on_deactivation();

--- a/infra/migrations/0025_dre_session_revocation.sql
+++ b/infra/migrations/0025_dre_session_revocation.sql
@@ -1,0 +1,47 @@
+-- 0025_dre_session_revocation.sql
+-- Revoga definitivamente sessões JWT quando um usuário DRE ou a própria DRE
+-- é desativada. A revogação é baseada em auth_version, portanto reativar a
+-- conta/regional não ressuscita tokens emitidos antes da desativação.
+--
+-- A lógica fica no banco para cobrir todos os caminhos de escrita existentes
+-- (AdminUserModel.SetActive*, DREModel.SetActive e DREModel.Update) dentro da
+-- mesma transação que altera o status.
+
+CREATE OR REPLACE FUNCTION revoke_admin_user_session_on_deactivation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.active IS TRUE AND NEW.active IS FALSE THEN
+        NEW.auth_version := COALESCE(OLD.auth_version, 1) + 1;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_admin_users_revoke_session_on_deactivation ON admin_users;
+CREATE TRIGGER trg_admin_users_revoke_session_on_deactivation
+BEFORE UPDATE OF active ON admin_users
+FOR EACH ROW
+EXECUTE FUNCTION revoke_admin_user_session_on_deactivation();
+
+CREATE OR REPLACE FUNCTION revoke_dre_sessions_on_deactivation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.ativa IS TRUE AND NEW.ativa IS FALSE THEN
+        UPDATE admin_users
+        SET auth_version = COALESCE(auth_version, 1) + 1,
+            updated_at = NOW()
+        WHERE dre_id = NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_dres_revoke_sessions_on_deactivation ON dres;
+CREATE TRIGGER trg_dres_revoke_sessions_on_deactivation
+AFTER UPDATE OF ativa ON dres
+FOR EACH ROW
+EXECUTE FUNCTION revoke_dre_sessions_on_deactivation();


### PR DESCRIPTION
## Objetivo
Entrega da #241: tornar a revogação de sessão DRE definitiva quando usuário ou DRE é desativado, impedindo que tokens antigos voltem a funcionar após reativação.

## Implementação
- adiciona a migration crítica `0025_dre_session_revocation.sql`;
- revoga por `auth_version` na transição `admin_users.active: true -> false`;
- revoga as sessões de todos os usuários vinculados por `dre_id` na transição `dres.ativa: true -> false`;
- cobre tanto `DREModel.SetActive` quanto `DREModel.Update` (caminho usado pela UI);
- reativação não incrementa versão e não ressuscita token antigo;
- chamadas repetidas/concorrrentes de desativação são idempotentes quanto à versão;
- migration é registrada como administrativa crítica/fail-closed;
- API CI passa a aplicar 0025 explicitamente nos gates PostgreSQL 16.

## Testes adicionados/ajustados
- token antigo permanece 401 após reativação de usuário;
- token antigo permanece 401 após reativação de DRE;
- novo login após reativação funciona;
- usuários de outra DRE não são revogados;
- múltiplas desativações do mesmo estado não incrementam `auth_version` repetidamente;
- fluxo real via `DREModel.Update` é coberto;
- reset de senha e rename continuam com os contratos esperados.

Refs #241

**Não realizar merge automaticamente; PR aberto para aprovação.**