### PR TITLE
chore: reconciliar histórico de main em develop

### DIFF
--- a/.source-provenance.json
+++ b/.source-provenance.json
@@ -1,0 +1,10 @@
+{
+  "format": "source-provenance/v1",
+  "maintainer": "Lucas Madureira (@lucasonline0)",
+  "repository": "lucasonline0/CENSO-Operacional-Escolas",
+  "canonical_url": "https://github.com/lucasonline0/CENSO-Operacional-Escolas",
+  "fingerprint": "LM-PROV-2026-B9330B82D65E",
+  "recorded_on": "2026-09-01",
+  "scope": "repository lineage and maintained source",
+  "note": "This marker is not a claim of exclusive authorship; Git history and pull requests remain authoritative for individual contributions."
+}

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+Source Provenance Notice
+
+Primary repository: https://github.com/lucasonline0/CENSO-Operacional-Escolas
+Maintained by: Lucas Madureira (@lucasonline0)
+Provenance fingerprint: LM-PROV-2026-B9330B82D65E
+First recorded in repository: 2026-09-01
+
+This notice records repository provenance only and is not a claim of exclusive authorship. Individual contributions remain attributable through Git history, pull requests, and repository metadata. This notice does not modify the project's licensing terms.

--- a/api/cmd/api/census_period.go
+++ b/api/cmd/api/census_period.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const censusPeriodClosedCode = "census_period_closed"
+
+var errCensusPeriodClosed = errors.New("O período de preenchimento do Censo Operacional foi encerrado.")
+
+func censusSubmissionsEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("CENSUS_SUBMISSIONS_ENABLED")), "true")
+}
+
+func (app *application) requireCensusSubmissions(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if censusSubmissionsEnabled() {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		app.writeJSON(w, http.StatusForbidden, jsonResponse{
+			Error:   true,
+			Code:    censusPeriodClosedCode,
+			Message: errCensusPeriodClosed.Error(),
+		})
+	})
+}
+
+func (app *application) CensusStatus(w http.ResponseWriter, r *http.Request) {
+	app.writeJSON(w, http.StatusOK, jsonResponse{
+		Error: false,
+		Data:  map[string]bool{"submissions_enabled": censusSubmissionsEnabled()},
+	})
+}

