### PR TITLE
feat(api): canonicalizar provisioning DRE por dre_id (#242)

### DIFF
--- a/api/cmd/api/admin.go
+++ b/api/cmd/api/admin.go
@@ -898,7 +898,9 @@ func (app *application) AdminUpdateDRE(w http.ResponseWriter, r *http.Request) {
 
 // ─── Gestão de Usuários Administrativos (role=admin) ─────────────────────────
 
-// AdminCreateUser cria um novo usuário DRE com hash bcrypt e validação de DRE (exclusivo para role=admin).
+// AdminCreateUser cria um novo usuário DRE. dre_id é a identidade canônica;
+// o campo dre textual é mantido somente como compatibilidade para clientes
+// legados que ainda não migraram para o contrato por ID.
 func (app *application) AdminCreateUser(w http.ResponseWriter, r *http.Request) {
 	scope, ok := GetAdminAccessScope(r.Context())
 	if !ok || scope.Role != RoleAdmin {
@@ -911,6 +913,7 @@ func (app *application) AdminCreateUser(w http.ResponseWriter, r *http.Request) 
 		Password string `json:"password"`
 		Role     string `json:"role"`
 		DRE      string `json:"dre"`
+		DREID    *int   `json:"dre_id"`
 	}
 
 	if err := app.readJSON(w, r, &req); err != nil {
@@ -922,7 +925,37 @@ func (app *application) AdminCreateUser(w http.ResponseWriter, r *http.Request) 
 		req.Role = RoleDRE
 	}
 
-	user, err := app.models.AdminUsers.Create(r.Context(), req.Username, req.Password, req.Role, req.DRE)
+	var (
+		user *models.AdminUser
+		err  error
+	)
+
+	if req.DREID != nil {
+		// Quando ambos os campos são enviados, dre é somente uma asserção de
+		// consistência. O vínculo continua sendo decidido exclusivamente por
+		// dre_id; nunca fazemos fallback textual quando o ID está presente.
+		if strings.TrimSpace(req.DRE) != "" {
+			canonical, lookupErr := app.models.DREs.GetByID(r.Context(), *req.DREID)
+			if lookupErr != nil {
+				if errors.Is(lookupErr, models.ErrDRENotFound) || errors.Is(lookupErr, models.ErrDREInvalidID) {
+					app.errorJSON(w, fmt.Errorf("DRE não encontrada"), http.StatusBadRequest)
+					return
+				}
+				app.errorJSON(w, fmt.Errorf("erro ao validar dre_id: %w", lookupErr), http.StatusInternalServerError)
+				return
+			}
+			if !strings.EqualFold(strings.TrimSpace(req.DRE), strings.TrimSpace(canonical.Nome)) {
+				app.errorJSON(w, fmt.Errorf("dre e dre_id referenciam DREs diferentes"), http.StatusBadRequest)
+				return
+			}
+		}
+		user, err = app.models.AdminUsers.CreateForDREID(r.Context(), req.Username, req.Password, req.Role, *req.DREID)
+	} else {
+		// Compatibilidade temporária: clientes antigos ainda podem enviar apenas
+		// dre textual. Novos clientes devem enviar dre_id.
+		user, err = app.models.AdminUsers.Create(r.Context(), req.Username, req.Password, req.Role, req.DRE)
+	}
+
 	if err != nil {
 		if errors.Is(err, models.ErrUsernameExists) {
 			app.errorJSON(w, err, http.StatusConflict)

--- a/api/cmd/api/admin_user_provisioning_dre_id_test.go
+++ b/api/cmd/api/admin_user_provisioning_dre_id_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"censo-api/internal/models"
+)
+
+type adminCreateUserResponse struct {
+	Error   bool             `json:"error"`
+	Message string           `json:"message"`
+	Data    models.AdminUser `json:"data"`
+}
+
+func callAdminCreateUser(t *testing.T, app *application, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/users", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	scope := AdminAccessScope{Username: "admin.provisioning", Role: RoleAdmin}
+	req = req.WithContext(context.WithValue(req.Context(), contextKeyAdminScope, scope))
+
+	rr := httptest.NewRecorder()
+	app.AdminCreateUser(rr, req)
+	return rr
+}
+
+func decodeAdminCreateUserResponse(t *testing.T, rr *httptest.ResponseRecorder) adminCreateUserResponse {
+	t.Helper()
+	var resp adminCreateUserResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode create-user response: %v; body=%s", err, rr.Body.String())
+	}
+	return resp
+}
+
+func assertNoAdminUser(t *testing.T, dbQuery interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, username string) {
+	t.Helper()
+	var count int
+	if err := dbQuery.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM admin_users WHERE username = $1`, username).Scan(&count); err != nil {
+		t.Fatalf("count admin user %q: %v", username, err)
+	}
+	if count != 0 {
+		t.Fatalf("user %q was persisted despite rejected provisioning", username)
+	}
+}
+
+func TestDRELifecycleCanonicalUserProvisioningByID(t *testing.T) {
+	ctx := context.Background()
+	db, m := setupDRELifecycleTestDB(t, true)
+	app := &application{models: m}
+
+	t.Run("dre_id only persists canonical relation", func(t *testing.T) {
+		dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE PROVISION ID", Ativa: true})
+		if err != nil {
+			t.Fatalf("create DRE: %v", err)
+		}
+
+		body := fmt.Sprintf(`{"username":"provision.by.id","password":"password1234","role":"dre","dre_id":%d}`, dre.ID)
+		rr := callAdminCreateUser(t, app, body)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("dre_id provisioning status=%d want=201 body=%s", rr.Code, rr.Body.String())
+		}
+
+		resp := decodeAdminCreateUserResponse(t, rr)
+		if resp.Error {
+			t.Fatalf("successful provisioning returned error response: %s", rr.Body.String())
+		}
+		if resp.Data.DREID != dre.ID || resp.Data.DRE != dre.Nome {
+			t.Fatalf("response relation mismatch: dre_id=%d dre=%q want id=%d name=%q", resp.Data.DREID, resp.Data.DRE, dre.ID, dre.Nome)
+		}
+
+		var storedID int
+		var storedName string
+		if err := db.QueryRowContext(ctx, `SELECT dre_id, dre FROM admin_users WHERE username = $1`, "provision.by.id").Scan(&storedID, &storedName); err != nil {
+			t.Fatalf("read persisted relation: %v", err)
+		}
+		if storedID != dre.ID || storedName != dre.Nome {
+			t.Fatalf("stored relation mismatch: dre_id=%d dre=%q want id=%d name=%q", storedID, storedName, dre.ID, dre.Nome)
+		}
+	})
+
+	t.Run("matching dre text is only a consistency assertion", func(t *testing.T) {
+		dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE ASSERT MATCH", Ativa: true})
+		if err != nil {
+			t.Fatalf("create DRE: %v", err)
+		}
+		body := fmt.Sprintf(`{"username":"provision.match","password":"password1234","role":"dre","dre_id":%d,"dre":"  dre assert match  "}`, dre.ID)
+		rr := callAdminCreateUser(t, app, body)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("matching assertion status=%d want=201 body=%s", rr.Code, rr.Body.String())
+		}
+		resp := decodeAdminCreateUserResponse(t, rr)
+		if resp.Data.DREID != dre.ID || resp.Data.DRE != dre.Nome {
+			t.Fatalf("matching assertion changed canonical identity: %+v", resp.Data)
+		}
+	})
+
+	t.Run("contradictory dre and dre_id is rejected without insert", func(t *testing.T) {
+		dreA, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE ASSERT A", Ativa: true})
+		if err != nil {
+			t.Fatalf("create DRE A: %v", err)
+		}
+		if _, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE ASSERT B", Ativa: true}); err != nil {
+			t.Fatalf("create DRE B: %v", err)
+		}
+		body := fmt.Sprintf(`{"username":"provision.conflict","password":"password1234","role":"dre","dre_id":%d,"dre":"DRE ASSERT B"}`, dreA.ID)
+		rr := callAdminCreateUser(t, app, body)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("contradictory payload status=%d want=400 body=%s", rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(strings.ToLower(rr.Body.String()), "diferentes") {
+			t.Fatalf("contradictory payload did not explain mismatch: %s", rr.Body.String())
+		}
+		var count int
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM admin_users WHERE username = $1`, "provision.conflict").Scan(&count); err != nil {
+			t.Fatalf("count rejected user: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("contradictory payload persisted %d user(s)", count)
+		}
+	})
+
+	t.Run("nonexistent dre_id is rejected", func(t *testing.T) {
+		rr := callAdminCreateUser(t, app, `{"username":"provision.missing","password":"password1234","role":"dre","dre_id":99999999}`)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("nonexistent dre_id status=%d want=400 body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("nonpositive dre_id is rejected", func(t *testing.T) {
+		for _, id := range []int{0, -1} {
+			username := fmt.Sprintf("provision.badid.%d", -id)
+			body := fmt.Sprintf(`{"username":%q,"password":"password1234","role":"dre","dre_id":%d}`, username, id)
+			rr := callAdminCreateUser(t, app, body)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("dre_id=%d status=%d want=400 body=%s", id, rr.Code, rr.Body.String())
+			}
+		}
+	})
+
+	t.Run("inactive dre_id is rejected", func(t *testing.T) {
+		dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE PROVISION INACTIVE", Ativa: false})
+		if err != nil {
+			t.Fatalf("create inactive DRE: %v", err)
+		}
+		body := fmt.Sprintf(`{"username":"provision.inactive","password":"password1234","role":"dre","dre_id":%d}`, dre.ID)
+		rr := callAdminCreateUser(t, app, body)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("inactive dre_id status=%d want=400 body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("rename before submit preserves identity by id", func(t *testing.T) {
+		dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE BEFORE RENAME", Ativa: true})
+		if err != nil {
+			t.Fatalf("create DRE: %v", err)
+		}
+		originalID := dre.ID
+		dre.Nome = "DRE AFTER RENAME"
+		updated, err := m.DREs.Update(ctx, *dre)
+		if err != nil {
+			t.Fatalf("rename DRE: %v", err)
+		}
+
+		body := fmt.Sprintf(`{"username":"provision.after.rename","password":"password1234","role":"dre","dre_id":%d}`, originalID)
+		rr := callAdminCreateUser(t, app, body)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("post-rename provisioning status=%d want=201 body=%s", rr.Code, rr.Body.String())
+		}
+		resp := decodeAdminCreateUserResponse(t, rr)
+		if resp.Data.DREID != originalID || resp.Data.DRE != updated.Nome {
+			t.Fatalf("rename altered canonical binding: dre_id=%d dre=%q want id=%d name=%q", resp.Data.DREID, resp.Data.DRE, originalID, updated.Nome)
+		}
+	})
+
+	t.Run("name longer than 100 characters does not affect provisioning", func(t *testing.T) {
+		longName := "DRE " + strings.Repeat("N", 108)
+		if len(longName) <= 100 {
+			t.Fatal("test fixture must exceed 100 characters")
+		}
+		dre, err := m.DREs.Create(ctx, models.DRE{Nome: longName, Ativa: true})
+		if err != nil {
+			t.Fatalf("create long-name DRE: %v", err)
+		}
+		body := fmt.Sprintf(`{"username":"provision.long.name","password":"password1234","role":"dre","dre_id":%d}`, dre.ID)
+		rr := callAdminCreateUser(t, app, body)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("long-name provisioning status=%d want=201 body=%s", rr.Code, rr.Body.String())
+		}
+		resp := decodeAdminCreateUserResponse(t, rr)
+		if resp.Data.DREID != dre.ID || resp.Data.DRE != longName {
+			t.Fatalf("long-name relation mismatch: dre_id=%d dre=%q", resp.Data.DREID, resp.Data.DRE)
+		}
+	})
+
+	t.Run("legacy text-only payload remains compatible", func(t *testing.T) {
+		dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE LEGACY COMPAT", Ativa: true})
+		if err != nil {
+			t.Fatalf("create DRE: %v", err)
+		}
+		rr := callAdminCreateUser(t, app, `{"username":"provision.legacy","password":"password1234","role":"dre","dre":"DRE LEGACY COMPAT"}`)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("legacy provisioning status=%d want=201 body=%s", rr.Code, rr.Body.String())
+		}
+		resp := decodeAdminCreateUserResponse(t, rr)
+		if resp.Data.DREID != dre.ID || resp.Data.DRE != dre.Nome {
+			t.Fatalf("legacy path did not resolve to canonical relation: %+v", resp.Data)
+		}
+	})
+}
+
+func TestDRELifecycleCanonicalUserProvisioningModel(t *testing.T) {
+	ctx := context.Background()
+	_, m := setupDRELifecycleTestDB(t, true)
+
+	dre, err := m.DREs.Create(ctx, models.DRE{Nome: "DRE MODEL ID", Ativa: true})
+	if err != nil {
+		t.Fatalf("create DRE: %v", err)
+	}
+
+	user, err := m.AdminUsers.CreateForDREID(ctx, "model.by.id", "password1234", RoleDRE, dre.ID)
+	if err != nil {
+		t.Fatalf("CreateForDREID valid: %v", err)
+	}
+	if user.DREID != dre.ID || user.DRE != dre.Nome {
+		t.Fatalf("model relation mismatch: %+v", user)
+	}
+
+	dre.Nome = "DRE MODEL RENAMED"
+	updated, err := m.DREs.Update(ctx, *dre)
+	if err != nil {
+		t.Fatalf("rename DRE: %v", err)
+	}
+	postRename, err := m.AdminUsers.CreateForDREID(ctx, "model.after.rename", "password1234", RoleDRE, dre.ID)
+	if err != nil {
+		t.Fatalf("CreateForDREID after rename: %v", err)
+	}
+	if postRename.DREID != dre.ID || postRename.DRE != updated.Nome {
+		t.Fatalf("model used stale name after rename: %+v", postRename)
+	}
+
+	if err := m.DREs.SetActive(ctx, dre.ID, false); err != nil {
+		t.Fatalf("deactivate DRE: %v", err)
+	}
+	if _, err := m.AdminUsers.CreateForDREID(ctx, "model.inactive", "password1234", RoleDRE, dre.ID); !errors.Is(err, models.ErrDREInactive) {
+		t.Fatalf("inactive DRE error=%v want ErrDREInactive", err)
+	}
+	if _, err := m.AdminUsers.CreateForDREID(ctx, "model.missing", "password1234", RoleDRE, 99999999); !errors.Is(err, models.ErrInvalidDRE) {
+		t.Fatalf("missing DRE error=%v want ErrInvalidDRE", err)
+	}
+}