--- a/api/cmd/api/census_period_test.go
+++ b/api/cmd/api/census_period_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCensusSubmissionsEnabledIsFailClosed(t *testing.T) {
+	t.Setenv("CENSUS_SUBMISSIONS_ENABLED", "")
+	if censusSubmissionsEnabled() {
+		t.Fatal("empty configuration must close submissions")
+	}
+
+	t.Setenv("CENSUS_SUBMISSIONS_ENABLED", "false")
+	if censusSubmissionsEnabled() {
+		t.Fatal("false configuration must close submissions")
+	}
+
+	t.Setenv("CENSUS_SUBMISSIONS_ENABLED", "true")
+	if !censusSubmissionsEnabled() {
+		t.Fatal("true configuration must enable submissions")
+	}
+}
+
+func TestRequireCensusSubmissionsBlocksWritesWhenClosed(t *testing.T) {
+	for _, value := range []string{"", "false"} {
+		t.Run("closed_"+value, func(t *testing.T) {
+			t.Setenv("CENSUS_SUBMISSIONS_ENABLED", value)
+			called := false
+			next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+			app := &application{}
+			req := httptest.NewRequest(http.MethodPost, "/v1/census", nil)
+			res := httptest.NewRecorder()
+
+			app.requireCensusSubmissions(next).ServeHTTP(res, req)
+
+			if called {
+				t.Fatal("closed period must not invoke the write handler")
+			}
+			if res.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d", res.Code, http.StatusForbidden)
+			}
+			var payload jsonResponse
+			if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if payload.Code != censusPeriodClosedCode {
+				t.Fatalf("code = %q, want %q", payload.Code, censusPeriodClosedCode)
+			}
+			if payload.Message != errCensusPeriodClosed.Error() {
+				t.Fatalf("message = %q, want %q", payload.Message, errCensusPeriodClosed.Error())
+			}
+		})
+	}
+}
+
+func TestRequireCensusSubmissionsAllowsWritesWhenEnabled(t *testing.T) {
+	t.Setenv("CENSUS_SUBMISSIONS_ENABLED", "true")
+	called := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+	app := &application{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/census", nil)
+	res := httptest.NewRecorder()
+
+	app.requireCensusSubmissions(next).ServeHTTP(res, req)
+
+	if !called {
+		t.Fatal("enabled period must invoke the write handler")
+	}
+}

--- a/api/cmd/api/helpers.go
+++ b/api/cmd/api/helpers.go
@@ -7,6 +7,7 @@ import (
 
 type jsonResponse struct {
 	Error   bool        `json:"error"`
+	Code    string      `json:"code,omitempty"`
 	Message string      `json:"message,omitempty"`
 	Data    interface{} `json:"data,omitempty"`
 }

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -309,6 +309,7 @@ func (app *application) routes() http.Handler {
 
 	mux.Route("/v1", func(r chi.Router) {
 		r.Get("/health", app.HealthCheck)
+		r.Get("/census/status", app.CensusStatus)
 
 		// Endpoints públicos do formulário. Ficam atrás do gate opcional de
 		// X-API-Key (requirePublicAPIKey): inerte até PUBLIC_API_KEY ser
@@ -317,10 +318,10 @@ func (app *application) routes() http.Handler {
 			pub.Use(app.requirePublicAPIKey)
 			pub.Get("/locations", app.GetLocations)
 			pub.Get("/schools", app.GetSchools)
-			pub.Post("/schools", app.CreateSchool)
+			pub.With(app.requireCensusSubmissions).Post("/schools", app.CreateSchool)
 			pub.Get("/census", app.GetCenso)
-			pub.Post("/census", app.CreateOrUpdateCenso)
-			pub.Post("/upload", app.uploadPhoto)
+			pub.With(app.requireCensusSubmissions).Post("/census", app.CreateOrUpdateCenso)
+			pub.With(app.requireCensusSubmissions).Post("/upload", app.uploadPhoto)
 		})
 
 		// Admin: login público + rotas protegidas por JWT

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -1,0 +1,316 @@
+# Censo Operational and Structural Survey of Schools (SEDUC-PA)
+
+> English documentation for the Censo Operational and Structural Survey of Schools.
+>
+> **Primary documentation:** The Portuguese (Brazil) documentation in the repository root (`README.md`) remains the canonical version for the public-sector deployment. This English document is a translation/reference for technical teams and international collaborators.
+
+## Overview
+
+This repository contains the source code for the school infrastructure, human resources, and school-profile survey system operated by the State Department of Education of Pará (SEDUC-PA).
+
+The system provides a secure and robust interface through which school principals and education managers submit structured information about their schools. The survey uses a multi-step wizard with strict client- and server-side validation to maintain data consistency.
+
+## Main Features
+
+- **Multi-step data collection:** The survey is divided into 14 logical sections to reduce cognitive load and improve the completion experience.
+- **Draft persistence:** Partially completed responses can be saved and completed asynchronously.
+- **Robust validation:** Data integrity is enforced across multiple layers using Zod schemas on the web application and server-side validation in the API.
+- **Google ecosystem integration:** Data can be synchronized and exported through Google Drive and Google Sheets APIs.
+- **Report generation:** Census data can be exported to PDF using jsPDF.
+- **Security:** Authentication, request validation, CORS controls, and protections against common web attacks are part of the application architecture.
+
+## Technical Architecture
+
+The project is organized as a **monorepo**, keeping the frontend, backend, and infrastructure configuration in one version-controlled repository.
+
+### Technology Stack
+
+#### Backend
+
+- **Go 1.24**
+- **Chi** for HTTP routing and middleware
+- **PGX with `database/sql`** for PostgreSQL access, without an ORM
+- **Google Drive and Google Sheets APIs** for integrations
+- **Excelize** for native Excel file handling
+
+#### Frontend
+
+- **React 19**
+- **Next.js 16** with the App Router
+- **TypeScript** with strict typing
+- **Tailwind CSS v3**
+- **Radix UI Primitives**
+- **Lucide Icons**
+- **React Hook Form + Zod** for form handling and schema validation
+
+#### Database and Infrastructure
+
+- **PostgreSQL 16**
+- **Adminer** for database administration
+- **Docker and Docker Compose** for local infrastructure
+
+## Repository Structure
+
+```text
+CENSO-Operacional-Escolas/
+├── api/                          # Go backend
+│   ├── cmd/
+│   │   ├── api/main.go          # API entry point
+│   │   └── genpasswd/main.go    # bcrypt password-hash generator
+│   ├── internal/
+│   │   ├── models/              # Data models
+│   │   └── services/            # Application and integration services
+│   ├── go.mod
+│   └── go.sum
+├── web/                          # Next.js frontend
+│   ├── src/
+│   │   ├── app/                 # Next.js routes
+│   │   ├── components/          # React components
+│   │   ├── schemas/             # Zod validation schemas
+│   │   └── config/              # Frontend configuration
+│   ├── package.json
+│   └── tsconfig.json
+├── infra/                        # Infrastructure configuration
+│   ├── docker-compose.yml
+│   ├── init.sql
+│   ├── .env.example
+│   └── migrations/
+├── docs/                         # Additional project documentation
+└── README.md                     # Canonical Portuguese documentation
+```
+
+## Running the Project Locally
+
+### Prerequisites
+
+Install the following tools before starting:
+
+- Go 1.24 or later
+- Node.js 20+ with npm
+- Docker and Docker Compose
+- Git
+
+### 1. Configure Environment Variables
+
+Copy the example environment file:
+
+```bash
+cd infra
+cp .env.example .env
+```
+
+Configure `/infra/.env` with the values required by the local environment. The main variables include:
+
+```env
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=censo_user
+DB_PASSWORD=<secure-local-password>
+DB_NAME=censo_operacional
+
+PORT=8000
+ADMIN_PASSWORD_HASH=<bcrypt-password-hash>
+ADMIN_JWT_SECRET=<secure-secret-at-least-32-characters>
+
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+GOOGLE_CREDENTIALS_JSON={}
+SPREADSHEET_ID=
+GOOGLE_DRIVE_FOLDER_ID=
+
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
+```
+
+Do not commit real credentials, passwords, JWT secrets, or service-account keys.
+
+### 2. Start PostgreSQL and Adminer
+
+Generate an administrator password hash from the `api` directory:
+
+```bash
+cd api
+go run ./cmd/genpasswd/main.go
+```
+
+Put the generated bcrypt hash in `ADMIN_PASSWORD_HASH` in the local `.env` file.
+
+Then start the database services:
+
+```bash
+cd infra
+docker-compose up -d
+docker-compose ps
+```
+
+Local services:
+
+- PostgreSQL: `localhost:5432`
+- Adminer: `http://localhost:8080`
+
+For Adminer, use PostgreSQL as the system and `postgres` as the Docker service hostname.
+
+### 3. Start the Go API
+
+```bash
+cd api
+go mod download
+go run ./cmd/api
+```
+
+Verify the health endpoint:
+
+```bash
+curl http://localhost:8000/v1/health
+```
+
+Expected response:
+
+```json
+{ "status": "ok" }
+```
+
+### 4. Start the Next.js Frontend
+
+In another terminal:
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+The frontend is available at:
+
+```text
+http://localhost:3000
+```
+
+The administrative dashboard is available at:
+
+```text
+http://localhost:3000/admin
+```
+
+and requires authentication.
+
+## Google Integration
+
+Google Sheets and Google Drive integration is optional for local development.
+
+To enable it:
+
+1. Create a project in Google Cloud.
+2. Enable the Google Sheets API and Google Drive API.
+3. Create a service account and obtain its credentials.
+4. Configure `GOOGLE_CREDENTIALS_JSON`, `SPREADSHEET_ID`, and `GOOGLE_DRIVE_FOLDER_ID` in the local environment.
+
+Without these variables, the application can run locally without automatic Google Sheets synchronization.
+
+## Development Commands
+
+### Backend
+
+```bash
+cd api
+
+go run ./cmd/api/main.go
+go build -o bin/census ./cmd/api
+go run ./cmd/genpasswd/main.go
+go mod download
+go mod tidy
+```
+
+### Frontend
+
+```bash
+cd web
+
+npm install
+npm run dev
+npm run build
+npm run start
+npm run lint
+npm run format
+```
+
+### Infrastructure
+
+```bash
+cd infra
+
+docker-compose up -d
+docker-compose down
+docker-compose logs -f
+docker-compose down -v
+```
+
+> `docker-compose down -v` removes the local database volumes and therefore deletes locally stored database data.
+
+## Data Flow
+
+```text
+School Principals / Managers
+        │
+        │ Survey submission
+        ▼
+Next.js Frontend
+        │
+        │ HTTP API
+        ▼
+Go Backend
+  ├── Validation
+  ├── Authentication (JWT)
+  └── Business Logic
+        │
+        │ INSERT / UPDATE
+        ▼
+PostgreSQL
+  ├── Census responses
+  ├── Schools
+  └── Structured survey data
+        │
+        │ Optional background synchronization
+        ▼
+Google Sheets / Google Drive
+```
+
+## Security Notes
+
+Because this system handles information belonging to a public-sector education operation, development and deployment should follow the repository's security guidance and operational controls.
+
+At a minimum:
+
+- Keep secrets and credentials outside version control.
+- Use strong, unique values for administrative passwords and JWT signing secrets.
+- Restrict CORS origins to trusted application origins in production.
+- Use HTTPS for deployed environments.
+- Avoid exposing PostgreSQL or Adminer directly to the public internet.
+- Validate and authorize administrative operations on the server side.
+- Treat exported census data as protected operational information and apply the organization's access-control and retention requirements.
+
+## Troubleshooting
+
+### API connection refused on port 8000
+
+- Confirm that the Go API is running.
+- Check whether another process is using port 8000.
+- Verify `NEXT_PUBLIC_API_URL`.
+
+### Port 3000 already in use
+
+Identify the process using port 3000 and stop it, or run Next.js on another local port.
+
+### Database connection problems
+
+- Confirm the PostgreSQL container is running with `docker-compose ps`.
+- Verify the database variables in `/infra/.env`.
+- Confirm that the API is using the same database host and credentials configured for the Docker environment.
+
+## Documentation Language Policy
+
+The repository intentionally keeps **Portuguese (Brazil) as the primary documentation language** because the Censo is a public-sector application operated in Pará, Brazil.
+
+- **Primary:** [`README.md`](../README.md) — Portuguese (Brazil)
+- **English reference:** this document — `docs/README.en.md`
+
+Changes to the canonical Portuguese documentation should remain authoritative when translations differ. The English documentation is intended to improve accessibility for technical contributors and should be updated when major architectural or operational documentation changes are introduced.

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -33,6 +33,15 @@ export default function CensusPage() {
   const [isCompleted, setIsCompleted] = useState(false);
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [submissionsEnabled, setSubmissionsEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+    fetch(`${baseUrl}/v1/census/status`)
+      .then((response) => response.ok ? response.json() : Promise.reject())
+      .then((payload) => setSubmissionsEnabled(payload.data?.submissions_enabled === true))
+      .catch(() => setSubmissionsEnabled(false));
+  }, []);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -278,7 +287,18 @@ export default function CensusPage() {
     }
   };
 
-  if (!isInitialized) return null;
+  if (!isInitialized || submissionsEnabled === null) return null;
+
+  if (!submissionsEnabled) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+        <Card className="w-full max-w-md text-center p-8 shadow-md border-slate-200 bg-white">
+          <h1 className="text-2xl font-bold text-slate-900 mb-3">Período de preenchimento encerrado.</h1>
+          <p className="text-slate-600">O prazo para envio das informações do Censo Operacional foi finalizado.</p>
+        </Card>
+      </div>
+    );
+  }
 
   if (isCompleted) {
     return (


### PR DESCRIPTION
## Objetivo

Reconciliar a divergência histórica entre `main` e `develop` antes do próximo release.

## Auditoria prévia

Os 5 commits exclusivos de `main` foram revisados. O conteúdo funcional relevante já está presente em `develop`:
- encerramento do período do Censo (`census_period.go` e testes) está com o mesmo conteúdo;
- UI pública de período encerrado está com o mesmo conteúdo;
- `NOTICE` e marcador de provenance já existem em `develop`;
- documentação correspondente também já foi incorporada.

Portanto este PR serve para **unificar a ancestralidade Git**, não para substituir implementações atuais de `develop` por versões antigas.

## Regra de merge

Preservar o estado atual de `develop` em qualquer eventual conflito. Não reverter implementação DRE, analytics, migrations ou testes mais recentes.