--- a/api/cmd/api/admin_user_provisioning_dre_id_test.go
+++ b/api/cmd/api/admin_user_provisioning_dre_id_test.go
@@ -40,19 +40,6 @@ func decodeAdminCreateUserResponse(t *testing.T, rr *httptest.ResponseRecorder) 
 	return resp
 }
 
-func assertNoAdminUser(t *testing.T, dbQuery interface {
-	QueryRowContext(context.Context, string, ...any) *sql.Row
-}, username string) {
-	t.Helper()
-	var count int
-	if err := dbQuery.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM admin_users WHERE username = $1`, username).Scan(&count); err != nil {
-		t.Fatalf("count admin user %q: %v", username, err)
-	}
-	if count != 0 {
-		t.Fatalf("user %q was persisted despite rejected provisioning", username)
-	}
-}
-
 func TestDRELifecycleCanonicalUserProvisioningByID(t *testing.T) {
 	ctx := context.Background()
 	db, m := setupDRELifecycleTestDB(t, true)

--- a/docs/dre-user-provisioning-contract.md
+++ b/docs/dre-user-provisioning-contract.md
@@ -1,0 +1,55 @@
+# Provisioning de usuário DRE por `dre_id`
+
+## Contrato canônico
+
+Novos clientes devem criar contas regionais com `POST /v1/admin/users` enviando `dre_id` como identidade da DRE:
+
+```json
+{
+  "username": "usuario.dre",
+  "password": "senha-com-12-ou-mais",
+  "role": "dre",
+  "dre_id": 123
+}
+```
+
+O backend usa `dre_id` como única autoridade para estabelecer o vínculo `admin_users.dre_id -> dres.id`. O nome da DRE é dado de apresentação e é resolvido a partir da entidade mestre atual.
+
+A resposta de sucesso continua expondo os dois campos para consumo do cliente:
+
+```json
+{
+  "error": false,
+  "message": "Usuário criado com sucesso",
+  "data": {
+    "id": 456,
+    "username": "usuario.dre",
+    "role": "dre",
+    "dre": "DRE atual",
+    "dre_id": 123,
+    "active": true
+  }
+}
+```
+
+## Compatibilidade temporária do campo `dre`
+
+O campo textual `dre` permanece aceito quando `dre_id` não é enviado para preservar clientes legados durante a migração do frontend da task #244. Nesse caminho legado, o backend resolve primeiro a DRE na entidade mestre e persiste a relação canônica por ID.
+
+Quando `dre_id` está presente, o backend nunca usa `dre` como fallback de identidade. Se ambos forem enviados, `dre` funciona somente como uma asserção de consistência contra o nome atual da DRE identificada por `dre_id`:
+
+- `dre_id` válido + `dre` compatível (ignorando caixa e espaços externos): criação permitida;
+- `dre_id` válido + `dre` de outra DRE/nome stale: `400 Bad Request`;
+- `dre_id` inexistente, inválido ou de DRE inativa: `400 Bad Request`;
+- `dre_id` sem `dre`: caminho preferencial e canônico.
+
+Após a migração do frontend em #244, o caminho textual poderá ser descontinuado em task específica, sem alterar a identidade persistida.
+
+## Invariantes
+
+- rename da DRE não muda `dres.id` nem `admin_users.dre_id`;
+- carregar a lista de DREs, renomear a regional e depois submeter o mesmo `dre_id` continua vinculando à mesma entidade;
+- nomes longos não participam da decisão de identidade no caminho canônico;
+- DRE inativa ou inexistente não aceita novo usuário;
+- payload contraditório não é aceito silenciosamente;
+- a relação persistida e a resposta de criação carregam o `dre_id` solicitado e o nome atual resolvido pela entidade mestre.


### PR DESCRIPTION
## Objetivo
Entrega da #242: tornar `dre_id` a identidade canônica no provisioning de usuários DRE em `POST /v1/admin/users`.

## Implementação
- adiciona `dre_id` ao contrato de criação de usuário;
- quando `dre_id` é enviado, o handler usa exclusivamente `AdminUsers.CreateForDREID` para estabelecer o vínculo;
- `dre` textual permanece apenas como compatibilidade temporária para clientes antigos;
- quando `dre_id` + `dre` são enviados juntos, o texto é somente uma asserção de consistência e payload contraditório retorna 400;
- não existe fallback textual quando `dre_id` está presente;
- DRE inexistente/inválida/inativa continua bloqueada;
- resposta preserva `dre_id` e o nome atual resolvido pela entidade mestre;
- rename antes do submit e nomes >100 caracteres são cobertos sem alterar a identidade por ID.

## Testes adicionados
A suíte PostgreSQL real cobre:
- criação somente por `dre_id` e persistência canônica;
- `dre_id` + texto compatível;
- payload contraditório sem insert;
- ID inexistente, zero e negativo;
- DRE inativa;
- rename entre carregamento/submissão usando o mesmo ID;
- nome DRE >100 caracteres;
- compatibilidade do payload textual legado;
- primitive `CreateForDREID` diretamente no model, incluindo rename/inativo/inexistente.

Os testes começam com `TestDRELifecycle...`, portanto também entram no gate dedicado de lifecycle/auth além da suíte completa.

## Documentação
Adiciona `docs/dre-user-provisioning-contract.md` com o contrato canônico e a janela de compatibilidade até a migração do frontend na #244.

Refs #242

**PR aberto para aprovação; não realizar merge automaticamente.**